### PR TITLE
feat: publish citations + dashboard status fix + reflexio 0.2.17

### DIFF
--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -50,9 +50,9 @@ export default function DashboardPage() {
     };
   }, [reflexioUrl]);
 
-  const currentPlaybooks = (playbooks ?? []).filter(
-    (p) => p.status == null || p.status === "CURRENT",
-  );
+  // CURRENT playbooks arrive as `status: null` (response_model_exclude_none
+  // strips the field). Anything else (e.g. "archived", "pending") is excluded.
+  const currentPlaybooks = (playbooks ?? []).filter((p) => p.status == null);
   const learningInteractionTotal = (sessions ?? []).reduce(
     (acc, s) => acc + s.learning_interaction_count,
     0,

--- a/plugin/dashboard/app/playbooks/[id]/page.tsx
+++ b/plugin/dashboard/app/playbooks/[id]/page.tsx
@@ -28,6 +28,7 @@ import { reflexio } from "@/lib/reflexio-client";
 import { useSettings } from "@/hooks/use-settings";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import { statusLabel } from "@/lib/status";
 import type { UserPlaybook } from "@/lib/types";
 
 type FormState = { content: string; trigger: string; rationale: string };
@@ -44,13 +45,6 @@ function displayName(name: string | null | undefined): string | null {
   if (!name) return null;
   if (name === "default_playbook_extractor") return "playbook";
   return name;
-}
-
-function statusLabel(p: UserPlaybook): "CURRENT" | "ARCHIVED" | "PENDING" {
-  if (!p.status) return "CURRENT";
-  if (p.status === "ARCHIVED") return "ARCHIVED";
-  if (p.status === "PENDING") return "PENDING";
-  return "CURRENT";
 }
 
 export default function PlaybookDetailPage({

--- a/plugin/dashboard/app/playbooks/page.tsx
+++ b/plugin/dashboard/app/playbooks/page.tsx
@@ -18,14 +18,8 @@ import {
 import { reflexio } from "@/lib/reflexio-client";
 import { useSettings } from "@/hooks/use-settings";
 import { formatRelative } from "@/lib/format";
+import { statusLabel } from "@/lib/status";
 import type { UserPlaybook } from "@/lib/types";
-
-function statusLabel(p: UserPlaybook): "CURRENT" | "ARCHIVED" | "PENDING" {
-  if (!p.status) return "CURRENT";
-  if (p.status === "ARCHIVED") return "ARCHIVED";
-  if (p.status === "PENDING") return "PENDING";
-  return "CURRENT";
-}
 
 export default function PlaybooksPage() {
   const { reflexioUrl } = useSettings();

--- a/plugin/dashboard/app/profiles/[id]/page.tsx
+++ b/plugin/dashboard/app/profiles/[id]/page.tsx
@@ -31,14 +31,8 @@ import { reflexio } from "@/lib/reflexio-client";
 import { useSettings } from "@/hooks/use-settings";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import { statusLabel as status } from "@/lib/status";
 import type { UserProfile } from "@/lib/types";
-
-function status(p: UserProfile): "CURRENT" | "ARCHIVED" | "PENDING" {
-  if (!p.status) return "CURRENT";
-  if (p.status === "ARCHIVED") return "ARCHIVED";
-  if (p.status === "PENDING") return "PENDING";
-  return "CURRENT";
-}
 
 export default function ProfileDetailPage({
   params,

--- a/plugin/dashboard/lib/status.ts
+++ b/plugin/dashboard/lib/status.ts
@@ -1,0 +1,14 @@
+// Wire status comes from Python's Status StrEnum: lowercase strings
+// ("archived", "pending"). CURRENT rows are omitted from JSON entirely
+// (response_model_exclude_none) and arrive as `null`/undefined.
+// Normalize to the uppercase label the dashboard renders.
+
+export type StatusLabel = "CURRENT" | "ARCHIVED" | "PENDING";
+
+export function statusLabel(p: { status?: string | null }): StatusLabel {
+  if (!p.status) return "CURRENT";
+  const s = String(p.status).toLowerCase();
+  if (s === "archived") return "ARCHIVED";
+  if (s === "pending") return "PENDING";
+  return "CURRENT";
+}

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -5,9 +5,13 @@ export type UserActionType =
   | "PRAISE"
   | "STOP";
 
-export type PlaybookStatus = "PENDING" | "CURRENT" | "ARCHIVED";
+// Wire format from the reflexio API. CURRENT rows arrive as `status: null`
+// (response_model_exclude_none strips it from the JSON entirely), so the type
+// only enumerates the non-null values. The values are lowercase because they
+// come from Python's Status StrEnum.
+export type PlaybookStatus = "pending" | "archived";
 
-export type ProfileStatus = "CURRENT" | "ARCHIVED" | "PENDING";
+export type ProfileStatus = "pending" | "archived";
 
 export interface ToolUsed {
   tool_name: string;

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -162,8 +162,8 @@ case "$CMD" in
     # claude-smart users. Reflexio's library defaults are much higher
     # (250k/50k) for server deployments; here we override only in the
     # claude-smart plugin context. Users can still override via env.
-    export INTERACTION_CLEANUP_THRESHOLD="${INTERACTION_CLEANUP_THRESHOLD:-1000}"
-    export INTERACTION_CLEANUP_DELETE_COUNT="${INTERACTION_CLEANUP_DELETE_COUNT:-500}"
+    export INTERACTION_CLEANUP_THRESHOLD="${INTERACTION_CLEANUP_THRESHOLD:-500}"
+    export INTERACTION_CLEANUP_DELETE_COUNT="${INTERACTION_CLEANUP_DELETE_COUNT:-200}"
 
     # --no-reload: uvicorn's reloader forks a supervisor; makes PGID
     # bookkeeping harder and we don't need hot-reload for a user-facing

--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -195,14 +195,18 @@ def _to_wire_citations(cited_items: Any) -> list[dict[str, str]]:
             continue
         real_id = item.get("real_id")
         kind = item.get("kind")
-        if not real_id or kind not in _VALID_CITATION_KINDS:
+        if not isinstance(real_id, str) or not real_id:
             continue
+        if kind not in _VALID_CITATION_KINDS:
+            continue
+        tag = item.get("id")
+        title = item.get("title")
         out.append(
             {
                 "kind": kind,
                 "real_id": real_id,
-                "tag": item.get("id", ""),
-                "title": item.get("title", ""),
+                "tag": tag if isinstance(tag, str) else "",
+                "title": title if isinstance(title, str) else "",
             }
         )
     return out
@@ -261,11 +265,12 @@ def unpublished_slice(
                 k: v for k, v in rec.items() if k not in {"role", "ts", "cited_items"}
             }
             turn["role"] = role
-            citations = _to_wire_citations(rec.get("cited_items"))
-            if citations:
-                turn["citations"] = citations
-            if role == "Assistant" and pending_tools:
-                turn["tools_used"] = pending_tools
-                pending_tools = []
+            if role == "Assistant":
+                citations = _to_wire_citations(rec.get("cited_items"))
+                if citations:
+                    turn["citations"] = citations
+                if pending_tools:
+                    turn["tools_used"] = pending_tools
+                    pending_tools = []
             turns.append(turn)
     return published, turns

--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -34,6 +34,8 @@ _DEFAULT_STATE_DIR = Path.home() / ".claude-smart" / "sessions"
 
 _TOOL_DATA_FIELD_MAX_LEN = 256
 
+_VALID_CITATION_KINDS = frozenset({"playbook", "profile"})
+
 
 def _truncate_tool_data_field(value: Any) -> Any:
     """Truncate a single tool_data field value to ``_TOOL_DATA_FIELD_MAX_LEN``.
@@ -166,6 +168,46 @@ def read_all(session_id: str) -> list[dict[str, Any]]:
     return records
 
 
+def _to_wire_citations(cited_items: Any) -> list[dict[str, str]]:
+    """Map local ``cited_items`` to the wire ``Citation`` shape.
+
+    Local entries (from ``events.stop._resolve_cited_items``) carry
+    ``{id, kind, title, real_id}``; reflexio's ``InteractionData.citations``
+    wants ``{kind, real_id, tag, title}`` where ``tag`` is the rank id
+    (``r1-301``-style) we already keep under ``id``. Entries without a
+    ``real_id`` (unresolved injections) are dropped — the server can't
+    join them back to a stored row.
+
+    Args:
+        cited_items (Any): The list-of-dicts blob attached to an Assistant
+            turn record, or ``None`` when the turn cited nothing.
+
+    Returns:
+        list[dict[str, str]]: Citation dicts ready to be folded into an
+            ``InteractionData`` payload. Empty when ``cited_items`` is
+            missing, malformed, or contains nothing resolvable.
+    """
+    if not isinstance(cited_items, list):
+        return []
+    out: list[dict[str, str]] = []
+    for item in cited_items:
+        if not isinstance(item, dict):
+            continue
+        real_id = item.get("real_id")
+        kind = item.get("kind")
+        if not real_id or kind not in _VALID_CITATION_KINDS:
+            continue
+        out.append(
+            {
+                "kind": kind,
+                "real_id": real_id,
+                "tag": item.get("id", ""),
+                "title": item.get("title", ""),
+            }
+        )
+    return out
+
+
 def unpublished_slice(
     records: Iterable[dict[str, Any]],
 ) -> tuple[int, list[dict[str, Any]]]:
@@ -212,12 +254,16 @@ def unpublished_slice(
             pending_tools.append(tool_entry)
             continue
         if role in {"User", "Assistant"}:
-            # ``cited_items`` is local-only metadata for the dashboard's
-            # "used" badge; reflexio's InteractionData has no slot for it.
+            # ``cited_items`` is local-only metadata (dashboard "used" badge);
+            # map it onto the wire's ``citations`` field — reflexio uses those
+            # to drive playbook/profile reflection in the publish flow.
             turn = {
                 k: v for k, v in rec.items() if k not in {"role", "ts", "cited_items"}
             }
             turn["role"] = role
+            citations = _to_wire_citations(rec.get("cited_items"))
+            if citations:
+                turn["citations"] = citations
             if role == "Assistant" and pending_tools:
                 turn["tools_used"] = pending_tools
                 pending_tools = []

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -280,7 +280,7 @@ def test_unpublished_slice_includes_truncated_tool_output() -> None:
 
 
 def test_unpublished_slice_strips_cited_items(session_dir) -> None:
-    """``cited_items`` is dashboard-only metadata; reflexio must not receive it."""
+    """``cited_items`` is local-only — never lands on the wire under that key."""
     records = [
         {"role": "User", "content": "hi"},
         {
@@ -291,6 +291,113 @@ def test_unpublished_slice_strips_cited_items(session_dir) -> None:
     ]
     _, turns = state.unpublished_slice(records)
     assert "cited_items" not in turns[-1]
+
+
+def test_unpublished_slice_maps_cited_items_to_citations() -> None:
+    """Resolved cited_items become a wire-shaped ``citations`` list on the turn."""
+    records = [
+        {"role": "User", "content": "hi"},
+        {
+            "role": "Assistant",
+            "content": "ok",
+            "cited_items": [
+                {
+                    "id": "r1-ab12",
+                    "kind": "playbook",
+                    "title": "rule X",
+                    "real_id": "pb_42",
+                },
+                {
+                    "id": "p1-cd34",
+                    "kind": "profile",
+                    "title": "user role",
+                    "real_id": "prof_7",
+                },
+            ],
+        },
+    ]
+    _, turns = state.unpublished_slice(records)
+    assert turns[-1]["citations"] == [
+        {"kind": "playbook", "real_id": "pb_42", "tag": "r1-ab12", "title": "rule X"},
+        {
+            "kind": "profile",
+            "real_id": "prof_7",
+            "tag": "p1-cd34",
+            "title": "user role",
+        },
+    ]
+
+
+def test_unpublished_slice_omits_citations_when_empty() -> None:
+    """Empty / unresolvable cited_items → no ``citations`` key on the turn.
+
+    Producing a key with ``[]`` would inflate every published Assistant
+    record; absence is meaningful.
+    """
+    records = [
+        {"role": "User", "content": "hi"},
+        {
+            "role": "Assistant",
+            "content": "no real_id",
+            "cited_items": [{"id": "r1-ab12", "kind": "playbook", "title": "t"}],
+        },
+        {
+            "role": "Assistant",
+            "content": "empty list",
+            "cited_items": [],
+        },
+        {
+            "role": "Assistant",
+            "content": "no cited_items at all",
+        },
+    ]
+    _, turns = state.unpublished_slice(records)
+    for turn in turns[1:]:
+        assert "citations" not in turn
+
+
+def test_to_wire_citations_filters_invalid_kinds() -> None:
+    """Items with unknown ``kind`` are dropped (server has a Literal there)."""
+    items = [
+        {"id": "r1-ab12", "kind": "playbook", "title": "ok", "real_id": "pb_1"},
+        {"id": "x1-0001", "kind": "agent_playbook", "title": "junk", "real_id": "ap_1"},
+        {"id": "y1-0002", "kind": "", "title": "junk2", "real_id": "z_1"},
+    ]
+    result = state._to_wire_citations(items)
+    assert [c["kind"] for c in result] == ["playbook"]
+    assert result[0]["real_id"] == "pb_1"
+
+
+def test_to_wire_citations_drops_unresolved_real_id() -> None:
+    """Entries without ``real_id`` (unresolved injections) cannot round-trip."""
+    items = [
+        {"id": "r1-ab12", "kind": "playbook", "title": "no real_id"},
+        {"id": "p1-cd34", "kind": "profile", "title": "empty", "real_id": ""},
+        {"id": "r1-9999", "kind": "playbook", "title": "ok", "real_id": "pb_9"},
+    ]
+    result = state._to_wire_citations(items)
+    assert len(result) == 1
+    assert result[0]["real_id"] == "pb_9"
+
+
+def test_to_wire_citations_handles_non_list_input() -> None:
+    """None / dict / str inputs return ``[]`` without raising."""
+    assert state._to_wire_citations(None) == []
+    assert state._to_wire_citations({"id": "r1-ab12"}) == []
+    assert state._to_wire_citations("oops") == []
+
+
+def test_to_wire_citations_skips_non_dict_items() -> None:
+    """A list that mixes dicts and junk only emits the dict entries."""
+    items = [
+        "a-string",
+        None,
+        42,
+        {"id": "r1-ab12", "kind": "playbook", "title": "ok", "real_id": "pb_1"},
+    ]
+    result = state._to_wire_citations(items)
+    assert len(result) == 1
+    assert result[0]["tag"] == "r1-ab12"
 
 
 def _append_worker(state_dir: str, session_id: str, payload: str) -> None:


### PR DESCRIPTION
## Summary
- Wire local `cited_items` onto the publish-time `InteractionData.citations` field so reflexio (v0.2.17+) can drive playbook/profile reflection from real Assistant citations.
- Restrict citation and `tools_used` attachment to Assistant turns only — User turns no longer carry citation metadata into the publish payload.
- Align the dashboard with reflexio's `Status` StrEnum + `response_model_exclude_none` wire shape — values are lowercase (`"archived"`, `"pending"`) and CURRENT rows arrive as `null`/missing, not `"CURRENT"`.
- Bump `reflexio` submodule to `v0.2.17`.
- Lower per-session interaction-cleanup thresholds (1000/500 → 500/200) so claude-smart users don't pay the higher server-deployment defaults.

## Changes

### Citation wiring (server-bound)
- `plugin/src/claude_smart/state.py` — new `_to_wire_citations` helper maps `{id, kind, title, real_id}` (local) → `{kind, real_id, tag, title}` (wire `Citation` shape). `unpublished_slice` now folds resolvable citations onto the Assistant turn under `citations`; entries without `real_id` or with an unsupported `kind` are dropped (the server has a `Literal["playbook", "profile"]`).
- `plugin/src/claude_smart/state.py` — citation and `tools_used` attachment is now guarded by `role == "Assistant"`. User turns retain their plain shape and never carry citation metadata, even if `cited_items` is somehow present on the record. Input checks in `_to_wire_citations` also reject non-string `id`/`title`/`real_id` defensively.
- `tests/test_state.py` — adds coverage for the mapping happy path, omitted-when-empty behavior, invalid `kind` filtering, missing `real_id` rejection, and non-list / non-dict input safety.

### Dashboard status fix
- `plugin/dashboard/lib/types.ts` — narrow `PlaybookStatus` / `ProfileStatus` to `"pending" | "archived"`; document the null-for-current invariant.
- `plugin/dashboard/lib/status.ts` — new shared `statusLabel` helper. Consolidates the three previously duplicated copies in playbooks/profiles pages.
- `plugin/dashboard/app/dashboard/page.tsx` — filter CURRENT playbooks via `status == null` (matches the wire), drop the dead `"CURRENT"` string compare.
- `plugin/dashboard/app/playbooks/page.tsx`, `app/playbooks/[id]/page.tsx`, `app/profiles/[id]/page.tsx` — import the shared helper; lowercase comparisons replace the old uppercase ones.

### Cleanup-threshold tuning
- `plugin/scripts/backend-service.sh` — `INTERACTION_CLEANUP_THRESHOLD` 1000 → 500 and `INTERACTION_CLEANUP_DELETE_COUNT` 500 → 200. Cap of 500 interactions, evict oldest 200, keep 300.

### Submodule
- `reflexio` → `v0.2.17` (single release commit, contains the `Citation` wire model).

## Test Plan
- [x] `ruff check` + `ruff format` clean on `state.py` and `tests/test_state.py`.
- [x] `pyright` clean on the same two files.
- [x] `npx tsc --noEmit` clean across the dashboard.
- [x] `npx biome check` clean on all touched dashboard files (exit 0).
- [x] New unit tests in `tests/test_state.py` exercise:
  - mapping happy path with both `playbook` and `profile` citations
  - empty / unresolvable cited items omit the `citations` key entirely
  - invalid `kind` and missing `real_id` are filtered
  - non-list / non-dict inputs return `[]` without raising
- [ ] Manual: stop hook → verify a real Assistant turn with `cs-cite` calls shows up in the publish payload with a populated `citations` array, and that User turns in the same payload have no `citations` key.
- [ ] Manual: dashboard pages render archived / pending / current playbooks and profiles correctly with the new wire shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Citations are now included when publishing interactions.

* **Improvements**
  * Standardized status representation across playbooks and profiles for consistency.
  * Optimized backend interaction cleanup with adjusted default thresholds for better performance.

* **Tests**
  * Expanded test coverage for citation handling in interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
