### PR TITLE
refactor(cite): rank+fingerprint citation ids + uninstall subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   claude-smart
 </h1>
 
-<h4 align="center">The <a href="https://claude.com/claude-code" target="_blank">Claude Code</a> plugin that makes Claude Code self-improve as you use it — not by remembering past sessions, but by turning your corrections into rules it actually follows next time.</h4>
+<h4 align="center">The <a href="https://claude.com/claude-code" target="_blank">Claude Code</a> plugin that makes Claude Code self-improve as you use it — not by remembering past sessions, but by turning your corrections into playbooks it actually follows next time.</h4>
 
 <p align="center">
   <a href="LICENSE">
@@ -47,13 +47,13 @@
 
 ## Why Learning, Not Memory
 
-Most memory solutions re-inject transcripts or summaries from prior sessions, but it is still mostly informative—Claude remembers what happened, without necessarily changing what it does next.
+Most memory solutions are still mostly informative—Claude remembers what happened, without necessarily changing what it does next.
 
 `claude-smart` focuses on learning instead.
 
 Four ways this changes what Claude Code can do for you:
 
-- **Actionable, not just informative:** Produces rules Claude can follow next time; memory only records what happened; 
+- **Actionable, not just informative:** Produces playbooks Claude can follow next time; memory only records what happened.
 
   > *Example:* you tell Claude to stop running `npm test` without `--run` because watch mode hangs.
   > **Memory:** “user was annoyed about npm test hanging”
@@ -68,7 +68,7 @@ Four ways this changes what Claude Code can do for you:
 
 - **Project-wide, not session-siloed:** Session memory disappears with the conversation. The project playbook persists and improves across every session in that repo.
 
-- **Compact:** Distilled, deduplicated rules stay in dozens of tokens—not thousands—even as the project grows.
+- **Compact:** Distilled, deduplicated playbooks stay in dozens of tokens—not thousands—even as the project grows.
 
 claude-smart turns corrections and successful execution patterns into two artifacts:
 
@@ -85,16 +85,20 @@ Both are automatically reinjected at the start of every session, so Claude Code 
 npx claude-smart install     # or: uvx claude-smart install
 ```
 
-Or run the equivalent marketplace commands directly inside Claude Code:
+Or run the equivalent marketplace commands directly via the Claude Code CLI:
 
-```text
-/plugin marketplace add ReflexioAI/claude-smart
-/plugin install claude-smart@reflexioai
+```bash
+claude plugin marketplace add ReflexioAI/claude-smart
+claude plugin install claude-smart@reflexioai
 ```
 
 Then restart Claude Code.
 
-To uninstall: `/plugin uninstall claude-smart@reflexioai`.
+To uninstall:
+
+```bash
+npx claude-smart uninstall     # or: claude plugin uninstall claude-smart@reflexioai
+```
 
 Developing the plugin itself? See [DEVELOPER.md](./DEVELOPER.md#developing-locally).
 
@@ -104,7 +108,7 @@ Developing the plugin itself? See [DEVELOPER.md](./DEVELOPER.md#developing-local
 
 - 🧠 **Learn, don't just remember** — Corrections become structured, deduplicated rules, not transcript replays.
 - ⚡ **Fully automatic learning** — Every user turn, tool call, and assistant response is captured via lifecycle hooks and extracted into rules without you running anything.
-- 📈 **Compounds with every session** — Rules auto-merge, supersede, and archive as your project evolves — the playbook sharpens with use instead of bloating.
+- 📈 **Updates with every session** — Playbooks auto-merge, supersede, and archive as your project evolves — the playbook sharpens with use instead of bloating.
   > *e.g.* you correct the same `npm test --run` gotcha twice → **claude-smart** consolidates them into one stronger rule. Later you switch the policy to `pnpm test` → the old rule is archived and the new one supersedes it, no manual cleanup.
 - 🎯 **Two-tier scope** — Per-session profiles for the current conversation; cross-session playbooks for the whole project.
 - 🔌 **No external API call** — semantic search runs on an in-process ONNX embedder (all-MiniLM-L6-v2), and all data (profiles, playbooks, interaction buffers) is stored locally on your machine (`~/.reflexio/` and `~/.claude-smart/`).
@@ -132,7 +136,7 @@ claude-smart builds two artifacts as you work and injects them into Claude at th
 - **User profile** — session-scoped preferences (stack, role, small quirks). *e.g.* "uses pnpm, not npm"; "prefers terse answers"; "backend engineer — explain frontend with backend analogues."
 - **Project playbook** — durable, generalized rules accumulated across every session in the repo. Each says when it applies and why. *e.g.* "always pass `--run` to `npm test` — watch mode hangs CI"; "use real Postgres for integration tests — mocks once hid a broken migration."
 
-Rules clean themselves up: correct the same thing twice and they merge; change your mind and the old one is archived.
+Playbooks clean themselves up: correct the same thing twice and they merge; change your mind and the old one is archived.
 
 Under the hood: hooks watch your turns, tool calls, and Claude's replies, auto-flagging corrections (or anything you `/tag`). At session end (or on `/learn`), [reflexio](https://github.com/ReflexioAI/reflexio) — the self-improving engine that powers claude-smart — extracts profile entries and playbook rules. Next session, both get injected into the system prompt — run `/show` to see what Claude is being told. Everything runs on your machine.
 
@@ -144,7 +148,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for hooks, data flow, and reflexio deta
 
 | Command | What it does |
 | --- | --- |
-| `/show` | Print the current project playbook plus the current session's user profiles (same markdown that `SessionStart` injects). Use it to audit what rules and preferences Claude is being told to follow. |
+| `/show` | Print the current project playbook plus the current session's user profiles (same markdown that `SessionStart` injects). Use it to audit what playbooks and preferences Claude is being told to follow. |
 | `/learn` | Force reflexio to run extraction *now* on the current session's unpublished interactions. Without this, extraction runs at the end of the session or on reflexio's batch interval. |
 | `/tag [note]` | Tag the most recent turn as a correction, for cases the automatic heuristic missed. The note becomes the correction description the extractor sees. |
 | `/restart` | Restart the reflexio backend and dashboard to pick up new changes (e.g. after upgrading the plugin or editing local reflexio code). |

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -61,6 +61,9 @@ function printHelp() {
       "Update:",
       "  npx claude-smart update                        Update to the latest version",
       "",
+      "Uninstall:",
+      "  npx claude-smart uninstall                     Remove the plugin from Claude Code",
+      "",
     ].join("\n"),
   );
 }
@@ -94,6 +97,35 @@ function runUpdate() {
   }
 
   process.stdout.write("\nclaude-smart updated. Restart Claude Code to apply.\n");
