### PR TITLE
feat: /claude-smart:tag publishes and forces immediate extraction

### DIFF
--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -240,6 +240,7 @@ def cmd_tag(args: argparse.Namespace) -> int:
     if not session_id:
         sys.stdout.write("No active claude-smart session buffer found.\n")
         return 0
+    project_id = args.project or ids.resolve_project_id(os.getcwd())
     note = args.note or "the previous answer was wrong"
     state.append(
         session_id,
@@ -247,11 +248,26 @@ def cmd_tag(args: argparse.Namespace) -> int:
             "ts": int(time.time()),
             "role": "User",
             "content": f"[correction] {note}",
-            "user_id": ids.resolve_project_id(os.getcwd()),
+            "user_id": project_id,
         },
     )
-    sys.stdout.write(f"Tagged correction on session `{session_id}`.\n")
-    return 0
+    status, count = publish.publish_unpublished(
+        session_id=session_id,
+        project_id=project_id,
+        force_extraction=True,
+        skip_aggregation=True,
+    )
+    if status == "ok":
+        sys.stdout.write(
+            f"Tagged correction on session `{session_id}` and forced extraction "
+            f"over {count} interactions.\n"
+        )
+        return 0
+    if status == "nothing":
+        sys.stdout.write(f"Tagged correction on session `{session_id}`.\n")
+        return 0
+    sys.stdout.write(_REFLEXIO_UNREACHABLE_MSG)
+    return 1
 
 
 def _run_service(script: Path, subcmd: str) -> int:
@@ -487,6 +503,7 @@ def _build_parser() -> argparse.ArgumentParser:
     tg = sub.add_parser("tag", help="Tag the current session with a correction note")
     tg.add_argument("note", nargs="?", default="", help="Correction description")
     tg.add_argument("--session", help="Session id (defaults to latest)")
+    tg.add_argument("--project", help="Override project id")
     tg.set_defaults(func=cmd_tag)
 
     ca = sub.add_parser(


### PR DESCRIPTION
## Summary
- `/claude-smart:tag` was buffer-only — the `[correction]` record sat unpublished until the next Stop hook fired or the user manually ran `/learn`. Corrections are the highest-signal event the system can capture, so the wait was the wrong shape.
- Even when published, reflexio applied multiple gates that could suppress extraction (batch_interval, slash-only cheap-reject, LLM should_run vote). For tag we want "no gates: extract this batch right now."
- Two coordinated fixes: tag now publishes immediately with `force_extraction=True`, and reflexio (#38) extends `force_extraction=True` to short-circuit the cheap pre-filter and LLM should_run gate too — symmetric with the existing batch-interval bypass.

## Changes

**`plugin/src/claude_smart/cli.py`**
- `cmd_tag` now appends the `[correction]` User record, then calls `publish.publish_unpublished(force_extraction=True, skip_aggregation=True)` (mirrors `cmd_learn`).
- Branches on the publish status: `ok` → "Tagged correction … forced extraction over N interactions"; `failed` → `_REFLEXIO_UNREACHABLE_MSG` and exit 1 (record stays on disk for the next Stop hook to retry); `nothing` → defensive fallback.
- Adds `--project` to the `tag` subparser for symmetry with `show` / `learn`.

**`reflexio` submodule pointer bump**
- Updates to `235b75e` (PR ReflexioAI/reflexio#38) which adds the `force_extraction=True` short-circuit at the top of `should_generate_consolidated`. With the existing batch-interval bypass at line 364, the flag now skips: batch_interval, batch_size, the cheap pre-filter (slash-only / too-short / extractor-prompt-echo rejects), and the LLM should_run vote. Field-level comment on `PublishUserInteractionRequest.force_extraction` updated to document the broader semantics.

## Test Plan
- `uv run --project plugin pytest tests/` → 156 passed; the 1 unrelated failure is the documented pre-existing `test_restart_starts_backend_even_when_dashboard_build_fails`.
- `uv run ruff check plugin/src/claude_smart/cli.py` → clean.
- Manual end-to-end:
  - `/claude-smart:tag "test correction"` in a live session prints `Tagged correction on session \`<id>\` and forced extraction over N interactions.` and the dev_server.log shows the extractor running within ~1s.
  - With reflexio backend stopped, `/claude-smart:tag` returns the unreachable message and exit 1; the buffer record remains on disk.
  - Two consecutive tags publish twice with two distinct `[correction]` records and the watermark advances cleanly.
