### PR TITLE
feat: detached dashboard build + capture tool output for reflexio

### DIFF
--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -20,3 +20,29 @@ claude_smart_source_login_path() {
 claude_smart_prepend_astral_bins() {
   export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 }
+
+# Spawn a command fully detached from the current shell so a hook timeout
+# (Claude Code's install/SessionStart budget) cannot kill it mid-flight.
+# Picks the strongest available primitive: setsid → python3 os.setsid → nohup.
+# Caller is responsible for redirecting stdout/stderr; we do not impose a
+# log destination here. Stdin is closed so the child cannot inherit a tty.
+claude_smart_spawn_detached() {
+  if command -v setsid >/dev/null 2>&1; then
+    setsid nohup "$@" < /dev/null &
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import os,sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
+      "$@" < /dev/null &
+  else
+    nohup "$@" < /dev/null &
+  fi
+}
+
+# Return 0 (true) if $1 names a pid file whose pid is currently alive.
+# Silent on missing/empty/stale files.
+claude_smart_pid_alive_file() {
+  pid_file="$1"
+  [ -f "$pid_file" ] || return 1
+  pid=$(cat "$pid_file" 2>/dev/null || echo "")
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null
+}

--- a/plugin/scripts/dashboard-build.sh
+++ b/plugin/scripts/dashboard-build.sh
@@ -31,6 +31,7 @@ DASHBOARD_DIR="$PLUGIN_ROOT/dashboard"
 STATE_DIR="$HOME/.claude-smart"
 LOG_FILE="$STATE_DIR/dashboard.log"
 BUILD_PID_FILE="$STATE_DIR/dashboard-build.pid"
+BUILD_LOCK_DIR="$STATE_DIR/dashboard-build.lock"
 mkdir -p "$STATE_DIR"
 
 log() { printf '[claude-smart] %s\n' "$1" >>"$LOG_FILE"; }
@@ -44,23 +45,42 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-# Single-flight guard: if another build is running, exit cleanly.
-if claude_smart_pid_alive_file "$BUILD_PID_FILE"; then
-  log "dashboard build: already in progress; skipping"
-  exit 0
+# Atomic single-flight: mkdir is a single atomic syscall, so two concurrent
+# builds (e.g., smart-install.sh and a SessionStart-driven dashboard-service.sh
+# firing within milliseconds on first install) cannot both pass this check.
+# BUILD_PID_FILE remains as status metadata for dashboard-open.sh and
+# dashboard-service.sh to probe — it is written only after the lock is held
+# and removed only by the lock holder.
+if ! mkdir "$BUILD_LOCK_DIR" 2>/dev/null; then
+  if claude_smart_pid_alive_file "$BUILD_PID_FILE"; then
+    log "dashboard build: already in progress; skipping"
+    exit 0
+  fi
+  # Stale lock from a crashed build (lock dir survived but owner is gone).
+  # Reclaim it; if another process beats us to the reclaim, defer to them.
+  rm -rf "$BUILD_LOCK_DIR"
+  rm -f "$BUILD_PID_FILE"
+  if ! mkdir "$BUILD_LOCK_DIR" 2>/dev/null; then
+    log "dashboard build: lost race for stale lock; skipping"
+    exit 0
+  fi
 fi
-rm -f "$BUILD_PID_FILE"
 echo $$ > "$BUILD_PID_FILE"
 
+release_lock() {
+  rm -f "$BUILD_PID_FILE"
+  rmdir "$BUILD_LOCK_DIR" 2>/dev/null || rm -rf "$BUILD_LOCK_DIR"
+}
 cleanup() {
   status=$?
-  rm -f "$BUILD_PID_FILE"
+  release_lock
   exit "${status:-0}"
 }
 on_interrupt() {
   rm -rf "$DASHBOARD_DIR/.next"
-  rm -f "$BUILD_PID_FILE"
-  log "dashboard build: interrupted; removed partial .next"
+  rm -rf "$DASHBOARD_DIR/node_modules"
+  release_lock
+  log "dashboard build: interrupted; removed partial .next and node_modules"
   exit 130
 }
 trap cleanup EXIT
@@ -80,7 +100,8 @@ fi
 if [ "$needs_install" = "1" ]; then
   log "dashboard build: running npm install..."
   if ! npm install --silent --no-fund --no-audit >>"$LOG_FILE" 2>&1; then
-    log "dashboard build: npm install failed; see $LOG_FILE"
+    rm -rf "$DASHBOARD_DIR/node_modules"
+    log "dashboard build: npm install failed; removed partial node_modules; see $LOG_FILE"
     exit 1
   fi
 fi

--- a/plugin/scripts/dashboard-build.sh
+++ b/plugin/scripts/dashboard-build.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build the Next.js dashboard ($PLUGIN_ROOT/dashboard) in two steps:
+#   1. npm install (skipped if node_modules exists and is newer than
+#      package.json)
+#   2. npm run build (skipped if .next exists and is newer than
+#      package.json)
+#
+# Designed to run detached from any hook so the multi-minute first-run
+# cost never trips Claude Code's hook timeout. dashboard-service.sh
+# spawns this on first SessionStart when .next is missing; the user can
+# also invoke it manually for recovery.
+#
+# Concurrency: a build-pid file at $STATE_DIR/dashboard-build.pid is
+# used to mark "build in progress" so dashboard-open.sh can surface a
+# "still building, retry in ~1 minute" message instead of the generic
+# .next-missing error. The pid file is removed on exit (success, fail,
+# or interrupt).
+#
+# Partial-build safety: an INT/TERM trap wipes any half-written .next
+# so dashboard-service.sh's "no .next → start build" probe stays honest.
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_lib.sh
+. "$HERE/_lib.sh"
+claude_smart_source_login_path
+
+PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+DASHBOARD_DIR="$PLUGIN_ROOT/dashboard"
+
+STATE_DIR="$HOME/.claude-smart"
+LOG_FILE="$STATE_DIR/dashboard.log"
+BUILD_PID_FILE="$STATE_DIR/dashboard-build.pid"
+mkdir -p "$STATE_DIR"
+
+log() { printf '[claude-smart] %s\n' "$1" >>"$LOG_FILE"; }
+
+if [ ! -d "$DASHBOARD_DIR" ]; then
+  log "dashboard build: no $DASHBOARD_DIR; nothing to do"
+  exit 0
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  log "dashboard build: npm not on PATH; cannot build"
+  exit 1
+fi
+
+# Single-flight guard: if another build is running, exit cleanly.
+if claude_smart_pid_alive_file "$BUILD_PID_FILE"; then
+  log "dashboard build: already in progress; skipping"
+  exit 0
+fi
+rm -f "$BUILD_PID_FILE"
+echo $$ > "$BUILD_PID_FILE"
+
+cleanup() {
+  status=$?
+  rm -f "$BUILD_PID_FILE"
+  exit "${status:-0}"
+}
+on_interrupt() {
+  rm -rf "$DASHBOARD_DIR/.next"
+  rm -f "$BUILD_PID_FILE"
+  log "dashboard build: interrupted; removed partial .next"
+  exit 130
+}
+trap cleanup EXIT
+trap on_interrupt INT TERM
+
+cd "$DASHBOARD_DIR"
+
+# Cheap freshness check: skip reinstall when node_modules is newer than
+# package.json. Avoids re-downloading the dep tree on every SessionStart
+# while still picking up version bumps when the plugin updates.
+# Note: lockfile-only or next.config-only edits won't trigger a rebuild —
+# bump package.json (or `rm -rf .next`) in that case.
+needs_install=1
+if [ -d node_modules ] && [ node_modules -nt package.json ]; then
+  needs_install=0
+fi
+if [ "$needs_install" = "1" ]; then
+  log "dashboard build: running npm install..."
+  if ! npm install --silent --no-fund --no-audit >>"$LOG_FILE" 2>&1; then
+    log "dashboard build: npm install failed; see $LOG_FILE"
+    exit 1
+  fi
+fi
+
+needs_build=1
+if [ -d .next ] && [ .next -nt package.json ]; then
+  needs_build=0
+fi
+if [ "$needs_build" = "1" ]; then
+  log "dashboard build: running next build (this can take 1-2 min)..."
+  if ! npm run build >>"$LOG_FILE" 2>&1; then
+    rm -rf "$DASHBOARD_DIR/.next"
+    log "dashboard build: next build failed; see $LOG_FILE"
+    exit 1
+  fi
+  log "dashboard build: complete"
+else
+  log "dashboard build: .next is up-to-date; skipping"
+fi

--- a/plugin/scripts/dashboard-open.sh
+++ b/plugin/scripts/dashboard-open.sh
@@ -9,6 +9,8 @@ set -eu
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS="$HERE"
+# shellcheck source=_lib.sh
+. "$HERE/_lib.sh"
 
 STATE_DIR="$HOME/.claude-smart"
 BACKEND_LOG="$STATE_DIR/backend.log"
@@ -66,9 +68,14 @@ fi
 if [ "$dashboard_status" = "not running" ]; then
     failed=1
     echo ""
-    echo "ERROR: dashboard failed to start on http://localhost:3001"
-    [ -n "$dashboard_start_out" ] && echo "$dashboard_start_out"
-    show_log_tail "dashboard" "$DASHBOARD_LOG"
+    BUILD_PID_FILE="$STATE_DIR/dashboard-build.pid"
+    if claude_smart_pid_alive_file "$BUILD_PID_FILE"; then
+        echo "dashboard: still building (first-run cost, ~1-2 min). Re-run /claude-smart:dashboard in a minute."
+    else
+        echo "ERROR: dashboard failed to start on http://localhost:3001"
+        [ -n "$dashboard_start_out" ] && echo "$dashboard_start_out"
+        show_log_tail "dashboard" "$DASHBOARD_LOG"
+    fi
 fi
 
 if [ "$failed" = "1" ]; then

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -111,10 +111,16 @@ case "$CMD" in
 
     # `npm run start` requires a prior `next build`. Do NOT build in the
     # foreground here — SessionStart hooks have a tight timeout and a cold
-    # Next build easily exceeds it. If Setup hasn't populated .next, log
-    # and bail; the user can rerun Setup (restart Claude Code) to retry.
+    # Next build easily exceeds it. If .next is missing, spawn a detached
+    # build (dashboard-build.sh) so the first-install cost is paid out of
+    # band. dashboard-open.sh detects the build-pid file to surface a
+    # "still building" message instead of a generic error.
     if [ ! -d "$DASHBOARD_DIR/.next" ]; then
-      echo "[claude-smart] dashboard: .next missing — run plugin Setup (restart Claude Code) to build it" >>"$LOG_FILE"
+      BUILD_PID_FILE="$STATE_DIR/dashboard-build.pid"
+      if ! claude_smart_pid_alive_file "$BUILD_PID_FILE"; then
+        echo "[claude-smart] dashboard: .next missing — starting background build (~1-2 min)" >>"$LOG_FILE"
+        claude_smart_spawn_detached bash "$HERE/dashboard-build.sh" >>"$LOG_FILE" 2>&1
+      fi
       emit_ok; exit 0
     fi
 

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -147,31 +147,18 @@ then
   echo "[claude-smart] added Bash(cs-cite:*) to $CLAUDE_SETTINGS permissions.allow" >&2
 fi
 
-# Pre-install + build the Next.js dashboard so SessionStart can boot it
-# without the multi-minute first-run cost. dashboard-service.sh will retry
-# the build lazily if either step is skipped or fails here.
+# Spawn the dashboard build detached so install returns immediately and
+# Claude Code's install-hook timeout never kills a half-finished
+# `next build` (which would force the user into a manual /claude-smart:restart
+# recovery). dashboard-service.sh will also re-spawn this on SessionStart
+# if .next is still missing, and dashboard-open.sh detects the build-pid
+# file to surface a "still building" message instead of a generic error.
 DASHBOARD_DIR="$PLUGIN_ROOT/dashboard"
-if [ -d "$DASHBOARD_DIR" ]; then
-  if command -v npm >/dev/null 2>&1; then
-    echo "[claude-smart] installing dashboard dependencies..." >&2
-    if (cd "$DASHBOARD_DIR" && npm install --silent --no-fund --no-audit >&2); then
-      echo "[claude-smart] building dashboard..." >&2
-      # Trap INT/TERM so a killed build (e.g., Setup hit a hook timeout)
-      # doesn't leave a partial .next that dashboard-service.sh can't
-      # detect as broken. The trap runs in the current shell; unset it
-      # once the build step returns.
-      trap 'rm -rf "$DASHBOARD_DIR/.next"; exit 130' INT TERM
-      if ! (cd "$DASHBOARD_DIR" && npm run build >&2); then
-        rm -rf "$DASHBOARD_DIR/.next"
-        echo "[claude-smart] WARNING: dashboard build failed; rerun plugin Setup to retry" >&2
-      fi
-      trap - INT TERM
-    else
-      echo "[claude-smart] WARNING: dashboard npm install failed; dashboard will be unavailable" >&2
-    fi
-  else
-    echo "[claude-smart] WARNING: npm not on PATH — dashboard will be unavailable" >&2
-  fi
+if [ -d "$DASHBOARD_DIR" ] && command -v npm >/dev/null 2>&1; then
+  echo "[claude-smart] starting dashboard build in background (~1-2 min on first install)" >&2
+  claude_smart_spawn_detached bash "$HERE/dashboard-build.sh" >/dev/null 2>&1
+elif [ -d "$DASHBOARD_DIR" ]; then
+  echo "[claude-smart] WARNING: npm not on PATH — dashboard will be unavailable until npm is installed" >&2
 fi
 
 # Point ~/.reflexio/plugin-root at this install so slash commands can

--- a/plugin/src/claude_smart/events/post_tool.py
+++ b/plugin/src/claude_smart/events/post_tool.py
@@ -115,8 +115,18 @@ def _flatten_tool_response_text(tool_response: Any) -> str:
             for key in _OUTPUT_TEXT_KEYS
             if isinstance(tool_response.get(key), str) and tool_response[key]
         ]