+}
+
+function runUninstall() {
+  if (!hasClaudeCli()) {
+    process.stderr.write(
+      "error: 'claude' CLI not found on PATH. " +
+        "Install Claude Code first: https://claude.com/claude-code\n",
+    );
+    process.exit(1);
+  }
+
+  try {
+    execFileSync("claude", ["plugin", "uninstall", PLUGIN_SPEC], { stdio: "inherit" });
+  } catch (err) {
+    const code = typeof err.status === "number" ? err.status : 1;
+    process.stderr.write(
+      `error: \`claude plugin uninstall ${PLUGIN_SPEC}\` failed (exit ${code})\n`,
+    );
+    process.exit(code);
+  }
+
+  process.stdout.write(
+    [
+      "",
+      "claude-smart uninstalled. Restart Claude Code to apply.",
+      "Local data in ~/.reflexio/ and ~/.claude-smart/ was left in place — remove manually if desired.",
+      "",
+    ].join("\n"),
+  );
 }
 
 function runInstall(args) {
@@ -157,6 +189,11 @@ function main() {
 
   if (cmd === "update") {
     runUpdate();
+    return;
+  }
+
+  if (cmd === "uninstall") {
+    runUninstall();
     return;
   }
 

--- a/plugin/bin/cs-cite
+++ b/plugin/bin/cs-cite
@@ -11,16 +11,19 @@ sidecar file, no state.
 Usage:
     cs-cite <id> [<id>...]            # space- or comma-separated
 
-Accepts one or more 4-hex-char ids as arguments, separated by commas
-and/or whitespace. An optional ``cs:`` prefix is stripped for
-convenience, since playbook items render as ``[cs:ab12]`` and the model
-often copies the tag verbatim. Case is normalized to lowercase.
+Accepts one or more rank ids: ``p<N>[-<fp>]`` for profile preferences
+and ``r<N>[-<fp>]`` for playbook rules, as emitted in ``[cs:p1-ab12]``
+/ ``[cs:r2-cd34]`` tags. The optional ``-<fp>`` suffix is a 1–4 char
+alphanumeric fingerprint of the underlying real id. Tokens may be
+separated by commas and/or whitespace. An optional ``cs:`` prefix is
+stripped for convenience since the model often copies the tag
+verbatim. Case is normalized to lowercase.
 
 Examples:
-    cs-cite ab12              -> ✨ used 1 claude-smart learning
-    cs-cite ab12,cd34         -> ✨ used 2 claude-smart learnings
-    cs-cite cs:ab12,cs:cd34   -> ✨ used 2 claude-smart learnings
-    cs-cite ab12 cd34         -> ✨ used 2 claude-smart learnings
+    cs-cite p1-ab12                 -> ✨ used 1 claude-smart learning
+    cs-cite p1-ab12,r2-cd34         -> ✨ used 2 claude-smart learnings
+    cs-cite cs:p1-ab12,cs:r2-cd34   -> ✨ used 2 claude-smart learnings
+    cs-cite p1-ab12 r2-cd34         -> ✨ used 2 claude-smart learnings
 """
 
 from __future__ import annotations
@@ -28,11 +31,11 @@ from __future__ import annotations
 import re
 import sys
 
-_TOKEN_RE = re.compile(r"^(?:cs:)?([a-f0-9]{4})$", re.IGNORECASE)
+_TOKEN_RE = re.compile(r"^(?:cs:)?([pr]\d+(?:-[a-z0-9]{1,4})?)$", re.IGNORECASE)
 _SPLIT_RE = re.compile(r"[,\s]+")
 _USAGE = (
-    "cs-cite: expected one or more 4-hex-char ids "
-    "(e.g. `cs-cite ab12,cd34` or `cs-cite cs:ab12`)\n"
+    "cs-cite: expected one or more rank ids "
+    "(e.g. `cs-cite p1-ab12,r2-cd34` or `cs-cite cs:p1-ab12`)\n"
 )
 
 
@@ -59,8 +62,8 @@ def main() -> int:
             bad.append(tok)
     if bad:
         sys.stderr.write(
-            "cs-cite: ignoring invalid tokens (expected 4-hex-char ids, "
-            f"optionally 'cs:'-prefixed): {', '.join(bad)}\n"
+            "cs-cite: ignoring invalid tokens (expected rank ids like "
+            f"`p1` or `r2`, optionally 'cs:'-prefixed): {', '.join(bad)}\n"
         )
     if not ids:
         sys.stderr.write(_USAGE)

--- a/plugin/dashboard/app/interactions/[sessionId]/page.tsx
+++ b/plugin/dashboard/app/interactions/[sessionId]/page.tsx
@@ -212,16 +212,27 @@ function CitedItemsRow({ items }: { items: CitedItem[] }) {
       <Sparkles className="h-3.5 w-3.5 mt-0.5 text-amber-500 shrink-0" />
       <div className="flex items-center gap-1 flex-wrap">
         <span className="text-muted-foreground">Used</span>
-        {items.map((item) => (
-          <Badge
-            key={item.id}
-            variant="outline"
-            className="h-5 gap-1 text-[10px] border-amber-500/40"
-            title={`${item.kind} • id=${item.id}`}
-          >
-            {item.title || item.id}
-          </Badge>
-        ))}
+        {items.map((item) => {
+          const targetId = item.real_id ?? item.id;
+          const href =
+            item.kind === "playbook"
+              ? `/playbooks/${encodeURIComponent(targetId)}`
+              : `/profiles/${encodeURIComponent(targetId)}`;
+          return (
+            <Link
+              key={item.id}
+              href={href}
+              title={`${item.kind} • id=${targetId}`}
+            >
+              <Badge
+                variant="outline"
+                className="h-5 gap-1 text-[10px] border-amber-500/40 cursor-pointer hover:bg-amber-500/10 hover:border-amber-500/70 transition-colors"
+              >
+                {item.title || item.id}
+              </Badge>
+            </Link>
+          );
+        })}
       </div>
     </div>
   );

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -19,6 +19,7 @@ export interface CitedItem {
   id: string;
   kind: "playbook" | "profile";
   title: string;
+  real_id?: string;
 }
 
 export interface Interaction {

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -152,13 +152,16 @@ def _format_playbooks(
 ) -> tuple[list[str], list[dict[str, Any]]]:
     lines: list[str] = []
     entries: list[dict[str, Any]] = []
+    rank = 0
     for pb in playbooks:
         content = _first_nonempty(_field(pb, "content"))
         if not content:
             continue
+        rank += 1
         trigger = _first_nonempty(_field(pb, "trigger"))
         rationale = _first_nonempty(_field(pb, "rationale"))
-        item_id = cs_cite.short_id("playbook", content)
+        real_id = _field(pb, "user_playbook_id")
+        item_id = cs_cite.rank_id("playbook", rank, real_id)
         title = _title_from_content(content)
         bullet = f"- [cs:{item_id}] {content}"
         if trigger:
@@ -172,6 +175,7 @@ def _format_playbooks(
                 "kind": "playbook",
                 "title": title,
                 "content": content,
+                "real_id": str(real_id) if real_id is not None else None,
             }
         )
     return lines, entries
@@ -182,11 +186,14 @@ def _format_profiles(
 ) -> tuple[list[str], list[dict[str, Any]]]:
     lines: list[str] = []
     entries: list[dict[str, Any]] = []
+    rank = 0
     for p in profiles:
         content = _first_nonempty(_field(p, "content"))
         if not content:
             continue
-        item_id = cs_cite.short_id("profile", content)
+        rank += 1
+        real_id = _field(p, "profile_id")
+        item_id = cs_cite.rank_id("profile", rank, real_id)
         title = _title_from_content(content)
         lines.append(f"- [cs:{item_id}] {content}")
         entries.append(
@@ -195,6 +202,7 @@ def _format_profiles(
                 "kind": "profile",
                 "title": title,
                 "content": content,
+                "real_id": str(real_id) if real_id is not None else None,
             }
         )
     return lines, entries

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -1,18 +1,31 @@
 """Support helpers for the ``cs-cite`` citation channel.
 
 Context injected at SessionStart / PreToolUse tags each playbook and
-profile bullet with a short stable id (``[cs:ab12]``). The injected
-instruction asks Claude to end impactful replies with a call like::
+profile bullet with a rank-based id fingerprinted by the underlying
+real id (``[cs:r1-1a2b]`` for the first playbook rule whose
+``user_playbook_id`` starts with ``1a2b``, ``[cs:p2-c3d4]`` for the
+second profile preference). The injected instruction asks Claude to
+end impactful replies with a call like::
 
-    cs-cite ab12,cd34
+    cs-cite p1-c3d4,r2-1a2b
 
 via the Bash tool. The Stop hook later scans the session transcript for
 those tool calls and resolves the ids against a per-session registry
 persisted at ``~/.claude-smart/sessions/<session_id>.injected.jsonl``.
 
+Why rank + fingerprint: rank alone resets at every injection, so a
+later injection's ``r1`` would silently overwrite an earlier entry in
+the append-only registry — if Claude cited ``r1`` across a turn
+boundary, the resolver would pick the wrong playbook. Appending the
+first four alphanumeric chars of the real id makes the id stable
+across injections in the common case (distinct real ids → distinct
+fingerprints), so cross-injection collisions become rare.
+
 This module holds:
 
-- ``short_id``: stable 4-hex-char id per (kind, content) pair.
+- ``rank_id``: ``p{n}-{fp}`` / ``r{n}-{fp}`` tag for a given
+  (kind, rank, real_id) tuple. Fingerprint is omitted when no real id
+  is available.
 - ``CITATION_CMD_RE``: regex matching a valid ``cs-cite`` command line.
 - ``ensure_installed``: idempotent copy of ``plugin/bin/cs-cite`` to
   ``~/.claude-smart/bin/cs-cite`` with the executable bit set.
@@ -22,12 +35,12 @@ This module holds:
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import re
 import shutil
 import stat as stat_
 from pathlib import Path
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,53 +50,93 @@ _SOURCE_SCRIPT = _PLUGIN_ROOT / "bin" / "cs-cite"
 _INSTALL_DIR = Path.home() / ".claude-smart" / "bin"
 INSTALL_PATH = _INSTALL_DIR / "cs-cite"
 
-# Match a bare `cs-cite <ids>` invocation. Ids are 4-hex-char tokens,
-# optionally `cs:`-prefixed (since playbook items render as `[cs:ab12]`
-# and the model often copies the tag verbatim). The `(?i:cs:)` inline
-# flag makes only the prefix case-insensitive so `CS:AB12` is accepted
-# — matching the `re.IGNORECASE` used by the standalone `cs-cite`
-# script. Tokens may be comma- and/or whitespace-separated. Chained
-# commands (&&, |, ;) and extra trailing tokens remain rejected by the
-# anchored `\s*$` terminator so accidental mentions don't register as
-# citations.
-_ID_TOKEN = r"(?i:cs:)?[A-Fa-f0-9]{4}"
+_FINGERPRINT_LEN = 4
+
+# Match a bare `cs-cite <ids>` invocation. Ids are rank tokens of the
+# form `p<N>` (profile) or `r<N>` (playbook rule) with an optional
+# `-<fp>` fingerprint (1-4 alphanumeric chars), optionally
+# `cs:`-prefixed (since bullets render as `[cs:p1-ab12]` and the model
+# often copies the tag verbatim). The `(?i:...)` inline flags make the
+# prefix, kind letter, and fingerprint case-insensitive so `CS:P1-AB12`
+# is accepted — matching the `re.IGNORECASE` used by the standalone
+# `cs-cite` script. Tokens may be comma- and/or whitespace-separated.
+# Chained commands (&&, |, ;) and extra trailing tokens remain rejected
+# by the anchored `\s*$` terminator so accidental mentions don't
+# register as citations.
+_ID_TOKEN = r"(?i:cs:)?(?i:[pr])\d+(?:-(?i:[a-z0-9]){1,4})?"
 _ID_SEP = r"[,\s]+"
 CITATION_CMD_RE = re.compile(
     rf"^\s*(?:[^\s]*/)?cs-cite\s+({_ID_TOKEN}(?:{_ID_SEP}{_ID_TOKEN})*)\s*$"
 )
-_CLEAN_ID_RE = re.compile(r"^(?i:cs:)?([A-Fa-f0-9]{4})$")
+_CLEAN_ID_RE = re.compile(r"^(?i:cs:)?((?i:[pr])\d+(?:-(?i:[a-z0-9]){1,4})?)$")
 _SPLIT_RE = re.compile(_ID_SEP)
 
 CITATION_INSTRUCTION = (
     "_If any item above materially shaped this response, end your reply "
-    "with `cs-cite ab12,cd34` via the Bash tool — pass the 4-hex ids "
-    "from the `[cs:xxxx]` tags (e.g. for `[cs:ab12]` and `[cs:cd34]` run "
-    "`cs-cite ab12,cd34`; the `cs:` prefix is stripped automatically if "
-    "you include it). Ids only, no prose, one Bash call. Omit if none "
-    "applied._"
+    "with `cs-cite p1-ab12,r2-cd34` via the Bash tool — pass the full ids "
+    "from the `[cs:xxxx]` tags (e.g. for `[cs:p1-ab12]` and `[cs:r2-cd34]` "
+    "run `cs-cite p1-ab12,r2-cd34`; the `cs:` prefix is stripped "
+    "automatically if you include it). Use `p<N>-<fp>` for profile "
+    "preferences and `r<N>-<fp>` for playbook rules. Ids only, no prose, "
+    "one Bash call. Omit if none applied._"
 )
 
 
-def short_id(kind: str, content: str) -> str:
-    """Return a stable 4-hex-char id for a playbook or profile item.
+def _fingerprint(real_id: Any) -> str:
+    """Return the first ``_FINGERPRINT_LEN`` alphanumeric chars of ``real_id``.
 
-    The id is a prefix of ``sha1(f"{kind}:{content}")`` so the same item
-    injected across hooks or sessions receives the same tag. Four hex
-    chars yield 65,536 possible values, which gives a negligible
-    collision probability within the small registries (<= 25 items) that
-    a single session produces.
+    The fingerprint disambiguates rank ids across injections: two
+    injections both producing ``r1`` for different playbooks will still
+    yield distinct tags when their real ids have different prefixes.
 
     Args:
-        kind: ``"playbook"`` or ``"profile"`` — namespaces the hash so
-            two items with identical content but different kinds don't
-            collapse to the same id.
-        content: The rendered bullet content used for stability.
+        real_id: The underlying ``user_playbook_id`` or ``profile_id``.
+            Accepts anything ``str()`` handles (int, UUID, etc.).
+            ``None`` yields an empty string.
 
     Returns:
-        str: 4-character lowercase hex id.
+        str: Up to 4 lowercase alphanumeric chars; empty when the real
+            id has no alphanumeric characters or is ``None``.
     """
-    digest = hashlib.sha1(f"{kind}:{content}".encode("utf-8")).hexdigest()
-    return digest[:4]
+    if real_id is None:
+        return ""
+    return "".join(c for c in str(real_id).lower() if c.isalnum())[:_FINGERPRINT_LEN]
+
+
+def rank_id(kind: str, rank: int, real_id: Any = None) -> str:
+    """Return the citation id for a playbook or profile item.
+
+    Format is ``{letter}{rank}-{fingerprint}`` where ``letter`` is ``p``
+    for profiles and ``r`` for playbooks, ``rank`` is the 1-based
+    position within the current retrieval batch, and ``fingerprint`` is
+    up to 4 alphanumeric chars derived from ``real_id``. The fingerprint
+    is omitted when no real id is available (falling back to the rank
+    form ``r1`` / ``p1``).
+
+    Args:
+        kind: ``"playbook"`` or ``"profile"``. Unknown values raise
+            ``ValueError`` — callers never build registry entries for
+            other kinds.
+        rank: 1-based position within the retrieval batch.
+        real_id: The underlying ``user_playbook_id`` or ``profile_id``
+            used to derive the fingerprint suffix. Optional.
+
+    Returns:
+        str: ``p<rank>-<fp>`` for profiles, ``r<rank>-<fp>`` for
+            playbooks. Suffix is omitted when the real id yields no
+            alphanumeric fingerprint.
+
+    Raises:
+        ValueError: If ``kind`` is not ``"profile"`` or ``"playbook"``.
+    """
+    if kind == "profile":
+        prefix = "p"
+    elif kind == "playbook":
+        prefix = "r"
+    else:
+        raise ValueError(f"unknown citation kind: {kind!r}")
+    fp = _fingerprint(real_id)
+    return f"{prefix}{rank}-{fp}" if fp else f"{prefix}{rank}"
 
 
 def parse_citation_command(command: str) -> list[str]:
@@ -99,8 +152,9 @@ def parse_citation_command(command: str) -> list[str]:
             block.
 
     Returns:
-        list[str]: Lowercase 4-hex-char ids, in the order Claude cited
-            them. Empty when the command does not match.
+        list[str]: Lowercase rank ids (e.g. ``"p1"``, ``"r3"``), in the
+            order Claude cited them. Empty when the command does not
+            match.
     """
     match = CITATION_CMD_RE.match(command or "")
     if not match:

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -150,8 +150,8 @@ def _scan_transcript_for_cs_cite_ids(path: Path) -> list[str]:
         path (Path): Absolute path to the transcript JSONL.
 
     Returns:
-        list[str]: 4-hex-char ids in emission order. Empty when no
-            ``cs-cite`` call is found.
+        list[str]: Rank ids (e.g. ``"r1-ab12"``, ``"p2-cd34"``) in
+            emission order. Empty when no ``cs-cite`` call is found.
     """
     out: list[str] = []
     for entry in _iter_current_turn_assistant_entries(path):
@@ -198,13 +198,15 @@ def _resolve_cited_items(session_id: str, cited_ids: list[str]) -> list[dict[str
         if not entry:
             continue
         seen.add(cid)
-        resolved.append(
-            {
-                "id": entry.get("id", cid),
-                "kind": entry.get("kind", ""),
-                "title": entry.get("title", ""),
-            }
-        )
+        item: dict[str, Any] = {
+            "id": entry.get("id", cid),
+            "kind": entry.get("kind", ""),
+            "title": entry.get("title", ""),
+        }
+        real_id = entry.get("real_id")
+        if real_id:
+            item["real_id"] = real_id
+        resolved.append(item)
     return resolved
 
 

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -25,19 +25,68 @@ def test_render_with_registry_empty_content_items_ignored() -> None:
 
 
 def test_render_with_registry_ids_match_between_markdown_and_registry() -> None:
-    pbs = [{"content": "use pathlib"}]
-    prs = [{"content": "prefers anyio"}]
+    pbs = [{"content": "use pathlib", "user_playbook_id": 17}]
+    prs = [{"content": "prefers anyio", "profile_id": "uuid-profile-1"}]
     md, registry = context_format.render_with_registry(
         project_id="demo", playbooks=pbs, profiles=prs
     )
-    pb_id = cs_cite.short_id("playbook", "use pathlib")
-    pr_id = cs_cite.short_id("profile", "prefers anyio")
-    assert f"[cs:{pb_id}]" in md
-    assert f"[cs:{pr_id}]" in md
-    assert {e["id"] for e in registry} == {pb_id, pr_id}
-    kinds = {e["id"]: e["kind"] for e in registry}
-    assert kinds[pb_id] == "playbook"
-    assert kinds[pr_id] == "profile"
+    assert "[cs:r1-17]" in md
+    assert "[cs:p1-uuid]" in md
+    assert {e["id"] for e in registry} == {"r1-17", "p1-uuid"}
+    by_id = {e["id"]: e for e in registry}
+    assert by_id["r1-17"]["kind"] == "playbook"
+    assert by_id["p1-uuid"]["kind"] == "profile"
+    assert by_id["r1-17"]["real_id"] == "17"
+    assert by_id["p1-uuid"]["real_id"] == "uuid-profile-1"
+
+
+def test_render_with_registry_ranks_increase_in_order() -> None:
+    """Rank ids reflect retrieval order within each kind."""
+    pbs = [
+        {"content": "first rule", "user_playbook_id": 1},
+        {"content": "second rule", "user_playbook_id": 2},
+    ]
+    prs = [
+        {"content": "first pref", "profile_id": "a"},
+        {"content": "second pref", "profile_id": "b"},
+    ]
+    md, registry = context_format.render_with_registry(
+        project_id="demo", playbooks=pbs, profiles=prs
+    )
+    assert "[cs:r1-1] first rule" in md
+    assert "[cs:r2-2] second rule" in md
+    assert "[cs:p1-a] first pref" in md
+    assert "[cs:p2-b] second pref" in md
+    assert [e["id"] for e in registry] == ["r1-1", "r2-2", "p1-a", "p2-b"]
+
+
+def test_render_with_registry_omits_fingerprint_when_real_id_missing() -> None:
+    """Items without a real id render as bare ranks (back-compat path)."""
+    pbs = [{"content": "orphan rule"}]
+    prs = [{"content": "orphan pref"}]
+    md, registry = context_format.render_with_registry(
+        project_id="demo", playbooks=pbs, profiles=prs
+    )
+    assert "[cs:r1] orphan rule" in md
+    assert "[cs:p1] orphan pref" in md
+    ids = {e["id"] for e in registry}
+    assert ids == {"r1", "p1"}
+
+
+def test_render_with_registry_fingerprint_disambiguates_same_rank() -> None:
+    """Two renders with the same rank but different real ids → distinct tags."""
+    md_a, _ = context_format.render_with_registry(
+        project_id="demo",
+        playbooks=[{"content": "rule A", "user_playbook_id": 100}],
+        profiles=[],
+    )
+    md_b, _ = context_format.render_with_registry(
+        project_id="demo",
+        playbooks=[{"content": "rule B", "user_playbook_id": 200}],
+        profiles=[],
+    )
+    assert "[cs:r1-100]" in md_a
+    assert "[cs:r1-200]" in md_b
 
 
 def test_render_with_registry_emits_citation_instruction() -> None:

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -14,74 +14,132 @@ from claude_smart import cs_cite
 
 
 def test_parse_citation_command_accepts_bare_invocation() -> None:
-    assert cs_cite.parse_citation_command("cs-cite ab12,cd34") == ["ab12", "cd34"]
+    assert cs_cite.parse_citation_command("cs-cite p1-ab12,r2-cd34") == [
+        "p1-ab12",
+        "r2-cd34",
+    ]
 
 
 def test_parse_citation_command_accepts_single_id() -> None:
-    assert cs_cite.parse_citation_command("cs-cite ab12") == ["ab12"]
+    assert cs_cite.parse_citation_command("cs-cite p1-ab12") == ["p1-ab12"]
+
+
+def test_parse_citation_command_accepts_id_without_fingerprint() -> None:
+    """Bare ``p1`` / ``r1`` still parse — fingerprint is optional."""
+    assert cs_cite.parse_citation_command("cs-cite p1") == ["p1"]
+    assert cs_cite.parse_citation_command("cs-cite p1,r2") == ["p1", "r2"]
 
 
 def test_parse_citation_command_accepts_absolute_path_prefix() -> None:
     """The regex documents an optional path prefix for bare TUI rendering."""
-    cmd = "/Users/me/.claude-smart/bin/cs-cite ab12"
-    assert cs_cite.parse_citation_command(cmd) == ["ab12"]
+    cmd = "/Users/me/.claude-smart/bin/cs-cite r3-abcd"
+    assert cs_cite.parse_citation_command(cmd) == ["r3-abcd"]
 
 
 def test_parse_citation_command_rejects_chained_commands() -> None:
-    assert cs_cite.parse_citation_command("cs-cite ab12 && echo ok") == []
-    assert cs_cite.parse_citation_command("cs-cite ab12 | cat") == []
-    assert cs_cite.parse_citation_command("cs-cite ab12; echo ok") == []
+    assert cs_cite.parse_citation_command("cs-cite p1-ab12 && echo ok") == []
+    assert cs_cite.parse_citation_command("cs-cite p1-ab12 | cat") == []
+    assert cs_cite.parse_citation_command("cs-cite p1-ab12; echo ok") == []
 
 
-def test_parse_citation_command_rejects_non_hex_ids() -> None:
+def test_parse_citation_command_rejects_malformed_ids() -> None:
     assert cs_cite.parse_citation_command("cs-cite xxxx") == []
-    assert cs_cite.parse_citation_command("cs-cite toolong") == []
+    assert cs_cite.parse_citation_command("cs-cite ab12") == []
+    assert cs_cite.parse_citation_command("cs-cite p") == []
+    assert cs_cite.parse_citation_command("cs-cite q1-abcd") == []
+    # Fingerprint > 4 chars is rejected.
+    assert cs_cite.parse_citation_command("cs-cite p1-abcde") == []
+    # Empty fingerprint after dash is rejected.
+    assert cs_cite.parse_citation_command("cs-cite p1-") == []
 
 
 def test_parse_citation_command_normalizes_uppercase() -> None:
-    """Uppercase ids are accepted and normalized to lowercase."""
-    assert cs_cite.parse_citation_command("cs-cite AB12") == ["ab12"]
-    assert cs_cite.parse_citation_command("cs-cite AB12,CD34") == ["ab12", "cd34"]
+    """Uppercase ids (prefix, kind, fingerprint) are normalized to lowercase."""
+    assert cs_cite.parse_citation_command("cs-cite P1-AB12") == ["p1-ab12"]
+    assert cs_cite.parse_citation_command("cs-cite P1-AB12,R2-CD34") == [
+        "p1-ab12",
+        "r2-cd34",
+    ]
 
 
 def test_parse_citation_command_strips_cs_prefix() -> None:
     """The `cs:` prefix from `[cs:xxxx]` tags is stripped automatically."""
-    assert cs_cite.parse_citation_command("cs-cite cs:ab12") == ["ab12"]
-    assert cs_cite.parse_citation_command("cs-cite cs:ab12,cs:cd34") == [
-        "ab12",
-        "cd34",
+    assert cs_cite.parse_citation_command("cs-cite cs:p1-ab12") == ["p1-ab12"]
+    assert cs_cite.parse_citation_command("cs-cite cs:p1-ab12,cs:r2-cd34") == [
+        "p1-ab12",
+        "r2-cd34",
     ]
-    assert cs_cite.parse_citation_command("cs-cite cs:ab12,cd34") == ["ab12", "cd34"]
+    assert cs_cite.parse_citation_command("cs-cite cs:p1-ab12,r2-cd34") == [
+        "p1-ab12",
+        "r2-cd34",
+    ]
 
 
 def test_parse_citation_command_accepts_uppercase_cs_prefix() -> None:
     """An uppercase `CS:` prefix is tolerated — the bin script accepts it too."""
-    assert cs_cite.parse_citation_command("cs-cite CS:ab12") == ["ab12"]
-    assert cs_cite.parse_citation_command("cs-cite CS:AB12,Cs:CD34") == [
-        "ab12",
-        "cd34",
+    assert cs_cite.parse_citation_command("cs-cite CS:p1-ab12") == ["p1-ab12"]
+    assert cs_cite.parse_citation_command("cs-cite CS:P1-AB12,Cs:R2-CD34") == [
+        "p1-ab12",
+        "r2-cd34",
     ]
 
 
 def test_parse_citation_command_accepts_whitespace_separators() -> None:
     """Whitespace between ids is accepted alongside commas."""
-    assert cs_cite.parse_citation_command("cs-cite ab12 cd34") == ["ab12", "cd34"]
-    assert cs_cite.parse_citation_command("cs-cite ab12, cd34") == ["ab12", "cd34"]
+    assert cs_cite.parse_citation_command("cs-cite p1-ab12 r2-cd34") == [
+        "p1-ab12",
+        "r2-cd34",
+    ]
+    assert cs_cite.parse_citation_command("cs-cite p1-ab12, r2-cd34") == [
+        "p1-ab12",
+        "r2-cd34",
+    ]
+
+
+def test_parse_citation_command_accepts_multi_digit_ranks() -> None:
+    """Rank numbers may grow beyond single digits."""
+    assert cs_cite.parse_citation_command("cs-cite p10-abcd,r42-ef01") == [
+        "p10-abcd",
+        "r42-ef01",
+    ]
 
 
 def test_parse_citation_command_rejects_embedded_path_traversal() -> None:
     """A path prefix is allowed, but must not contain spaces or extra tokens."""
-    assert cs_cite.parse_citation_command("/tmp/../evil cs-cite ab12") == []
+    assert cs_cite.parse_citation_command("/tmp/../evil cs-cite p1-ab12") == []
 
 
-def test_short_id_is_stable_and_namespaced() -> None:
-    a = cs_cite.short_id("playbook", "use pathlib")
-    b = cs_cite.short_id("playbook", "use pathlib")
-    c = cs_cite.short_id("profile", "use pathlib")
-    assert a == b
-    assert a != c
-    assert len(a) == 4
-    assert all(ch in "0123456789abcdef" for ch in a)
+def test_rank_id_without_real_id_omits_fingerprint() -> None:
+    assert cs_cite.rank_id("profile", 1) == "p1"
+    assert cs_cite.rank_id("profile", 7) == "p7"
+    assert cs_cite.rank_id("playbook", 1) == "r1"
+    assert cs_cite.rank_id("playbook", 12) == "r12"
+
+
+def test_rank_id_appends_fingerprint_from_real_id() -> None:
+    """Fingerprint is the first 4 alphanumeric chars of ``str(real_id)``, lowercased."""
+    assert cs_cite.rank_id("profile", 1, 17) == "p1-17"
+    assert cs_cite.rank_id("playbook", 2, "uuid-profile-1") == "r2-uuid"
+    assert cs_cite.rank_id("playbook", 3, "AbCdEfGh") == "r3-abcd"
+
+
+def test_rank_id_disambiguates_across_injections() -> None:
+    """Same rank + different real ids → distinct ids (core collision fix)."""
+    a = cs_cite.rank_id("playbook", 1, 100)
+    b = cs_cite.rank_id("playbook", 1, 200)
+    assert a != b
+    assert a == "r1-100"
+    assert b == "r1-200"
+
+
+def test_rank_id_real_id_without_alphanumeric_falls_back_to_rank() -> None:
+    """An id like ``"---"`` has no alphanumeric prefix → suffix omitted."""
+    assert cs_cite.rank_id("profile", 1, "---") == "p1"
+
+
+def test_rank_id_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError):
+        cs_cite.rank_id("other", 1)
 
 
 def test_ensure_installed_is_idempotent_and_executable(tmp_path, monkeypatch) -> None:
@@ -131,13 +189,13 @@ def _run_cs_cite(*argv: str) -> subprocess.CompletedProcess[str]:
 
 
 def test_cs_cite_script_prints_singular_line() -> None:
-    r = _run_cs_cite("ab12")
+    r = _run_cs_cite("p1-ab12")
     assert r.returncode == 0
     assert r.stdout == "✨ used 1 claude-smart learning\n"
 
 
 def test_cs_cite_script_prints_plural_line() -> None:
-    r = _run_cs_cite("ab12,cd34,ef56")
+    r = _run_cs_cite("p1-ab12,r2-cd34,p3-ef56")
     assert r.returncode == 0
     assert r.stdout == "✨ used 3 claude-smart learnings\n"
 
@@ -145,38 +203,46 @@ def test_cs_cite_script_prints_plural_line() -> None:
 def test_cs_cite_script_rejects_no_args() -> None:
     r = _run_cs_cite()
     assert r.returncode == 1
-    assert "4-hex-char" in r.stderr
+    assert "rank ids" in r.stderr
 
 
 def test_cs_cite_script_accepts_space_separated_argv() -> None:
     """Multiple argv tokens are joined; Stop-side regex tolerates the shape."""
-    r = _run_cs_cite("ab12", "cd34")
+    r = _run_cs_cite("p1-ab12", "r2-cd34")
     assert r.returncode == 0
     assert r.stdout == "✨ used 2 claude-smart learnings\n"
 
 
 def test_cs_cite_script_strips_cs_prefix() -> None:
     """Ids copied verbatim from `[cs:xxxx]` tags are accepted."""
-    r = _run_cs_cite("cs:ab12,cs:cd34,cs:ef56")
+    r = _run_cs_cite("cs:p1-ab12,cs:r2-cd34,cs:p3-ef56")
     assert r.returncode == 0
     assert r.stdout == "✨ used 3 claude-smart learnings\n"
 
 
 def test_cs_cite_script_normalizes_uppercase() -> None:
-    r = _run_cs_cite("AB12,CD34")
+    r = _run_cs_cite("P1-AB12,R2-CD34")
     assert r.returncode == 0
     assert r.stdout == "✨ used 2 claude-smart learnings\n"
 
 
-def test_cs_cite_script_rejects_non_hex_ids() -> None:
+def test_cs_cite_script_accepts_bare_rank_without_fingerprint() -> None:
+    """Fingerprint-less ids remain valid for back-compat with registry entries
+    that had no real id."""
+    r = _run_cs_cite("p1,r2")
+    assert r.returncode == 0
+    assert r.stdout == "✨ used 2 claude-smart learnings\n"
+
+
+def test_cs_cite_script_rejects_malformed_ids() -> None:
     r = _run_cs_cite("xxxx")
     assert r.returncode == 1
-    assert "4-hex-char" in r.stderr
+    assert "rank ids" in r.stderr
 
 
 def test_cs_cite_script_warns_on_mixed_valid_and_invalid() -> None:
     """Valid ids still succeed; invalid tokens are flagged on stderr."""
-    r = _run_cs_cite("ab12,notahex,cd34")
+    r = _run_cs_cite("p1-ab12,notarank,r3-cd34")
     assert r.returncode == 0
     assert r.stdout == "✨ used 2 claude-smart learnings\n"
-    assert "notahex" in r.stderr
+    assert "notarank" in r.stderr

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -433,17 +433,19 @@ def _prime_injected_registry(session_id: str) -> None:
         session_id,
         [
             {
-                "id": "ab12",
+                "id": "r1-42",
                 "kind": "playbook",
                 "title": "use pathlib",
                 "content": "use pathlib",
+                "real_id": "42",
                 "ts": 0,
             },
             {
-                "id": "cd34",
+                "id": "p1-uuid",
                 "kind": "profile",
                 "title": "prefers anyio",
                 "content": "prefers anyio",
+                "real_id": "uuid-anyio",
                 "ts": 0,
             },
         ],
@@ -455,7 +457,7 @@ def test_stop_records_cs_cite_ids_as_cited_items(
 ) -> None:
     """A single cs-cite call resolves ids against the session registry."""
     _prime_injected_registry("s1")
-    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite ab12,cd34")
+    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite r1-42,p1-uuid")
     monkeypatch.setattr(
         "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
     )
@@ -464,8 +466,13 @@ def test_stop_records_cs_cite_ids_as_cited_items(
     assert records[-1]["role"] == "Assistant"
     cited = records[-1].get("cited_items")
     assert cited == [
-        {"id": "ab12", "kind": "playbook", "title": "use pathlib"},
-        {"id": "cd34", "kind": "profile", "title": "prefers anyio"},
+        {"id": "r1-42", "kind": "playbook", "title": "use pathlib", "real_id": "42"},
+        {
+            "id": "p1-uuid",
+            "kind": "profile",
+            "title": "prefers anyio",
+            "real_id": "uuid-anyio",
+        },
     ]
 
 
@@ -495,7 +502,7 @@ def test_stop_omits_cited_items_when_no_cs_cite_call(
 def test_stop_drops_unknown_cs_cite_ids(session_dir, tmp_path, monkeypatch) -> None:
     """Ids not present in the session registry are silently dropped."""
     _prime_injected_registry("s1")
-    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite ab12,ffff")
+    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite r1-42,r9-ffff")
     monkeypatch.setattr(
         "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
     )
@@ -503,7 +510,7 @@ def test_stop_drops_unknown_cs_cite_ids(session_dir, tmp_path, monkeypatch) -> N
     records = state.read_all("s1")
     cited = records[-1].get("cited_items")
     assert cited == [
-        {"id": "ab12", "kind": "playbook", "title": "use pathlib"},
+        {"id": "r1-42", "kind": "playbook", "title": "use pathlib", "real_id": "42"},
     ]
 
 
@@ -523,7 +530,7 @@ def test_stop_merges_multiple_cs_cite_calls_dedup(
                         {
                             "type": "tool_use",
                             "name": "Bash",
-                            "input": {"command": "cs-cite ab12"},
+                            "input": {"command": "cs-cite r1-42"},
                         }
                     ]
                 },
@@ -535,7 +542,7 @@ def test_stop_merges_multiple_cs_cite_calls_dedup(
                         {
                             "type": "tool_use",
                             "name": "Bash",
-                            "input": {"command": "cs-cite ab12,cd34"},
+                            "input": {"command": "cs-cite r1-42,p1-uuid"},
                         }
                     ]
                 },
@@ -549,8 +556,13 @@ def test_stop_merges_multiple_cs_cite_calls_dedup(
     records = state.read_all("s1")
     cited = records[-1].get("cited_items")
     assert cited == [
-        {"id": "ab12", "kind": "playbook", "title": "use pathlib"},
-        {"id": "cd34", "kind": "profile", "title": "prefers anyio"},
+        {"id": "r1-42", "kind": "playbook", "title": "use pathlib", "real_id": "42"},
+        {
+            "id": "p1-uuid",
+            "kind": "profile",
+            "title": "prefers anyio",
+            "real_id": "uuid-anyio",
+        },
     ]
 
 
@@ -564,7 +576,7 @@ def test_stop_rejects_chained_cs_cite_commands(
     bare ``cs-cite <ids>`` invocation.
     """
     _prime_injected_registry("s1")
-    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite ab12 && echo done")
+    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite r1-42 && echo done")
     monkeypatch.setattr(
         "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
     )
@@ -589,7 +601,7 @@ def test_stop_citation_without_prior_registry_drops_all_ids(
     session_dir, tmp_path, monkeypatch
 ) -> None:
     """Citation with no ``.injected.jsonl`` (e.g. resumed session) → all ids drop."""
-    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite ab12")
+    transcript = _transcript_with_cs_cite_call(tmp_path, "cs-cite r1-42")
     monkeypatch.setattr(
         "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
     )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -139,13 +139,13 @@ def test_append_injected_roundtrip(session_dir) -> None:
     state.append_injected(
         "s1",
         [
-            {"id": "ab12", "kind": "playbook", "title": "t1", "content": "c1"},
-            {"id": "cd34", "kind": "profile", "title": "t2", "content": "c2"},
+            {"id": "r1-ab12", "kind": "playbook", "title": "t1", "content": "c1"},
+            {"id": "p1-cd34", "kind": "profile", "title": "t2", "content": "c2"},
         ],
     )
     registry = state.read_injected("s1")
-    assert registry["ab12"]["title"] == "t1"
-    assert registry["cd34"]["kind"] == "profile"
+    assert registry["r1-ab12"]["title"] == "t1"
+    assert registry["p1-cd34"]["kind"] == "profile"
 
 
 def test_append_injected_empty_iter_is_noop(session_dir) -> None:
@@ -161,25 +161,42 @@ def test_read_injected_missing_file_returns_empty(session_dir) -> None:
 def test_read_injected_last_entry_wins_on_duplicate_id(session_dir) -> None:
     """Same id injected twice → the later metadata shadows the earlier one."""
     state.append_injected(
-        "s1", [{"id": "ab12", "kind": "playbook", "title": "old", "content": "c"}]
+        "s1",
+        [{"id": "r1-ab12", "kind": "playbook", "title": "old", "content": "c"}],
     )
     state.append_injected(
-        "s1", [{"id": "ab12", "kind": "playbook", "title": "new", "content": "c"}]
+        "s1",
+        [{"id": "r1-ab12", "kind": "playbook", "title": "new", "content": "c"}],
     )
     registry = state.read_injected("s1")
-    assert registry["ab12"]["title"] == "new"
+    assert registry["r1-ab12"]["title"] == "new"
+
+
+def test_read_injected_different_fingerprints_do_not_collide(session_dir) -> None:
+    """Cross-injection disambiguation: same rank + different fingerprints coexist."""
+    state.append_injected(
+        "s1",
+        [{"id": "r1-0100", "kind": "playbook", "title": "older", "content": "c"}],
+    )
+    state.append_injected(
+        "s1",
+        [{"id": "r1-0200", "kind": "playbook", "title": "newer", "content": "c"}],
+    )
+    registry = state.read_injected("s1")
+    assert registry["r1-0100"]["title"] == "older"
+    assert registry["r1-0200"]["title"] == "newer"
 
 
 def test_read_injected_skips_malformed_lines(session_dir) -> None:
     path = state.injected_path("s1")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        '{"id":"ab12","kind":"playbook","title":"ok","content":"c"}\n'
+        '{"id":"r1-ab12","kind":"playbook","title":"ok","content":"c"}\n'
         "not-json\n"
-        '{"id":"cd34","kind":"profile","title":"ok2","content":"c"}\n'
+        '{"id":"p1-cd34","kind":"profile","title":"ok2","content":"c"}\n'
     )
     registry = state.read_injected("s1")
-    assert set(registry.keys()) == {"ab12", "cd34"}
+    assert set(registry.keys()) == {"r1-ab12", "p1-cd34"}
 
 
 def test_read_injected_drops_entries_without_id(session_dir) -> None:
@@ -188,10 +205,10 @@ def test_read_injected_drops_entries_without_id(session_dir) -> None:
     path.write_text(
         '{"kind":"playbook","title":"ok","content":"c"}\n'
         '{"id":"","kind":"playbook","title":"ok","content":"c"}\n'
-        '{"id":"ab12","kind":"playbook","title":"ok","content":"c"}\n'
+        '{"id":"r1-ab12","kind":"playbook","title":"ok","content":"c"}\n'
     )
     registry = state.read_injected("s1")
-    assert set(registry.keys()) == {"ab12"}
+    assert set(registry.keys()) == {"r1-ab12"}
 
 
 def test_unpublished_slice_strips_cited_items(session_dir) -> None:
@@ -201,7 +218,7 @@ def test_unpublished_slice_strips_cited_items(session_dir) -> None:
         {
             "role": "Assistant",
             "content": "ok",
-            "cited_items": [{"id": "ab12", "kind": "playbook", "title": "t"}],
+            "cited_items": [{"id": "r1-ab12", "kind": "playbook", "title": "t"}],
         },
     ]
     _, turns = state.unpublished_slice(records)


