### PR TITLE
refactor: scope user profiles to project instead of session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Thumbs.db
 
 # Experiment
 benchmarks/memory_comparison/results
+
+# Playwright MCP session dumps
+.playwright-mcp/

--- a/plugin/dashboard/app/playbooks/[id]/page.tsx
+++ b/plugin/dashboard/app/playbooks/[id]/page.tsx
@@ -256,23 +256,6 @@ export default function PlaybookDetailPage({
             )}
 
             <Section
-              icon={BookMarked}
-              title="Rule"
-              hint="What Claude should do. Injected into future sessions in this project."
-            >
-              {editing ? (
-                <AutoTextarea
-                  value={form.content}
-                  onChange={(v) => setForm((f) => ({ ...f, content: v }))}
-                  rows={6}
-                  placeholder="e.g. Use anyio with trio backend — never pytest-asyncio."
-                />
-              ) : (
-                <Prose text={playbook?.content ?? ""} />
-              )}
-            </Section>
-
-            <Section
               icon={AlertTriangle}
               title="Trigger"
               hint="When this rule should apply. Leave empty if it always applies."
@@ -286,6 +269,23 @@ export default function PlaybookDetailPage({
                 />
               ) : (
                 <Prose text={playbook?.trigger ?? ""} muted={!playbook?.trigger} />
+              )}
+            </Section>
+
+            <Section
+              icon={BookMarked}
+              title="Rule"
+              hint="What Claude should do. Injected into future sessions in this project."
+            >
+              {editing ? (
+                <AutoTextarea
+                  value={form.content}
+                  onChange={(v) => setForm((f) => ({ ...f, content: v }))}
+                  rows={6}
+                  placeholder="e.g. Use anyio with trio backend — never pytest-asyncio."
+                />
+              ) : (
+                <Prose text={playbook?.content ?? ""} />
               )}
             </Section>
 

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -6,7 +6,7 @@ Exposes five subcommands:
   Claude Code, then seed ``~/.reflexio/.env`` with the local-provider flags.
 - ``update``: update the plugin to the latest version via the native Claude
   Code plugin CLI.
-- ``show``: print the current project playbook and session user profiles
+- ``show``: print the current project playbook and project user profiles
   (as markdown).
 - ``learn``: force reflexio to run extraction on all unpublished interactions.
 - ``tag "<note>"``: append a ``[correction]``-prefixed turn to the active
@@ -134,25 +134,23 @@ def cmd_update(_args: argparse.Namespace) -> int:
 
 
 def cmd_show(args: argparse.Namespace) -> int:
-    """Print the current project playbook and session user profiles.
+    """Print the current project playbook and project user profiles.
 
-    The session profile fetch defaults to the most-recently-modified session
-    buffer so ``/show`` surfaces both playbook rules and user profiles in one
-    pass, without the caller having to know the session id.
+    Both playbooks and profiles are now scoped to the project (resolved from
+    cwd via ``ids.resolve_project_id``), so output is identical regardless of
+    which session is active in the repo.
 
     Args:
         args (argparse.Namespace): Parsed CLI args. Honors ``args.project``
