### PR TITLE
github workflow integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,47 @@
+name: integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: integration (${{ matrix.os }}, node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: ['18', '20', '22']
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@stable
+
+      - name: Run integration test
+        env:
+          # Plugin install is local-config only and shouldn't hit the API,
+          # but a dummy key prevents a hang at any first-launch login prompt.
+          # Real SessionStart-via-session testing would need a real key (see
+          # tests/integration/NOTES.md).
+          ANTHROPIC_API_KEY: dummy-for-plugin-install
+        run: bash tests/integration/integration.sh all

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Post-install runtime integration test for claude-smart.
+#
+# Simulates a fresh user environment: sandboxed HOME, no prior reflexio
+# state, no prior claude-smart state. Exercises the two hook-driven
+# long-lived services (backend on :8071, dashboard on :3001) and asserts
+# they come up healthy.
+#
+# Assumes a working install environment: uv, node, npm, python3 already
+# on PATH. The GitHub Actions matrix controls the node version; uv is
+# installed by the workflow before this runs. For local use, bring your
+# own toolchain.
+#
+# Usage:
+#   bash tests/integration/integration.sh            # all stages
+#   bash tests/integration/integration.sh setup      # single stage
+#   bash tests/integration/integration.sh backend
+#   bash tests/integration/integration.sh dashboard
+#
+# Exit status: 0 on success, non-zero on any stage failure. Dumps the
+# relevant service logs to stderr before exiting non-zero.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+PLUGIN_ROOT="$REPO_ROOT/plugin"
+
+BACKEND_PORT=8071
+DASHBOARD_PORT=3001
+
+# Sandbox HOME so real ~/.reflexio, ~/.claude-smart, ~/.claude stay
+# untouched. Created once, reused across stages within a single run.
+if [ -z "${CLAUDE_SMART_INTEG_HOME:-}" ]; then
+  INTEG_HOME="$(mktemp -d -t claude-smart-integration.XXXXXX)"
+  export CLAUDE_SMART_INTEG_HOME="$INTEG_HOME"
+else
+  INTEG_HOME="$CLAUDE_SMART_INTEG_HOME"
+fi
+export HOME="$INTEG_HOME"
+
+# Let the plugin scripts resolve their own root without the hooks.json
+# env var; smart-install.sh doesn't read CLAUDE_PLUGIN_ROOT but the
+# SessionStart hooks do. Exporting it here documents intent and keeps
+# any future script that honors it pointed at this checkout.
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+
+log()  { printf '[integration] %s\n' "$*" >&2; }
+fail() { printf '[integration] FAIL: %s\n' "$*" >&2; exit 1; }
+
+dump_logs() {
+  for f in "$HOME/.claude-smart/backend.log" "$HOME/.claude-smart/dashboard.log"; do
+    if [ -f "$f" ]; then
+      printf '\n===== %s =====\n' "$f" >&2
+      cat "$f" >&2 || true
+    fi
+  done
+}
+
+# Poll a URL up to $1 seconds for HTTP 2xx. Returns 0 on first success.
+poll_200() {
+  local url="$1" timeout="$2"
+  local i=0
+  while [ "$i" -lt "$timeout" ]; do
+    if curl -sf -o /dev/null "$url" 2>/dev/null; then return 0; fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# Poll a URL up to $1 seconds for a specific response header. Returns 0
+# when the header is present in the response. Used for the dashboard
+# marker check so a foreign listener on :3001 doesn't pass the integration.
+poll_header() {
+  local url="$1" header="$2" timeout="$3"
+  local i=0
+  while [ "$i" -lt "$timeout" ]; do
+    if curl -sfI "$url" 2>/dev/null | grep -qi "^${header}:"; then return 0; fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+stage_setup() {
+  log "setup: sandbox HOME=$HOME"
+  if ! command -v claude >/dev/null 2>&1; then
+    fail "claude CLI not on PATH — install via 'npm install -g @anthropic-ai/claude-code'"
+  fi
+  # Plugin subcommands are local-config only, but the CLI may probe for
+  # auth on first launch; a dummy key prevents a hang at a login prompt.
+  export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-dummy-for-plugin-install}"
+
+  log "setup: claude plugin marketplace add $REPO_ROOT"
+  if ! claude plugin marketplace add "$REPO_ROOT" >"$HOME/marketplace-add.log" 2>&1; then
+    cat "$HOME/marketplace-add.log" >&2 || true
+    fail "claude plugin marketplace add failed"
+  fi
+
+  log "setup: claude plugin install claude-smart@reflexioai (fires real Setup hook)"
+  if ! claude plugin install claude-smart@reflexioai >"$HOME/plugin-install.log" 2>&1; then
+    cat "$HOME/plugin-install.log" >&2 || true
+    fail "claude plugin install failed"
+  fi
+  if [ -f "$HOME/.claude-smart/install-failed" ]; then
+    cat "$HOME/.claude-smart/install-failed" >&2 || true
+    fail "Setup hook wrote install-failed marker"
+  fi
+  log "setup: ok"
+}
+
+stage_backend() {
+  log "backend: starting"
+  bash "$PLUGIN_ROOT/scripts/backend-service.sh" start >/dev/null
+  log "backend: polling http://127.0.0.1:$BACKEND_PORT/health (20s)"
+  if ! poll_200 "http://127.0.0.1:$BACKEND_PORT/health" 20; then
+    fail "backend /health did not return 200 within 20s"
+  fi
+  log "backend: ok"
+}
+
+stage_dashboard() {
+  log "dashboard: starting"
+  bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" start >/dev/null
+  log "dashboard: polling http://127.0.0.1:$DASHBOARD_PORT/api/health for x-claude-smart-dashboard header (30s)"
+  if ! poll_header "http://127.0.0.1:$DASHBOARD_PORT/api/health" "x-claude-smart-dashboard" 30; then
+    fail "dashboard marker header not present within 30s"
+  fi
+  log "dashboard: ok"
+}
+
+stage_cleanup() {
+  log "cleanup: stopping services (best-effort)"
+  bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" stop >/dev/null 2>&1 || true
+  bash "$PLUGIN_ROOT/scripts/backend-service.sh"   stop >/dev/null 2>&1 || true
+}
+
+# Always try to stop services and dump logs on any failure. Cleanup on
+# success runs as a normal stage so we can still see the logs if the
+# trap path fires.
+fail() {
+  printf '[integration] FAIL: %s\n' "$*" >&2
+  dump_logs
+  stage_cleanup
+  exit 1
+}
+
+# Keep ERR trap for unexpected failures (e.g., unhandled command failures)
+on_error() {
+  local rc=$?
+  dump_logs
+  stage_cleanup
+  exit "$rc"
+}
+trap on_error ERR
+
+CMD="${1:-all}"
+case "$CMD" in
+  setup)     stage_setup ;;
+  backend)   stage_backend ;;
+  dashboard) stage_dashboard ;;
+  cleanup)   stage_cleanup ;;
+  all)
+    stage_setup
+    stage_backend
+    stage_dashboard
+    stage_cleanup
+    log "all stages passed"
+    ;;
+  *) fail "unknown stage: $CMD (expected: setup|backend|dashboard|cleanup|all)" ;;
+esac

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Post-install runtime integration test for claude-smart.
+#
+# Simulates a fresh user environment: sandboxed HOME, no prior reflexio
+# state, no prior claude-smart state. Exercises the two hook-driven
+# long-lived services (backend on :8071, dashboard on :3001) and asserts
+# they come up healthy.
+#
+# Assumes a working install environment: uv, node, npm, python3 already
+# on PATH. The GitHub Actions matrix controls the node version; uv is
+# installed by the workflow before this runs. For local use, bring your
+# own toolchain.
+#
+# Usage:
+#   bash tests/integration/integration.sh            # all stages
+#   bash tests/integration/integration.sh setup      # single stage
+#   bash tests/integration/integration.sh backend
+#   bash tests/integration/integration.sh dashboard
+#
+# Exit status: 0 on success, non-zero on any stage failure. Dumps the
+# relevant service logs to stderr before exiting non-zero.
+
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+PLUGIN_ROOT="$REPO_ROOT/plugin"
+
+BACKEND_PORT=8071
+DASHBOARD_PORT=3001
+
+# Sandbox HOME so real ~/.reflexio, ~/.claude-smart, ~/.claude stay
+# untouched. Created once, reused across stages within a single run.
+if [ -z "${CLAUDE_SMART_INTEG_HOME:-}" ]; then
+  INTEG_HOME="$(mktemp -d -t claude-smart-integration.XXXXXX)"
+  export CLAUDE_SMART_INTEG_HOME="$INTEG_HOME"
+else
+  INTEG_HOME="$CLAUDE_SMART_INTEG_HOME"
+fi
+export HOME="$INTEG_HOME"
+
+# Let the plugin scripts resolve their own root without the hooks.json
+# env var; smart-install.sh doesn't read CLAUDE_PLUGIN_ROOT but the
+# SessionStart hooks do. Exporting it here documents intent and keeps
+# any future script that honors it pointed at this checkout.
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+
+log()  { printf '[integration] %s\n' "$*" >&2; }
+fail() { printf '[integration] FAIL: %s\n' "$*" >&2; exit 1; }
+
+dump_logs() {
+  for f in "$HOME/.claude-smart/backend.log" "$HOME/.claude-smart/dashboard.log"; do
+    if [ -f "$f" ]; then
+      printf '\n===== %s =====\n' "$f" >&2
+      cat "$f" >&2 || true
+    fi
+  done
+}
+
+# Poll a URL up to $1 seconds for HTTP 2xx. Returns 0 on first success.
+poll_200() {
+  local url="$1" timeout="$2"
+  local i=0
+  while [ "$i" -lt "$timeout" ]; do
+    if curl -sf -o /dev/null "$url" 2>/dev/null; then return 0; fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# Poll a URL up to $1 seconds for a specific response header. Returns 0
+# when the header is present in the response. Used for the dashboard
+# marker check so a foreign listener on :3001 doesn't pass the integration.
+poll_header() {
+  local url="$1" header="$2" timeout="$3"
+  local i=0
+  while [ "$i" -lt "$timeout" ]; do
+    if curl -sfI "$url" 2>/dev/null | grep -qi "^${header}:"; then return 0; fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+stage_setup() {
+  log "setup: sandbox HOME=$HOME"
+  if ! command -v claude >/dev/null 2>&1; then
+    fail "claude CLI not on PATH — install via 'npm install -g @anthropic-ai/claude-code'"
+  fi
+  # Plugin subcommands are local-config only, but the CLI may probe for
+  # auth on first launch; a dummy key prevents a hang at a login prompt.
+  export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-dummy-for-plugin-install}"
+
+  log "setup: claude plugin marketplace add $REPO_ROOT"
+  if ! claude plugin marketplace add "$REPO_ROOT" >"$HOME/marketplace-add.log" 2>&1; then
+    cat "$HOME/marketplace-add.log" >&2 || true
+    fail "claude plugin marketplace add failed"
+  fi
+
+  log "setup: claude plugin install claude-smart@reflexioai (fires real Setup hook)"
+  if ! claude plugin install claude-smart@reflexioai >"$HOME/plugin-install.log" 2>&1; then
+    cat "$HOME/plugin-install.log" >&2 || true
+    fail "claude plugin install failed"
+  fi
+  if [ -f "$HOME/.claude-smart/install-failed" ]; then
+    cat "$HOME/.claude-smart/install-failed" >&2 || true
+    fail "Setup hook wrote install-failed marker"
+  fi
+  log "setup: ok"
+}
+
+stage_backend() {
+  log "backend: starting"
+  bash "$PLUGIN_ROOT/scripts/backend-service.sh" start >/dev/null
+  log "backend: polling http://127.0.0.1:$BACKEND_PORT/health (20s)"
+  if ! poll_200 "http://127.0.0.1:$BACKEND_PORT/health" 20; then
+    fail "backend /health did not return 200 within 20s"
+  fi
+  log "backend: ok"
+}
+
+stage_dashboard() {
+  log "dashboard: starting"
+  bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" start >/dev/null
+  log "dashboard: polling http://127.0.0.1:$DASHBOARD_PORT/api/health for x-claude-smart-dashboard header (30s)"
+  if ! poll_header "http://127.0.0.1:$DASHBOARD_PORT/api/health" "x-claude-smart-dashboard" 30; then
+    fail "dashboard marker header not present within 30s"
+  fi
+  log "dashboard: ok"
+}
+
+stage_cleanup() {
+  log "cleanup: stopping services (best-effort)"
+  bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" stop >/dev/null 2>&1 || true
+  bash "$PLUGIN_ROOT/scripts/backend-service.sh"   stop >/dev/null 2>&1 || true
+}
+
+# Always try to stop services and dump logs on any failure. Cleanup on
+# success runs as a normal stage so we can still see the logs if the
+# trap path fires.
+fail() {
+  printf '[integration] FAIL: %s\n' "$*" >&2
+  dump_logs
+  stage_cleanup
+  exit 1
+}
+
+# Keep ERR trap for unexpected failures (e.g., unhandled command failures)
+on_error() {
+  local rc=$?
+  dump_logs
+  stage_cleanup
+  exit "$rc"
+}
+trap on_error ERR
+
+CMD="${1:-all}"
+case "$CMD" in
+  setup)     stage_setup ;;
+  backend)   stage_backend ;;
+  dashboard) stage_dashboard ;;
+  cleanup)   stage_cleanup ;;
+  all)
+    stage_setup
+    stage_backend
+    stage_dashboard
+    stage_cleanup
+    log "all stages passed"
+    ;;
+  *) fail "unknown stage: $CMD (expected: setup|backend|dashboard|cleanup|all)" ;;
+esac

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -142,6 +142,40 @@ stage_setup() {
   log "setup: ok"
 }
 