### PR DESCRIPTION
## Summary
- Replace hash-based `[cs:ab12]` citation ids with rank + fingerprint form `[cs:r1-ab12]` (playbook) / `[cs:p1-cd34]` (profile) — rank alone resets each injection and would silently alias into the append-only session registry; a fingerprint of the underlying `user_playbook_id` / `profile_id` keeps cross-injection ids distinct so the resolver matches the right item.
- Dashboard: cited-item badges are now links into the playbook/profile detail pages, using the real id when available so clicking through survives rank reshuffling.
- Add `npx claude-smart uninstall` as the mirror of the existing install/update subcommands, plus README updates to lead with the `claude plugin …` CLI form and refresh "rules" → "playbooks" phrasing.

## Changes

**Citation ids (`r1-ab12` / `p1-cd34`)**
- `plugin/src/claude_smart/cs_cite.py` — drop `short_id` (SHA1 prefix) in favor of `rank_id(kind, rank, real_id)`; rewrite `CITATION_CMD_RE` / `_CLEAN_ID_RE` to accept `p<N>[-<fp>]` / `r<N>[-<fp>]`; update `CITATION_INSTRUCTION` prose.
- `plugin/src/claude_smart/context_format.py` — pass rank and `user_playbook_id` / `profile_id` into `rank_id`; persist `real_id` on registry entries.
- `plugin/src/claude_smart/events/stop.py` — propagate `real_id` into resolved `cited_items` so the dashboard can link through.
- `plugin/bin/cs-cite` — accept the new token shape on the CLI side, error messages updated.
- Tests updated across `test_cs_cite.py`, `test_context_format.py`, `test_events.py`, `test_state.py`; adds cross-injection disambiguation coverage and multi-digit rank / bare-rank (no-fingerprint) cases.

