### PR TITLE
feat(dashboard): render captured tool_output in session detail

### DIFF
--- a/plugin/dashboard/app/sessions/[sessionId]/page.tsx
+++ b/plugin/dashboard/app/sessions/[sessionId]/page.tsx
@@ -144,9 +144,12 @@ export default function InteractionDetailPage({
                         <div className="flex items-center gap-1 flex-wrap">
                           {turn.tools_used.map((t, ti) => {
                             const input = t.tool_data?.input;
+                            const output = t.tool_data?.output;
                             const hasInput =
                               input && Object.keys(input).length > 0;
-                            if (!hasInput) {
+                            const hasOutput =
+                              typeof output === "string" && output.length > 0;
+                            if (!hasInput && !hasOutput) {
                               return (
                                 <span key={ti}>
                                   <Badge
@@ -171,9 +174,28 @@ export default function InteractionDetailPage({
                                     <ChevronRight className="h-3 w-3 transition-transform group-open:rotate-90" />
                                   </Badge>
                                 </summary>
-                                <pre className="mt-1 whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 px-2 py-1 text-[10px] font-mono text-muted-foreground">
-                                  {JSON.stringify(input, null, 2)}
-                                </pre>
+                                <div className="mt-1 space-y-1.5">
+                                  {hasInput && (
+                                    <div>
+                                      <div className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/70 mb-0.5">
+                                        input
+                                      </div>
+                                      <pre className="whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 px-2 py-1 text-[10px] font-mono text-muted-foreground">
+                                        {JSON.stringify(input, null, 2)}
+                                      </pre>
+                                    </div>
+                                  )}
+                                  {hasOutput && (
+                                    <div>
+                                      <div className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/70 mb-0.5">
+                                        output
+                                      </div>
+                                      <pre className="whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 px-2 py-1 text-[10px] font-mono text-muted-foreground">
+                                        {output}
+                                      </pre>
+                                    </div>
+                                  )}
+                                </div>
                               </details>
                             );
                           })}

--- a/plugin/dashboard/lib/session-reader.ts
+++ b/plugin/dashboard/lib/session-reader.ts
@@ -17,6 +17,18 @@ import type {
   UserActionType,
 } from "./types";
 
+// Mirrors _TOOL_DATA_FIELD_MAX_LEN in plugin/src/claude_smart/state.py — we
+// truncate to the same length the publisher ships to reflexio so the
+// dashboard renders the exact bytes the extractor sees.
+const TOOL_DATA_FIELD_MAX_LEN = 256;
+
+function truncateToolField<T>(value: T): T {
+  if (typeof value === "string" && value.length > TOOL_DATA_FIELD_MAX_LEN) {
+    return value.slice(0, TOOL_DATA_FIELD_MAX_LEN) as T;
+  }
+  return value;
+}
+
 export function stateDir(): string {
   const override = process.env.CLAUDE_SMART_STATE_DIR;
   if (override) return override;
@@ -30,6 +42,7 @@ type RawRecord = {
   user_id?: string;
   tool_name?: string;
   tool_input?: Record<string, unknown>;
+  tool_output?: string;
   status?: string;
   user_action?: UserActionType;
   user_action_description?: string;
@@ -81,8 +94,19 @@ function foldTurns(records: RawRecord[]): {
         tool_name: rec.tool_name ?? "",
         status: rec.status ?? "success",
       };
+      const toolData: { input?: Record<string, unknown>; output?: string } = {};
       if (rec.tool_input && Object.keys(rec.tool_input).length > 0) {
-        entry.tool_data = { input: rec.tool_input };
+        const input: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rec.tool_input)) {
+          input[k] = truncateToolField(v);
+        }
+        toolData.input = input;
+      }
+      if (typeof rec.tool_output === "string" && rec.tool_output.length > 0) {
+        toolData.output = truncateToolField(rec.tool_output);
+      }
+      if (toolData.input || toolData.output) {
+        entry.tool_data = toolData;
       }
       pendingTools.push(entry);
       continue;

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -12,7 +12,7 @@ export type ProfileStatus = "CURRENT" | "ARCHIVED" | "PENDING";
 export interface ToolUsed {
   tool_name: string;
   status: string;
-  tool_data?: { input?: Record<string, unknown> };
+  tool_data?: { input?: Record<string, unknown>; output?: string };
 }
 
 export interface CitedItem {


### PR DESCRIPTION
## Summary
- Surfaces the per-tool `tool_output` field that the publisher started capturing in #6 — the dashboard previously only rendered tool input.
- Mirrors the publisher's 256-char truncation cap (`_TOOL_DATA_FIELD_MAX_LEN` in `plugin/src/claude_smart/state.py`) so the UI shows exactly the bytes the extractor sees.

## Changes
**`plugin/dashboard/lib/types.ts`**
- `ToolUsed.tool_data` extended to `{ input?: Record<string, unknown>; output?: string }`.

**`plugin/dashboard/lib/session-reader.ts`**
- `RawRecord` gains `tool_output?: string`.
- New `TOOL_DATA_FIELD_MAX_LEN = 256` constant with a comment pointing back to `state.py` (single source of truth lives in Python; the cross-language duplicate is documented).
- New generic `truncateToolField<T>(value: T): T` helper — truncates only when `value` is a string longer than the cap, passes everything else through untouched.
- `foldTurns` now folds `tool_output` into `tool_data.output` (when non-empty) and runs each top-level `tool_input` value through `truncateToolField`. The "absent when empty" contract from `state.py:unpublished_slice` is preserved.

**`plugin/dashboard/app/sessions/[sessionId]/page.tsx`**
- Reads `t.tool_data?.output` alongside `t.tool_data?.input`.
- Tool badge becomes expandable when **either** input or output is present (previously only input gated expansion).
- Inside `<details>`, renders labeled `input` and `output` sections in a small stack — each a `<pre>` block with the existing styling.

## Test Plan
- `npx tsc --noEmit` → clean (EXIT=0).
- `npx biome check lib/session-reader.ts lib/types.ts 'app/sessions/[sessionId]/page.tsx'` → clean (EXIT=0).
- Manual: open the dashboard on a session with recent Bash/Read tool calls — the tool badge expands to show both `input` (existing) and the new `output` block, truncated at 256 chars; tools with empty `tool_output` continue to render input-only with no empty `output` section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool outputs are now captured and displayed in session transcripts alongside tool inputs
  * Tool data is presented in a structured format with clearly labeled input and output sections
  * Long outputs are automatically truncated to maintain readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->