+stage_setup_hook() {
+  # ─────────────────────────────────────────────────────────────────────
+  # CI-ONLY WORKAROUND — invoke smart-install.sh directly.
+  #
+  # Claude Code has no documented lifecycle event named "Setup", and
+  # `claude plugin install` does not fire any hooks in headless CI — it
+  # only writes local config. This is tracked upstream at
+  #   https://github.com/anthropics/claude-code/issues/11240
+  # (plugin Install/Uninstall lifecycle hooks — not yet implemented).
+  #
+  # In real use, smart-install.sh ends up running through some path that
+  # populates plugin/dashboard/.next before the first session start. In
+  # CI we have no such path, so we call the script directly here to
+  # simulate what that path produces (npm install + next build).
+  #
+  # Everything else in this test stays on the real CLI flow. Remove this
+  # stage once upstream ships a headless Setup trigger.
+  # ─────────────────────────────────────────────────────────────────────
+  log "setup-hook: running plugin/scripts/smart-install.sh (CI workaround — no headless Setup trigger; upstream #11240)"
+  if ! bash "$PLUGIN_ROOT/scripts/smart-install.sh" >"$HOME/smart-install.log" 2>&1; then
+    cat "$HOME/smart-install.log" >&2 || true
+    fail "smart-install.sh failed (exit $?)"
+  fi
+  # Always surface the log so build warnings (e.g., npm audit, node
+  # version mismatches) are visible even on success.
+  printf '\n===== %s/smart-install.log =====\n' "$HOME" >&2
+  cat "$HOME/smart-install.log" >&2 || true
+  printf '\n'
+  if [ ! -d "$PLUGIN_ROOT/dashboard/.next" ]; then
+    fail "smart-install.sh returned 0 but dashboard/.next was not produced"
+  fi
+  log "setup-hook: ok"
+}
+
 stage_backend() {
   log "backend: starting"
   bash "$PLUGIN_ROOT/scripts/backend-service.sh" start >/dev/null
@@ -170,16 +204,18 @@ stage_cleanup() {
 
 CMD="${1:-all}"
 case "$CMD" in
-  setup)     stage_setup ;;
-  backend)   stage_backend ;;
-  dashboard) stage_dashboard ;;
-  cleanup)   stage_cleanup ;;
+  setup)      stage_setup ;;
+  setup-hook) stage_setup_hook ;;
+  backend)    stage_backend ;;
+  dashboard)  stage_dashboard ;;
+  cleanup)    stage_cleanup ;;
   all)
     stage_setup
