### PR TITLE
feat: rename /interactions → /sessions and replace dead corrections metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <img src="https://img.shields.io/badge/python-%3E%3D3.12-brightgreen.svg" alt="Python">
   </a>
   <a href="package.json">
-    <img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg" alt="Node">
+    <img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg" alt="Node">
   </a>
   <a href="#quick-start">
     <img src="https://img.shields.io/badge/llm-claude%20code%20cli-purple.svg" alt="LLM">

--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -5,10 +5,11 @@ import Link from "next/link";
 import {
   BookOpen,
   MessageSquare,
-  AlertTriangle,
+  Sparkles,
   Activity,
   ExternalLink,
 } from "lucide-react";
+import { LearningsBadge } from "@/components/common/learnings-badge";
 import { PageHeader } from "@/components/common/page-header";
 import { StatCard } from "@/components/common/stat-card";
 import { EmptyState } from "@/components/common/empty-state";
@@ -52,7 +53,10 @@ export default function DashboardPage() {
   const currentPlaybooks = (playbooks ?? []).filter(
     (p) => p.status == null || p.status === "CURRENT",
   );
-  const correctionSessions = (sessions ?? []).filter((s) => s.has_correction);
+  const learningInteractionTotal = (sessions ?? []).reduce(
+    (acc, s) => acc + s.learning_interaction_count,
+    0,
+  );
   const lastActivity =
     (sessions ?? []).reduce<number | null>(
       (acc, s) => Math.max(acc ?? 0, s.last_activity ?? 0) || null,
@@ -69,7 +73,7 @@ export default function DashboardPage() {
       <div className="p-6 space-y-6">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
           <StatCard
-            label="Active sessions"
+            label="Sessions recorded"
             value={sessions?.length ?? "—"}
             hint="JSONL buffers on disk"
             icon={Activity}
@@ -81,10 +85,10 @@ export default function DashboardPage() {
             icon={BookOpen}
           />
           <StatCard
-            label="Sessions with corrections"
-            value={correctionSessions.length}
-            hint="unresolved feedback signals"
-            icon={AlertTriangle}
+            label="Interactions with learnings applied"
+            value={learningInteractionTotal}
+            hint="turns where a playbook or profile was cited"
+            icon={Sparkles}
           />
           <StatCard
             label="Last activity"
@@ -103,7 +107,7 @@ export default function DashboardPage() {
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-sm font-semibold">Recent sessions</h2>
             <Link
-              href="/interactions"
+              href="/sessions"
               className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
             >
               View all <ExternalLink className="h-3 w-3" />
@@ -114,7 +118,7 @@ export default function DashboardPage() {
               {sessions.slice(0, 5).map((s) => (
                 <Link
                   key={s.session_id}
-                  href={`/interactions/${s.session_id}`}
+                  href={`/sessions/${s.session_id}`}
                   className="flex items-center justify-between px-4 py-3 hover:bg-accent/40 transition-colors"
                 >
                   <div className="min-w-0 flex items-center gap-3">
@@ -122,11 +126,7 @@ export default function DashboardPage() {
                     <code className="font-mono text-xs truncate">
                       {truncateId(s.session_id, 10, 6)}
                     </code>
-                    {s.has_correction && (
-                      <Badge variant="destructive" className="h-5">
-                        correction
-                      </Badge>
-                    )}
+                    <LearningsBadge count={s.learning_interaction_count} />
                   </div>
                   <div className="flex items-center gap-4 text-xs text-muted-foreground shrink-0">
                     <span>{s.turn_count} turns</span>
@@ -183,7 +183,7 @@ export default function DashboardPage() {
             <EmptyState
               icon={BookOpen}
               title="No playbooks yet"
-              description="Playbooks are extracted from corrections after a few interactions — run /smart-sync to force extraction."
+              description="Playbooks are extracted from your interactions — run /smart-sync to force extraction."
             />
           )}
         </section>

--- a/plugin/dashboard/app/layout.tsx
+++ b/plugin/dashboard/app/layout.tsx
@@ -12,7 +12,7 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: "Claude-Smart Dashboard",
-  description: "Manage interactions, profiles, playbooks, and configuration",
+  description: "Manage sessions, profiles, playbooks, and configuration",
 };
 
 export default function RootLayout({

--- a/plugin/dashboard/app/sessions/[sessionId]/page.tsx
+++ b/plugin/dashboard/app/sessions/[sessionId]/page.tsx
@@ -43,7 +43,7 @@ export default function InteractionDetailPage({
         { method: "DELETE" },
       );
       if (!res.ok) throw new Error(`delete failed: ${res.status}`);
-      router.push("/interactions");
+      router.push("/sessions");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setDeleting(false);
@@ -75,7 +75,7 @@ export default function InteractionDetailPage({
         description={sessionId}
         actions={
           <div className="flex items-center gap-2">
-            <Link href="/interactions">
+            <Link href="/sessions">
               <Button variant="outline" size="sm">
                 <ArrowLeft className="h-3.5 w-3.5" />
                 Back

--- a/plugin/dashboard/app/sessions/page.tsx
+++ b/plugin/dashboard/app/sessions/page.tsx
@@ -2,16 +2,16 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { MessageSquare, AlertTriangle, Search } from "lucide-react";
+import { MessageSquare, Search } from "lucide-react";
 import { PageHeader } from "@/components/common/page-header";
 import { EmptyState } from "@/components/common/empty-state";
 import { DeleteAllButton } from "@/components/common/delete-all-button";
-import { Badge } from "@/components/ui/badge";
+import { LearningsBadge } from "@/components/common/learnings-badge";
 import { Input } from "@/components/ui/input";
 import { dayBucket, formatRelative, truncateId } from "@/lib/format";
 import type { SessionSummary } from "@/lib/types";
 
-export default function InteractionsPage() {
+export default function SessionsPage() {
   const router = useRouter();
   const [sessions, setSessions] = useState<SessionSummary[] | null>(null);
   const [filter, setFilter] = useState("");
@@ -55,8 +55,8 @@ export default function InteractionsPage() {
   return (
     <div className="flex-1 overflow-auto">
       <PageHeader
-        title="Interactions"
-        description="Sessions buffered locally under ~/.claude-smart/sessions/."
+        title="Sessions"
+        description="Sessions buffered locally under ~/.claude-smart/sessions/. Each row is one session; click to see its interactions."
         actions={
           <div className="flex items-center gap-2">
             <div className="relative">
@@ -122,12 +122,12 @@ export default function InteractionsPage() {
                       role="link"
                       tabIndex={0}
                       onClick={() =>
-                        router.push(`/interactions/${s.session_id}`)
+                        router.push(`/sessions/${s.session_id}`)
                       }
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
-                          router.push(`/interactions/${s.session_id}`);
+                          router.push(`/sessions/${s.session_id}`);
                         }
                       }}
                       className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-accent/40 focus:bg-accent/40 focus:outline-none transition-colors"
@@ -142,15 +142,10 @@ export default function InteractionsPage() {
                               </span>
                             )}
                           </p>
-                          {s.has_correction && (
-                            <Badge
-                              variant="destructive"
-                              className="h-4 gap-1 px-1.5 text-[10px] shrink-0"
-                            >
-                              <AlertTriangle className="h-2.5 w-2.5" />
-                              correction
-                            </Badge>
-                          )}
+                          <LearningsBadge
+                            count={s.learning_interaction_count}
+                            size="sm"
+                          />
                         </div>
                         <div className="flex items-center gap-3 text-[11px] text-muted-foreground mt-0.5">
                           <code className="font-mono">

--- a/plugin/dashboard/app/sessions/page.tsx
+++ b/plugin/dashboard/app/sessions/page.tsx
@@ -122,12 +122,16 @@ export default function SessionsPage() {
                       role="link"
                       tabIndex={0}
                       onClick={() =>
-                        router.push(`/sessions/${s.session_id}`)
+                        router.push(
+                          `/sessions/${encodeURIComponent(s.session_id)}`,
+                        )
                       }
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
-                          router.push(`/sessions/${s.session_id}`);
+                          router.push(
+                            `/sessions/${encodeURIComponent(s.session_id)}`,
+                          );
                         }
                       }}
                       className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-accent/40 focus:bg-accent/40 focus:outline-none transition-colors"

--- a/plugin/dashboard/components/common/learnings-badge.tsx
+++ b/plugin/dashboard/components/common/learnings-badge.tsx
@@ -28,7 +28,7 @@ export function LearningsBadge({
           isSmall ? "h-2.5 w-2.5" : "h-3 w-3",
         )}
       />
-      {count} learning{count === 1 ? "" : "s"}
+      {count} learning applied
     </Badge>
   );
 }

--- a/plugin/dashboard/components/common/learnings-badge.tsx
+++ b/plugin/dashboard/components/common/learnings-badge.tsx
@@ -1,0 +1,34 @@
+import { Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export function LearningsBadge({
+  count,
+  size = "md",
+  className,
+}: {
+  count: number;
+  size?: "md" | "sm";
+  className?: string;
+}) {
+  if (count <= 0) return null;
+  const isSmall = size === "sm";
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-amber-500/40 gap-1",
+        isSmall ? "h-4 px-1.5 text-[10px] shrink-0" : "h-5",
+        className,
+      )}
+    >
+      <Sparkles
+        className={cn(
+          "text-amber-500",
+          isSmall ? "h-2.5 w-2.5" : "h-3 w-3",
+        )}
+      />
+      {count} learning{count === 1 ? "" : "s"}
+    </Badge>
+  );
+}

--- a/plugin/dashboard/components/layout/nav-items.ts
+++ b/plugin/dashboard/components/layout/nav-items.ts
@@ -15,7 +15,7 @@ export interface NavItem {
 
 export const navItems: NavItem[] = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/interactions", label: "Interactions", icon: MessageSquare },
+  { href: "/sessions", label: "Sessions", icon: MessageSquare },
   { href: "/profiles", label: "Profiles", icon: Users },
   { href: "/playbooks", label: "Playbooks", icon: BookOpen },
   { href: "/configure", label: "Configure", icon: Settings },

--- a/plugin/dashboard/lib/session-reader.ts
+++ b/plugin/dashboard/lib/session-reader.ts
@@ -55,7 +55,7 @@ async function readJsonl(filePath: string): Promise<RawRecord[]> {
 function foldTurns(records: RawRecord[]): {
   turns: SessionTurn[];
   publishedUpTo: number;
-  hasCorrection: boolean;
+  learningInteractionCount: number;
   lastTs: number | null;
   firstTs: number | null;
   preview: string | null;
@@ -63,7 +63,7 @@ function foldTurns(records: RawRecord[]): {
   let published = 0;
   let pendingTools: ToolUsed[] = [];
   const turns: SessionTurn[] = [];
-  let hasCorrection = false;
+  let learningInteractionCount = 0;
   let lastTs: number | null = null;
   let firstTs: number | null = null;
   let preview: string | null = null;
@@ -89,7 +89,13 @@ function foldTurns(records: RawRecord[]): {
     }
     if (role !== "User" && role !== "Assistant") continue;
 
-    if (rec.user_action && rec.user_action !== "NONE") hasCorrection = true;
+    if (
+      role === "Assistant" &&
+      rec.cited_items &&
+      rec.cited_items.length > 0
+    ) {
+      learningInteractionCount += 1;
+    }
     if (typeof rec.ts === "number") {
       lastTs = rec.ts;
       if (firstTs === null) firstTs = rec.ts;
@@ -121,7 +127,14 @@ function foldTurns(records: RawRecord[]): {
     turns.push(turn);
   }
 
-  return { turns, publishedUpTo: published, hasCorrection, lastTs, firstTs, preview };
+  return {
+    turns,
+    publishedUpTo: published,
+    learningInteractionCount,
+    lastTs,
+    firstTs,
+    preview,
+  };
 }
 
 export async function listSessions(): Promise<SessionSummary[]> {
@@ -139,12 +152,18 @@ export async function listSessions(): Promise<SessionSummary[]> {
     if (entry.endsWith(".injected.jsonl")) continue;
     const fullPath = path.join(dir, entry);
     const records = await readJsonl(fullPath).catch(() => []);
-    const { turns, publishedUpTo, hasCorrection, lastTs, firstTs, preview } =
-      foldTurns(records);
+    const {
+      turns,
+      publishedUpTo,
+      learningInteractionCount,
+      lastTs,
+      firstTs,
+      preview,
+    } = foldTurns(records);
     summaries.push({
       session_id: entry.replace(/\.jsonl$/, ""),
       turn_count: turns.length,
-      has_correction: hasCorrection,
+      learning_interaction_count: learningInteractionCount,
       last_activity: lastTs,
       first_activity: firstTs,
       published_up_to: publishedUpTo,

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -77,7 +77,7 @@ export interface SessionTurn {
 export interface SessionSummary {
   session_id: string;
   turn_count: number;
-  has_correction: boolean;
+  learning_interaction_count: number;
   last_activity: number | null;
   first_activity: number | null;
   published_up_to: number;


### PR DESCRIPTION
## Summary
- Rename the dashboard list route `/interactions` → `/sessions` so the URL and nav match what the page actually shows (one row per JSONL session). "Interaction" is now reserved for individual User/Assistant turns within a session.
- Replace the always-zero "Sessions with corrections" stat tile with **"Interactions with learnings applied"**, derived from the `cited_items` field that `cs-cite` actually writes onto Assistant turns. The previous `user_action`-based metric was reading a field the hook pipeline never populates.
- Extract a shared `<LearningsBadge>` component to remove the duplicated badge logic between the dashboard and sessions list. Badge copy now reads `{count} learning applied` to make clear these are pre-existing learnings applied to the session.
- URL-encode `session_id` when navigating from the sessions list to the detail page, so IDs containing reserved characters don't break the route.
- Bump the README Node badge to `>=20` to match the Next.js 16 floor (the root `package.json` already pins `engines.node >=20.9.0`).

## Changes

**Routing / nav**
- `plugin/dashboard/app/interactions/` → `plugin/dashboard/app/sessions/` (both `page.tsx` and `[sessionId]/page.tsx`)
- `components/layout/nav-items.ts`: nav entry renamed `Interactions` → `Sessions`
- All `router.push` / `Link` hrefs and the detail-page back button now point at `/sessions`
- `app/sessions/page.tsx`: `router.push` calls in the row click and keyboard handlers now wrap `session_id` with `encodeURIComponent`
- `app/layout.tsx` metadata description updated for terminology consistency

**Metric replacement**
- `lib/types.ts`, `lib/session-reader.ts`: drop `has_correction: boolean`; add `learning_interaction_count: number` derived from Assistant turns where `cited_items?.length > 0`
- `app/dashboard/page.tsx`: stat tile now sums `learning_interaction_count` across sessions, with a Sparkles icon and amber accent
- `app/sessions/page.tsx`: per-row badge shows the per-session learning count
- Empty-state copy in `app/dashboard/page.tsx` no longer references the removed "corrections" terminology

**Refactor**
- New `components/common/learnings-badge.tsx` — `<LearningsBadge count size="md|sm" />`, used by both the dashboard and sessions list; renders `{count} learning applied`

**Docs**
- `README.md`: Node badge `>=18` → `>=20`

## Test Plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on changed files — clean
- [ ] Open the dashboard, confirm the nav item reads **Sessions** and clicking any row navigates under `/sessions/<encoded-id>`; back button returns to `/sessions`.
- [ ] Confirm the **Interactions with learnings applied** tile shows a non-zero value in a session that has `cs-cite` calls.
- [ ] Confirm the per-row "N learning applied" badge appears on session rows that include cited turns and is hidden otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now reports learnings-based metrics instead of corrections-based reporting.
  * Learning interaction counts are displayed on each session for improved visibility.
  * Navigation and terminology updated from "Interactions" to "Sessions" throughout the dashboard.

* **Chores**
  * Updated Node.js runtime requirement from >=18 to >=20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