**Dashboard link-through**
- `plugin/dashboard/app/interactions/[sessionId]/page.tsx` — wrap cited-item badges in `<Link>` targeting `/playbooks/<real_id>` or `/profiles/<real_id>`, falling back to the rank id; add hover styling.
- `plugin/dashboard/lib/types.ts` — add optional `real_id` to `CitedItem`.

**Install/uninstall CLI**
- `bin/claude-smart.js` — add `runUninstall()` shelling out to `claude plugin uninstall`, wire it into the command dispatch and `--help`.
- `README.md` — install section now uses `claude plugin marketplace add … / claude plugin install …`, documents `npx claude-smart uninstall`, and updates terminology to "playbooks".

## Why rank + fingerprint (not pure rank, not pure hash)

- **Pure rank** (`r1`, `p1`) collides across injections: turn N injects playbook A as `r1`, turn N+1 injects playbook B as `r1`; the append-only `~/.claude-smart/sessions/<id>.injected.jsonl` registry would have the later write shadow the earlier one. If Claude cites `r1` referring to turn N's item, the resolver picks turn N+1's — silent wrong attribution.
- **Pure hash** (the old `short_id`) is stable but opaque — the model has to copy 4 random hex chars with no hint of kind or position, which is error-prone and surfaces nothing useful to humans reading transcripts.
- **Rank + fingerprint** is readable for the model (`r1`, `p2` tells it what kind + where in the list), disambiguates the common collision case (distinct real ids → distinct 1–4-char suffixes), and degrades gracefully when a real id is absent (suffix omitted, falls back to bare rank).

## Test Plan
- [x] `uv run --project plugin pytest tests/test_cs_cite.py tests/test_context_format.py tests/test_events.py tests/test_state.py` — 89 passed
- [x] `ruff check --fix` / `ruff format` — clean
- [ ] Manual: start a session, confirm `/show` renders `[cs:r1-…]` / `[cs:p1-…]` tags
- [ ] Manual: click a cited-item badge in the dashboard interaction view — lands on the right playbook/profile page
- [ ] Manual: `npx claude-smart uninstall` removes the plugin and prints the leftover-data notice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin uninstall command: `npx claude-smart uninstall`.
  * Cited items in the dashboard are now interactive links to related profiles and playbooks.

* **Documentation**
  * Updated terminology: "rules" → "playbooks" throughout the app.
  * Revised CLI installation and uninstallation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->