+    stage_setup_hook
     stage_backend
     stage_dashboard
     stage_cleanup
     log "all stages passed"
     ;;
-  *) fail "unknown stage: $CMD (expected: setup|backend|dashboard|cleanup|all)" ;;
+  *) fail "unknown stage: $CMD (expected: setup|setup-hook|backend|dashboard|cleanup|all)" ;;
 esac

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -117,9 +117,23 @@ stage_setup() {
   fi
 
   log "setup: claude plugin install claude-smart@reflexioai (fires real Setup hook)"
-  if ! claude plugin install claude-smart@reflexioai >"$HOME/plugin-install.log" 2>&1; then
-    cat "$HOME/plugin-install.log" >&2 || true
-    fail "claude plugin install failed"
+  install_rc=0
+  claude plugin install claude-smart@reflexioai >"$HOME/plugin-install.log" 2>&1 || install_rc=$?
+
+  # Always surface what the install produced — success paths can still
+  # silently skip the Setup hook, which leaves .next unbuilt and surfaces
+  # only downstream as a dashboard failure. Dumping here makes the root
+  # cause visible in the CI log regardless of exit status.
+  printf '\n===== %s/plugin-install.log =====\n' "$HOME" >&2
+  cat "$HOME/plugin-install.log" >&2 || true
+  printf '\n===== ls -la %s/.claude-smart/ =====\n' "$HOME" >&2
+  ls -la "$HOME/.claude-smart/" >&2 2>/dev/null || echo "(no .claude-smart dir — Setup hook did not run)" >&2
+  printf '\n===== ls %s/dashboard/.next =====\n' "$PLUGIN_ROOT" >&2
+  ls "$PLUGIN_ROOT/dashboard/.next" >&2 2>/dev/null || echo "(no .next — dashboard build did not run)" >&2
+  printf '\n'
+
+  if [ "$install_rc" -ne 0 ]; then
+    fail "claude plugin install failed (exit $install_rc)"
   fi
   if [ -f "$HOME/.claude-smart/install-failed" ]; then
     cat "$HOME/.claude-smart/install-failed" >&2 || true

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -14,13 +14,15 @@
 # Usage:
 #   bash tests/integration/integration.sh            # all stages
 #   bash tests/integration/integration.sh setup      # single stage
+#   bash tests/integration/integration.sh setup-hook
 #   bash tests/integration/integration.sh backend
 #   bash tests/integration/integration.sh dashboard
+#   bash tests/integration/integration.sh cleanup
 #
 # Exit status: 0 on success, non-zero on any stage failure. Dumps the
 # relevant service logs to stderr before exiting non-zero.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
@@ -36,6 +38,9 @@ if [ -z "${CLAUDE_SMART_INTEG_HOME:-}" ]; then
   export CLAUDE_SMART_INTEG_HOME="$INTEG_HOME"
 else
   INTEG_HOME="$CLAUDE_SMART_INTEG_HOME"
+  # Caller-supplied path may not exist yet (fresh env, typo in reuse).
+  # Create it before exporting so later log redirects don't fail early.
+  mkdir -p "$INTEG_HOME"
 fi
 export HOME="$INTEG_HOME"
 
@@ -116,61 +121,37 @@ stage_setup() {
     fail "claude plugin marketplace add failed"
   fi
 
-  log "setup: claude plugin install claude-smart@reflexioai (fires real Setup hook)"
-  install_rc=0
-  claude plugin install claude-smart@reflexioai >"$HOME/plugin-install.log" 2>&1 || install_rc=$?
-
-  # Always surface what the install produced — success paths can still
-  # silently skip the Setup hook, which leaves .next unbuilt and surfaces
-  # only downstream as a dashboard failure. Dumping here makes the root
-  # cause visible in the CI log regardless of exit status.
-  printf '\n===== %s/plugin-install.log =====\n' "$HOME" >&2
-  cat "$HOME/plugin-install.log" >&2 || true
-  printf '\n===== ls -la %s/.claude-smart/ =====\n' "$HOME" >&2
-  ls -la "$HOME/.claude-smart/" >&2 2>/dev/null || echo "(no .claude-smart dir — Setup hook did not run)" >&2
-  printf '\n===== ls %s/dashboard/.next =====\n' "$PLUGIN_ROOT" >&2
-  ls "$PLUGIN_ROOT/dashboard/.next" >&2 2>/dev/null || echo "(no .next — dashboard build did not run)" >&2
-  printf '\n'
-
-  if [ "$install_rc" -ne 0 ]; then
-    fail "claude plugin install failed (exit $install_rc)"
-  fi
-  if [ -f "$HOME/.claude-smart/install-failed" ]; then
-    cat "$HOME/.claude-smart/install-failed" >&2 || true
-    fail "Setup hook wrote install-failed marker"
+  # `claude plugin install` only writes local config in headless mode — it
+  # does NOT fire any lifecycle hooks (there is no "Setup" event in the
+  # documented set). We still run it so the plugin is registered the way a
+  # real user's machine would have it; smart-install.sh is invoked in the
+  # next stage as a CI-only workaround. See upstream #11240.
+  log "setup: claude plugin install claude-smart@reflexioai"
+  if ! claude plugin install claude-smart@reflexioai >"$HOME/plugin-install.log" 2>&1; then
+    cat "$HOME/plugin-install.log" >&2 || true
+    fail "claude plugin install failed"
   fi
   log "setup: ok"
 }
 
 stage_setup_hook() {
-  # ─────────────────────────────────────────────────────────────────────
-  # CI-ONLY WORKAROUND — invoke smart-install.sh directly.
-  #
-  # Claude Code has no documented lifecycle event named "Setup", and
-  # `claude plugin install` does not fire any hooks in headless CI — it
-  # only writes local config. This is tracked upstream at
-  #   https://github.com/anthropics/claude-code/issues/11240
-  # (plugin Install/Uninstall lifecycle hooks — not yet implemented).
-  #
-  # In real use, smart-install.sh ends up running through some path that
-  # populates plugin/dashboard/.next before the first session start. In
-  # CI we have no such path, so we call the script directly here to
-  # simulate what that path produces (npm install + next build).
-  #
-  # Everything else in this test stays on the real CLI flow. Remove this
-  # stage once upstream ships a headless Setup trigger.
-  # ─────────────────────────────────────────────────────────────────────
-  log "setup-hook: running plugin/scripts/smart-install.sh (CI workaround — no headless Setup trigger; upstream #11240)"
+  # CI-only workaround. Claude Code has no documented Setup/Install
+  # lifecycle hook, so `claude plugin install` never runs smart-install.sh
+  # in any environment (upstream anthropics/claude-code#11240). We invoke
+  # it here directly to produce dashboard/.next, which dashboard-service.sh
+  # refuses to build in the foreground. Remove this stage once upstream
+  # ships a headless Setup trigger.
+  log "setup-hook: running plugin/scripts/smart-install.sh"
   if ! bash "$PLUGIN_ROOT/scripts/smart-install.sh" >"$HOME/smart-install.log" 2>&1; then
     cat "$HOME/smart-install.log" >&2 || true
-    fail "smart-install.sh failed (exit $?)"
+    fail "smart-install.sh failed"
   fi
-  # Always surface the log so build warnings (e.g., npm audit, node
-  # version mismatches) are visible even on success.
-  printf '\n===== %s/smart-install.log =====\n' "$HOME" >&2
-  cat "$HOME/smart-install.log" >&2 || true
-  printf '\n'
+  if [ -f "$HOME/.claude-smart/install-failed" ]; then
+    cat "$HOME/.claude-smart/install-failed" >&2 || true
+    fail "smart-install.sh wrote install-failed marker"
+  fi
   if [ ! -d "$PLUGIN_ROOT/dashboard/.next" ]; then
+    cat "$HOME/smart-install.log" >&2 || true
     fail "smart-install.sh returned 0 but dashboard/.next was not produced"
   fi
   log "setup-hook: ok"


### PR DESCRIPTION
## Summary                                                                                                                                                                             
                                                                                                                                                                                      
  Unblocks the integration workflow on Ubuntu. claude plugin install in headless CI only writes local config — it does not fire Setup (or any other) hooks, so smart-install.sh never 
  runs and plugin/dashboard/.next is never produced, causing the dashboard stage to fail with .next missing. Upstream issue: anthropics/claude-code#11240 (Install/Uninstall lifecycle
   hooks, not yet implemented).                                                                                                                                                       
                                                            
## Changes

**New** setup-hook stage in tests/integration/integration.sh — invokes plugin/scripts/smart-install.sh directly to build dashboard/.next. Labeled in a comment as a CI-only workaround  
  with a pointer to #11240 and a note to remove it once upstream ships a headless Setup trigger. The rest of the harness (marketplace add, claude plugin install, SessionStart-style
  invocation of backend-service.sh / dashboard-service.sh, /health + /api/health probes) stays on the real CLI flow.                                                                  
                                                                                                                                                                                                                    
   
## Out of scope                                                                                                                                                                        
                                                            
  - macOS matrix failure, node v18.x test is broken as plugin requires v20+                                      
  - Setup hook entry in plugin/hooks/hooks.json — effectively dead config in every environment (not just CI), since Claude Code doesn't define a Setup lifecycle event. Worth a
  separate cleanup / rethink of how smart-install.sh gets triggered in real usage.                                                                                                    
                                                            
## Test plan                                                                                                                                                                           
                                                            
  - Ubuntu × Node 20/22 integration jobs pass                                                                                                                                         
  - Backend /health returns 200 within 20s
  - Dashboard /api/health returns the x-claude-smart-dashboard marker within 30s                                                                                                      
  - setup-hook stage fails loudly (non-zero exit, log dumped) if smart-install.sh returns 0 but dashboard/.next is still missing  
<img width="818" height="534" alt="image" src="https://github.com/user-attachments/assets/2ef4ffd2-e03c-48cb-91b6-8236f3e1cfc1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated integration workflow that runs on main pushes, pull requests, and manual trigger across multiple OSes and Node.js versions to validate end-to-end behavior.
  * Added a comprehensive post-install integration test that verifies plugin installation, starts backend and dashboard services, polls their health endpoints, and captures logs on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->