-            (override project id) and ``args.session`` (override session id;
-            falls back to the latest session buffer).
+            (override project id).
 
     Returns:
         int: 0 on success.
     """
     project_id = args.project or ids.resolve_project_id()
-    session_id = args.session or _latest_session_id()
     adapter = Adapter()
     playbooks = adapter.fetch_project_playbooks(project_id)
-    profiles: list = adapter.fetch_session_profiles(session_id) if session_id else []
+    profiles: list = adapter.fetch_project_profiles(project_id)
     md = context_format.render(
         project_id=project_id, playbooks=playbooks, profiles=profiles
     )
@@ -180,7 +178,7 @@ def cmd_learn(args: argparse.Namespace) -> int:
     if status == "ok":
         sys.stdout.write(
             f"Published {count} interactions to reflexio "
-            f"(user_id={session_id}, agent_version={project_id}). "
+            f"(user_id={project_id}, session_id={session_id}). "
             "Extraction running.\n"
         )
         return 0
@@ -272,13 +270,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sh = sub.add_parser(
         "show",
-        help="Show the current project playbook and session user profiles",
+        help="Show the current project playbook and project user profiles",
     )
     sh.add_argument("--project", help="Override project id")
-    sh.add_argument(
-        "--session",
-        help="Session id for profile lookup (defaults to latest session)",
-    )
     sh.set_defaults(func=cmd_show)
 
     ln = sub.add_parser("learn", help="Force reflexio extraction now")

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -43,7 +43,7 @@ def render(
         sections.append("### Project playbook")
         sections.extend(playbook_lines)
     if profile_lines:
-        sections.append("### Session preferences")
+        sections.append("### Project preferences")
         sections.extend(profile_lines)
     return "\n".join(sections) + "\n"
 
@@ -81,7 +81,7 @@ def render_inline(
         sections.append("### Relevant playbook rules")
         sections.extend(playbook_lines)
     if profile_lines:
-        sections.append("### Relevant session preferences")
+        sections.append("### Relevant project preferences")
         sections.extend(profile_lines)
     return "\n".join(sections) + "\n"
 

--- a/plugin/src/claude_smart/events/pre_tool.py
+++ b/plugin/src/claude_smart/events/pre_tool.py
@@ -36,7 +36,6 @@ def handle(payload: dict[str, Any]) -> None:
     project_id = ids.resolve_project_id(payload.get("cwd"))
     playbooks, profiles = Adapter().search_both(
         project_id=project_id,
-        session_id=session_id,
         query=query,
         top_k=_TOP_K,
     )

--- a/plugin/src/claude_smart/events/session_start.py
+++ b/plugin/src/claude_smart/events/session_start.py
@@ -31,7 +31,6 @@ def handle(payload: dict[str, Any]) -> None:
     )
     playbooks, profiles = adapter.fetch_both(
         project_id=project_id,
-        session_id=session_id,
     )
 
     markdown = context_format.render(

--- a/plugin/src/claude_smart/ids.py
+++ b/plugin/src/claude_smart/ids.py
@@ -3,11 +3,13 @@
 Two identifiers matter to reflexio:
 
 - ``session_id``: Claude Code's per-session id, passed in hook stdin. We
-  use this as ``user_id`` so reflexio-extracted profiles/playbooks are
-  scoped to the current conversation.
+  forward it to reflexio's interaction ``session_id`` field so individual
+  turns remain attributable to their conversation, but it is no longer
+  the scope key for extracted profiles.
 - ``project_id``: a stable, cross-session name for the project. We use
-  this as ``agent_version`` so playbooks accumulate at the project level
-  (queryable by ``agent_version`` alone in ``search_user_playbooks``).
+  this as both ``agent_version`` (playbooks roll up at the project level)
+  and reflexio's ``user_id`` for profiles, so user preferences extracted
+  in one session are visible to every later session in the same repo.
 """
 
 from __future__ import annotations