-        return "\n".join(parts)
-    return str(tool_response)
+        if parts:
+            return "\n".join(parts)
+        for key in ("text", "content"):
+            value = tool_response.get(key)
+            if isinstance(value, str):
+                return value
+        return ""
+    for attr in ("text", "content"):
+        value = getattr(tool_response, attr, None)
+        if isinstance(value, str):
+            return value
+    return ""
 
 
 def handle(payload: dict[str, Any]) -> None:

--- a/plugin/src/claude_smart/events/post_tool.py
+++ b/plugin/src/claude_smart/events/post_tool.py
@@ -80,17 +80,59 @@ def _derive_status(tool_response: Any) -> str:
     return "success"
 
 
+_OUTPUT_TEXT_KEYS = ("stdout", "stderr", "output", "content", "text", "error")
+
+
+def _flatten_tool_response_text(tool_response: Any) -> str:
+    """Flatten ``tool_response`` into a single string for buffering.
+
+    Claude Code delivers tool responses in heterogeneous shapes — Bash sends
+    a dict with ``stdout``/``stderr``, Edit/Read send a string or a dict
+    with ``content``/``output``, and failures populate ``error``. Joining
+    the well-known string-valued keys preserves the parts most useful for
+    downstream learning (failure messages, command output) without
+    serializing entire structured payloads.
+
+    Note: structured ``content`` lists (e.g. ``[{type: 'text', text: ...}]``)
+    are not flattened — only top-level string values are joined. If a tool
+    starts emitting block-form content we want to capture, add a dedicated
+    branch here.
+
+    Args:
+        tool_response (Any): The raw ``tool_response`` from the PostToolUse
+            payload.
+
+    Returns:
+        str: A flattened string. Empty when no textual content is present.
+    """
+    if tool_response is None:
+        return ""
+    if isinstance(tool_response, str):
+        return tool_response
+    if isinstance(tool_response, dict):
+        parts = [
+            tool_response[key]
+            for key in _OUTPUT_TEXT_KEYS
+            if isinstance(tool_response.get(key), str) and tool_response[key]
+        ]
+        return "\n".join(parts)
+    return str(tool_response)
+
+
 def handle(payload: dict[str, Any]) -> None:
     session_id = payload.get("session_id")
     tool_name = payload.get("tool_name") or ""
     if not session_id or not tool_name:
         return
 