--- a/plugin/src/claude_smart/publish.py
+++ b/plugin/src/claude_smart/publish.py
@@ -27,8 +27,10 @@ def publish_unpublished(
     """Drain the session buffer to reflexio and stamp the high-water mark.
 
     Args:
-        session_id (str): Claude Code session id (also the reflexio user_id).
-        project_id (str): Stable project name (reflexio agent_version).
+        session_id (str): Claude Code session id, attached to each interaction.
+        project_id (str): Stable project name; used as both reflexio
+            ``agent_version`` (playbooks) and ``user_id`` (profiles), so both
+            entities accumulate at the project level across sessions.
         force_extraction (bool): Whether to ask reflexio to run extraction
             synchronously instead of queuing for the next sweep.
         skip_aggregation (bool): When True, reflexio extracts profiles and

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -75,7 +75,7 @@ class Adapter:
             return False
         try:
             client.publish_interaction(
-                user_id=session_id,
+                user_id=project_id,
                 interactions=list(interactions),
                 agent_version=project_id,
                 session_id=session_id,
@@ -183,14 +183,14 @@ class Adapter:
             return []
         return _extract_items(response, "user_playbooks")
 
-    def fetch_session_profiles(self, session_id: str, top_k: int = 20) -> list[Any]:
-        """Fetch profiles extracted for this specific session."""
+    def fetch_project_profiles(self, project_id: str, top_k: int = 20) -> list[Any]:
+        """Fetch profiles extracted for this project (across sessions)."""
         client = self._get_client()
         if client is None:
             return []
         try:
             response = client.search_profiles(
-                user_id=session_id,
+                user_id=project_id,
                 query="",
                 top_k=top_k,
             )
@@ -230,12 +230,13 @@ class Adapter:
         return _extract_items(response, "user_playbooks")
 
     def search_profiles(
-        self, *, session_id: str, query: str, top_k: int = 5
+        self, *, project_id: str, query: str, top_k: int = 5
     ) -> list[Any]:
-        """Query-aware profile search scoped to this session.
+        """Query-aware profile search scoped to this project.
 
         Args:
-            session_id (str): reflexio user_id — profiles are session-scoped.
+            project_id (str): reflexio user_id — profiles are project-scoped
+                so they persist across sessions in the same repo.
             query (str): Free-text query.
             top_k (int): Cap on results.
 
@@ -247,7 +248,7 @@ class Adapter:
             return []
         try:
             response = client.search_profiles(
-                user_id=session_id,
+                user_id=project_id,
                 query=query,
                 top_k=top_k,
             )
@@ -264,7 +265,6 @@ class Adapter:
         self,
         *,
         project_id: str,
-        session_id: str,
         query: str,
         top_k: int = 5,
     ) -> tuple[list[Any], list[Any]]:
@@ -280,7 +280,7 @@ class Adapter:
                 project_id=project_id, query=query, top_k=top_k
             ),
             profile_call=lambda: self.search_profiles(
-                session_id=session_id, query=query, top_k=top_k
+                project_id=project_id, query=query, top_k=top_k
             ),
         )
 
@@ -288,7 +288,6 @@ class Adapter:
         self,
         *,
         project_id: str,
-        session_id: str,
         playbook_top_k: int = 10,
         profile_top_k: int = 20,
     ) -> tuple[list[Any], list[Any]]:
@@ -297,8 +296,8 @@ class Adapter:
             playbook_call=lambda: self.fetch_project_playbooks(
                 project_id, top_k=playbook_top_k
             ),
-            profile_call=lambda: self.fetch_session_profiles(
-                session_id, top_k=profile_top_k
+            profile_call=lambda: self.fetch_project_profiles(
+                project_id, top_k=profile_top_k
             ),
         )
 


### PR DESCRIPTION
## Summary
- Re-scope user profiles from **session** to **project**: profiles extracted in one session are now visible to every later session in the same repo.
- `project_id` is now used as reflexio's `user_id` (for profiles) in addition to `agent_version` (for playbooks); `session_id` still travels on each interaction for attribution.
- `/show` no longer needs `--session` — playbook + profile output is deterministic per project.
- Dashboard: swap **Trigger** above **Rule** on the playbook detail page so context reads before action.
- Bump `reflexio` submodule to `main` (includes merged ReflexioAI/reflexio#31: same-role transcript merge, `CLAUDE_SMART_CLI_MODEL` override, v4.0.1 playbook extraction prompt).
- Chore: ignore `.playwright-mcp/` session dumps.

## Changes
**Python — profile scoping**
- `reflexio_adapter.py`: `publish` now sends `user_id=project_id`. `fetch_session_profiles` → `fetch_project_profiles`. `search_profiles` and the `search_both` / `fetch_both` fan-outs drop `session_id` and take `project_id`.
- `events/pre_tool.py`, `events/session_start.py`: stop forwarding `session_id` into profile queries.
- `ids.py`, `publish.py`: docstrings updated to reflect the dual role of `project_id` (playbooks + profiles).

**CLI**
- `cli.py`: `cmd_show` drops `--session`; fetches project profiles. `/learn` success message now reports `user_id={project_id}, session_id={session_id}` so users can find their data in reflexio.

**Rendering**
- `context_format.py`: section headings renamed "Session preferences" → "Project preferences" in both `render` and `render_inline`.

**Dashboard**
- `app/playbooks/[id]/page.tsx`: reorder Trigger (with `AlertTriangle`) before Rule (with `BookMarked`).

**Submodule**
- `reflexio`: bump pointer to `main` (post-merge of ReflexioAI/reflexio#31).

**Chore**
- `.gitignore`: add `.playwright-mcp/`.

## Test Plan
- `ruff check` — clean on all changed Python files.
- `pyright` — 0 errors/warnings on all changed Python files.
- `tsc --noEmit` in `plugin/dashboard/` — clean.
- Manual: run `claude-smart show` in a project and confirm profiles + playbook render without a session flag. Start a fresh Claude Code session and confirm the SessionStart injection includes "### Project preferences" when profiles exist.
- Post-merge: existing profiles published under the old `user_id=<session_id>` scheme will no longer surface; re-extraction via `/learn` or a `clear-all` regenerates them under the new project scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Profile Management Updates**
  * Preferences and profile retrieval are now project-scoped and persist across conversations instead of per-session.
  * CLI commands and data fetching consistently use project-level profiles.

* **Playbook Editor Changes**
  * Rule and Trigger sections swapped presentation and editing bindings with updated textarea sizing and hints.

* **Chores**
  * Updated .gitignore to ignore benchmarking results and a Playwright directory; fixed trailing newlines.

* **Documentation**
  * Help text and inline docs clarified project vs. session scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