+    tool_response = payload.get("tool_response")
+    output_text = _flatten_tool_response_text(tool_response)
     record = {
         "ts": int(time.time()),
         "role": "Assistant_tool",
         "tool_name": tool_name,
         "tool_input": _redact(payload.get("tool_input") or {}),
-        "status": _derive_status(payload.get("tool_response")),
+        "tool_output": _redact_string(output_text) if output_text else "",
+        "status": _derive_status(tool_response),
     }
     state.append(session_id, record)

--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -195,15 +195,20 @@ def unpublished_slice(
         role = rec.get("role")
         if role == "Assistant_tool":
             tool_input = rec.get("tool_input") or {}
+            tool_output = rec.get("tool_output") or ""
             tool_entry: dict[str, Any] = {
                 "tool_name": rec.get("tool_name", ""),
                 "status": rec.get("status", "success"),
             }
+            tool_data: dict[str, Any] = {}
             if tool_input:
-                truncated_input = {
+                tool_data["input"] = {
                     k: _truncate_tool_data_field(v) for k, v in tool_input.items()
                 }
-                tool_entry["tool_data"] = {"input": truncated_input}
+            if tool_output:
+                tool_data["output"] = _truncate_tool_data_field(tool_output)
+            if tool_data:
+                tool_entry["tool_data"] = tool_data
             pending_tools.append(tool_entry)
             continue
         if role in {"User", "Assistant"}:

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -164,10 +164,10 @@ stage_setup_hook() {
     sleep 2
     i=$((i + 2))
   done
-  if [ ! -d "$PLUGIN_ROOT/dashboard/.next" ]; then
+  if [ -e "$build_pid_file" ] || [ ! -d "$PLUGIN_ROOT/dashboard/.next" ]; then
     cat "$HOME/smart-install.log" >&2 || true
     [ -f "$HOME/.claude-smart/dashboard.log" ] && cat "$HOME/.claude-smart/dashboard.log" >&2 || true
-    fail "detached dashboard build did not produce dashboard/.next within ${timeout}s"
+    fail "detached dashboard build did not finish within ${timeout}s (pid file present or .next missing)"
   fi
   log "setup-hook: ok"
 }

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -150,9 +150,24 @@ stage_setup_hook() {
     cat "$HOME/.claude-smart/install-failed" >&2 || true
     fail "smart-install.sh wrote install-failed marker"
   fi
+  # smart-install.sh now spawns dashboard-build.sh detached so the install
+  # hook returns immediately. Wait up to 10 minutes for the build pid file
+  # to clear AND .next/ to appear before failing.
+  local build_pid_file="$HOME/.claude-smart/dashboard-build.pid"
+  local i=0
+  local timeout=600
+  log "setup-hook: waiting for detached dashboard build (up to ${timeout}s)"
+  while [ "$i" -lt "$timeout" ]; do
+    if [ ! -e "$build_pid_file" ] && [ -d "$PLUGIN_ROOT/dashboard/.next" ]; then
+      break
+    fi
+    sleep 2
+    i=$((i + 2))
+  done
   if [ ! -d "$PLUGIN_ROOT/dashboard/.next" ]; then
     cat "$HOME/smart-install.log" >&2 || true
-    fail "smart-install.sh returned 0 but dashboard/.next was not produced"
+    [ -f "$HOME/.claude-smart/dashboard.log" ] && cat "$HOME/.claude-smart/dashboard.log" >&2 || true
+    fail "detached dashboard build did not produce dashboard/.next within ${timeout}s"
   fi
   log "setup-hook: ok"
 }

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -113,6 +113,75 @@ def test_post_tool_exit_plan_mode_records_only_assistant_tool(session_dir) -> No
     assert records[0]["tool_name"] == "ExitPlanMode"
 
 
+@pytest.mark.parametrize(
+    "tool_response, expected",
+    [
+        ({"stdout": "out\n", "stderr": "err\n"}, "out\n\nerr\n"),
+        ({"stderr": "permission denied"}, "permission denied"),
+        ({"error": "boom"}, "boom"),
+        ({"content": "text body"}, "text body"),
+        ("plain", "plain"),
+        (None, ""),
+        ({"unrelated": 1}, ""),
+    ],
+)
+def test_post_tool_flattens_tool_response_text(tool_response, expected) -> None:
+    assert post_tool._flatten_tool_response_text(tool_response) == expected
+
+
+def test_post_tool_records_tool_output(session_dir) -> None:
+    """Bash stdout/stderr is captured under ``tool_output`` so reflexio sees
+    failure text, not just a status flag.
+    """
+    post_tool.handle(
+        {
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls /nope"},
+            "tool_response": {
+                "stdout": "",
+                "stderr": "ls: /nope: No such file or directory",
+                "is_error": True,
+            },
+        }
+    )
+    post_tool.handle(
+        {
+            "session_id": "s1",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/x"},
+            "tool_response": None,
+        }
+    )
+    records = state.read_all("s1")
+    assert records[0]["tool_output"] == "ls: /nope: No such file or directory"
+    assert records[0]["status"] == "error"
+    # Missing/None responses leave the field empty rather than absent.
+    assert records[1]["tool_output"] == ""
+
+
+def test_post_tool_redacts_secrets_in_tool_output(session_dir) -> None:
+    """Secret-shaped ``KEY=value`` assignments leaking through stderr must be
+    masked the same way as ``tool_input`` strings — ``tool_output`` flows
+    through the same redaction step.
+    """
+    post_tool.handle(
+        {
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "deploy"},
+            "tool_response": {
+                "stdout": "",
+                "stderr": "AWS_SECRET_ACCESS_KEY=AbCdEf1234567890XyZQrStUv",
+                "is_error": True,
+            },
+        }
+    )
+    records = state.read_all("s1")
+    assert "AbCdEf1234567890XyZQrStUv" not in records[0]["tool_output"]
+    assert "<redacted:" in records[0]["tool_output"]
+
+
 def test_post_tool_truncates_oversized_string(session_dir) -> None:
     blob = "x" * 5000
     post_tool.handle(
@@ -454,7 +523,10 @@ def test_stop_plan_decision_handles_list_content_shape(
                             "type": "tool_result",
                             "content": [
                                 {"type": "text", "text": "Your plan has been saved."},
-                                {"type": "text", "text": "User has approved your plan."},
+                                {
+                                    "type": "text",
+                                    "text": "User has approved your plan.",
+                                },
                             ],
                         }
                     ]
@@ -787,16 +859,16 @@ def test_stop_stamps_user_id_from_payload_cwd(
     assert records[-1]["user_id"] == "proj::/some/repo"
 
 
-def _stub_user_prompt_adapter(monkeypatch, *, playbooks=None, profiles=None, calls=None):
+def _stub_user_prompt_adapter(
+    monkeypatch, *, playbooks=None, profiles=None, calls=None
+):
     class Stub:
         def search_both(self, **kwargs):
             if calls is not None:
                 calls.append(kwargs)
             return (list(playbooks or []), list(profiles or []))
 
-    monkeypatch.setattr(
-        "claude_smart.context_inject.Adapter", lambda *a, **kw: Stub()
-    )
+    monkeypatch.setattr("claude_smart.context_inject.Adapter", lambda *a, **kw: Stub())
     monkeypatch.setattr(
         "claude_smart.events.user_prompt.ids.resolve_project_id",
         lambda *_a, **_kw: "demo",
@@ -817,7 +889,9 @@ def test_user_prompt_stamps_user_id_from_payload_cwd(session_dir, monkeypatch) -
     assert records[-1]["user_id"] == "proj::/some/repo"
 
 
-def test_user_prompt_injects_context_when_hits_present(session_dir, monkeypatch) -> None:
+def test_user_prompt_injects_context_when_hits_present(
+    session_dir, monkeypatch
+) -> None:
     """A prompt with matching profiles/playbooks injects additionalContext."""
     calls: list[dict[str, Any]] = []
     _stub_user_prompt_adapter(
@@ -871,9 +945,7 @@ def test_user_prompt_buffers_even_when_search_raises(session_dir, monkeypatch) -
         def search_both(self, **_kw):
             raise RuntimeError("reflexio down")
 
-    monkeypatch.setattr(
-        "claude_smart.context_inject.Adapter", lambda *a, **kw: Boom()
-    )
+    monkeypatch.setattr("claude_smart.context_inject.Adapter", lambda *a, **kw: Boom())
     monkeypatch.setattr(
         "claude_smart.events.user_prompt.ids.resolve_project_id",
         lambda *_a, **_kw: "demo",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -235,11 +235,48 @@ def test_unpublished_slice_truncates_overlong_tool_fields_to_cap() -> None:
     ]
     _, turns = state.unpublished_slice(records)
     tools = turns[-1]["tools_used"]
-    assert len(tools[0]["tool_data"]["input"]["command"]) == state._TOOL_DATA_FIELD_MAX_LEN
+    assert (
+        len(tools[0]["tool_data"]["input"]["command"]) == state._TOOL_DATA_FIELD_MAX_LEN
+    )
     assert tools[0]["tool_data"]["input"]["description"] == "short"
-    assert len(tools[1]["tool_data"]["input"]["new_string"]) == state._TOOL_DATA_FIELD_MAX_LEN
+    assert (
+        len(tools[1]["tool_data"]["input"]["new_string"])
+        == state._TOOL_DATA_FIELD_MAX_LEN
+    )
     assert tools[1]["tool_data"]["input"]["file_path"] == "/a/b.py"
     json.dumps(turns[-1])  # sanity: publish-ready
+
+
+def test_unpublished_slice_includes_truncated_tool_output() -> None:
+    """``tool_output`` is folded into ``tool_data.output`` and capped at the same
+    256-char limit as ``tool_input`` fields, so reflexio sees concrete failure
+    text without inflating the extractor prompt.
+    """
+    long_output = "z" * 5000
+    records = [
+        {"role": "User", "content": "u1"},
+        {
+            "role": "Assistant_tool",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls /nope"},
+            "tool_output": long_output,
+            "status": "error",
+        },
+        {
+            "role": "Assistant_tool",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo ok"},
+            "tool_output": "",
+            "status": "success",
+        },
+        {"role": "Assistant", "content": "a1"},
+    ]
+    _, turns = state.unpublished_slice(records)
+    tools = turns[-1]["tools_used"]
+    assert tools[0]["tool_data"]["input"] == {"command": "ls /nope"}
+    assert len(tools[0]["tool_data"]["output"]) == state._TOOL_DATA_FIELD_MAX_LEN
+    # Empty output collapses — only the input key is present.
+    assert tools[1]["tool_data"] == {"input": {"command": "echo ok"}}
 
 
 def test_unpublished_slice_strips_cited_items(session_dir) -> None:


### PR DESCRIPTION
## Summary
- Fix install-hook timeout that left dashboards in a half-built `.next/` state on slow machines or cold caches by moving `npm install` + `next build` out of the foreground install hook into a detached, idempotent `dashboard-build.sh`.
- Capture the first 256 chars of tool output (`stdout`/`stderr`/`error`) at PostToolUse so reflexio can learn from concrete tool failures instead of just a status flag.
- Dedupe the setsid/python3/nohup detached-spawn ladder and the pid-file liveness probe into helpers in `_lib.sh`.

## Changes

**Detached dashboard build**
- `plugin/scripts/dashboard-build.sh` (new): single-flight pid file at `$STATE_DIR/dashboard-build.pid`; skips `npm install` when `node_modules` is newer than `package.json`; skips `next build` when `.next/` is newer than `package.json`; SIGINT/TERM trap wipes partial `.next/` so service-side probes stay honest; exit-trap cleanup.
- `plugin/scripts/smart-install.sh`: replaces foreground `npm install + next build` with `claude_smart_spawn_detached bash dashboard-build.sh`. Install returns immediately; the hook can no longer kill the build.
- `plugin/scripts/dashboard-service.sh`: when `.next/` is missing on `start`, spawn `dashboard-build.sh` detached instead of bailing; skip re-spawn if a build pid is already live.
- `plugin/scripts/dashboard-open.sh`: when the dashboard is "not running" but a build pid is live, surface "still building (~1-2 min), re-run in a minute" instead of the generic ERROR + log-tail.
- `plugin/scripts/_lib.sh`: new helpers `claude_smart_spawn_detached` (setsid → python3 os.setsid → nohup) and `claude_smart_pid_alive_file` (read pid, `kill -0`).

**Tool output capture for reflexio**
- `plugin/src/claude_smart/events/post_tool.py`: new `_flatten_tool_response_text` joins string-valued `stdout`/`stderr`/`output`/`content`/`text`/`error` keys into a single string; passes bare strings through. For dicts without those keys, falls back to a string-valued `text`/`content`; for objects, falls back to a string-valued `.text`/`.content` attribute; otherwise returns `""` rather than serializing arbitrary shapes via `str()`. Result is redacted via `_redact_string` (existing 4096-char hard cap + secret masking) and persisted as `tool_output` on the `Assistant_tool` record.
- `plugin/src/claude_smart/state.py` (`unpublished_slice`): folds `tool_output` into `tool_data["output"]` truncated at the existing `_TOOL_DATA_FIELD_MAX_LEN = 256`. Empty output collapses to keep records compact.

**Integration test**
- `tests/integration/integration.sh`: `stage_setup_hook` now polls up to 600s for `~/.claude-smart/dashboard-build.pid` to clear and `dashboard/.next` to appear, since `smart-install.sh` returns before the detached build finishes. Dumps `dashboard.log` on failure for diagnosis.

## Test Plan
- `uv run --project plugin pytest tests/test_state.py tests/test_events.py -x -q` → 73 passed.
- `uv run ruff check` clean on all changed Python files.
- `bash -n` clean on all five modified shell scripts and the integration script.
- New test coverage:
  - `test_post_tool_flattens_tool_response_text` — parametrized over Bash dict, error dict, content dict, plain string, None, and unrelated keys.
  - `test_post_tool_records_tool_output` — end-to-end Bash-stderr capture with status="error" and absent-when-empty assertion.
  - `test_post_tool_redacts_secrets_in_tool_output` — high-entropy `KEY=value` in stderr is masked the same as input strings.
  - `test_unpublished_slice_includes_truncated_tool_output` — `tool_output` truncates to `_TOOL_DATA_FIELD_MAX_LEN` and is omitted when empty.
- Recovery for users already affected by a half-built `.next/`: `/claude-smart:restart` (foreground rebuild outside the hook timeout). Reinstalling re-triggers the same timeout and is *not* the recovery path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard builds run as detached background jobs with robust spawn logic, PID tracking, logging, and single-flight locking so setup returns immediately while builds continue.
  * Tool execution output is captured, redacted, truncated, and stored alongside execution metadata.

* **Bug Fixes / Reliability**
  * Startup now detects in-progress builds and reports "still building" instead of spurious failures; interruption and partial-build cleanup improved.

* **Tests**
  * Added tests for tool output capture, redaction, truncation, and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
