### PR TITLE
fix: route slash commands through cli.sh so uv is on PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #   - git (for the release flow)
 
 .PHONY: help bump release publish publish-npm publish-pypi publish-dry \
-        check-version check-clean ensure-remote-reflexio unskip-worktree
+        check-version check-clean check-npm-auth ensure-remote-reflexio unskip-worktree
 
 VERSION_FILES := package.json plugin/pyproject.toml \
                  plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json \
@@ -35,6 +35,14 @@ endif
 check-clean:
 	@git diff --quiet && git diff --cached --quiet \
 	  || { echo "error: working tree is dirty — commit or stash first" >&2; exit 1; }
+
+check-npm-auth: ## Verify npm login; run `npm login` interactively if not authenticated
+	@if npm whoami >/dev/null 2>&1; then \
+	  echo "→ npm: logged in as $$(npm whoami)"; \
+	else \
+	  echo "→ npm: not logged in, running npm login"; \
+	  npm login || { echo "error: npm login failed" >&2; exit 1; }; \
+	fi
 
 unskip-worktree: ## Clear skip-worktree on plugin/pyproject.toml and plugin/uv.lock so release edits land in git
 	@echo "→ clearing skip-worktree on $(PYPROJECT) $(LOCK_FILES)"
@@ -87,7 +95,7 @@ publish-dry: unskip-worktree ensure-remote-reflexio ## Show what would be publis
 
 publish: publish-npm publish-pypi ## Publish to both npm and PyPI
 
-release: check-version check-clean bump ## Bump + commit + tag + publish + push
+release: check-version check-clean check-npm-auth bump ## Bump + commit + tag + publish + push
 	@echo "→ committing release v$(VERSION)"
 	git add $(VERSION_FILES) $(LOCK_FILES)
 	git commit -m "Release v$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,14 @@ check-clean:
 	@git diff --quiet && git diff --cached --quiet \
 	  || { echo "error: working tree is dirty — commit or stash first" >&2; exit 1; }
 
-check-npm-auth: ## Verify npm login; run `npm login` interactively if not authenticated
-	@if npm whoami >/dev/null 2>&1; then \
+check-npm-auth: ## Verify npm auth via NPM_TOKEN or `npm whoami`; fail if neither is available
+	@if [ -n "$$NPM_TOKEN" ]; then \
+	  echo "→ npm: NPM_TOKEN is set"; \
+	elif npm whoami >/dev/null 2>&1; then \
 	  echo "→ npm: logged in as $$(npm whoami)"; \
 	else \
-	  echo "→ npm: not logged in, running npm login"; \
-	  npm login || { echo "error: npm login failed" >&2; exit 1; }; \
+	  echo "error: not authenticated via npm whoami and NPM_TOKEN is not set; set NPM_TOKEN for CI or run npm login locally" >&2; \
+	  exit 1; \
 	fi
 
 unskip-worktree: ## Clear skip-worktree on plugin/pyproject.toml and plugin/uv.lock so release edits land in git

--- a/plugin/commands/clear-all.md
+++ b/plugin/commands/clear-all.md
@@ -1,8 +1,8 @@
 ---
 description: Delete ALL reflexio interactions, profiles, and user playbooks (destructive)
-allowed-tools: Bash(uv run:*)
+allowed-tools: Bash(bash:*)
 ---
 
 Run this bash command and show its output verbatim:
 
-!`uv run --project "$HOME/.reflexio/plugin-root" --quiet python -m claude_smart.cli clear-all --yes`
+!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" clear-all --yes`

--- a/plugin/commands/learn.md
+++ b/plugin/commands/learn.md
@@ -1,10 +1,10 @@
 ---
 description: Flag the last turn as a correction so reflexio learns from it
-allowed-tools: Bash(uv run:*)
+allowed-tools: Bash(bash:*)
 argument-hint: [note]
 ---
 
 Flag the user's previous turn as a correction and force reflexio to run extraction on this session's interactions now.
 Run the bash command below and show its output verbatim.
 
-!`uv run --project "$HOME/.reflexio/plugin-root" --quiet python -m claude_smart.cli learn "$ARGUMENTS"`
+!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" learn "$ARGUMENTS"`

--- a/plugin/commands/restart.md
+++ b/plugin/commands/restart.md
@@ -1,8 +1,8 @@
 ---
 description: Restart the reflexio backend and dashboard to pick up new changes
-allowed-tools: Bash(uv run:*)
+allowed-tools: Bash(bash:*)
 ---
 
 Run this bash command and show its output verbatim:
 
-!`uv run --project "$HOME/.reflexio/plugin-root" --quiet python -m claude_smart.cli restart`
+!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" restart`

--- a/plugin/commands/show.md
+++ b/plugin/commands/show.md
@@ -1,8 +1,8 @@
 ---
 description: Show the current project playbook and session user profiles
-allowed-tools: Bash(uv run:*)
+allowed-tools: Bash(bash:*)
 ---
 
 Run this bash command and show its output verbatim:
 
-!`uv run --project "$HOME/.reflexio/plugin-root" --quiet python -m claude_smart.cli show`
+!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" show`

--- a/plugin/scripts/cli.sh
+++ b/plugin/scripts/cli.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Wrapper for slash commands that invoke the claude_smart CLI via uv.
+# Claude Code runs `!` bash directives in slash command .md files in a
+# non-interactive, non-login shell that does NOT source ~/.zshrc or
+# ~/.bash_profile. As a result, binaries installed by smart-install.sh
+# at ~/.local/bin (e.g. uv from the astral.sh installer) are invisible
+# to those directives until the user manually re-sources their shell rc.
+# This wrapper bootstraps PATH the same way hook_entry.sh does so the
+# slash commands work on a fresh install.
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_lib.sh
+. "$HERE/_lib.sh"
+claude_smart_source_login_path
+claude_smart_prepend_astral_bins
+
+PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+
+# If the Setup hook recorded an install failure, surface that reason
+# instead of falling through to a generic "uv not found" — mirrors the
+# branch at hook_entry.sh so slash commands and hooks behave consistently
+# on a broken install.
+FAILURE_MARKER="$HOME/.claude-smart/install-failed"
+if [ -f "$FAILURE_MARKER" ]; then
+  msg="$(cat "$FAILURE_MARKER" 2>/dev/null || echo "")"
+  [ -n "$msg" ] || msg="unknown error"
+  echo "claude-smart is not installed correctly: $msg" >&2
+  echo "Re-run the plugin's Setup (restart Claude Code) or fix the underlying issue and delete $FAILURE_MARKER to retry." >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "claude-smart: 'uv' not found on PATH." >&2
+  echo "Install it from https://docs.astral.sh/uv/ or restart Claude Code so the Setup hook can install it." >&2
+  exit 1
+fi
+
+exec uv run --project "$PLUGIN_ROOT" --quiet python -m claude_smart.cli "$@"

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -192,13 +192,13 @@ class Adapter:
         if client is None:
             return []
         try:
-            response = client.search_profiles(
+            response = client.search_user_profiles(
                 user_id=project_id,
                 query="",
                 top_k=top_k,
             )
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("search_profiles failed: %s", exc)
+            _LOGGER.debug("search_user_profiles failed: %s", exc)
             return []
         return _extract_items(response, "user_profiles")
 
@@ -250,13 +250,13 @@ class Adapter:
         if client is None:
             return []
         try:
-            response = client.search_profiles(
+            response = client.search_user_profiles(
                 user_id=project_id,
                 query=query,
                 top_k=top_k,
             )
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("search_profiles failed: %s", exc)
+            _LOGGER.debug("search_user_profiles failed: %s", exc)
             return []
         return _extract_items(response, "user_profiles")
 


### PR DESCRIPTION
## Summary
- Slash commands (`/learn`, `/show`, `/restart`, `/clear-all`) failed on fresh installs because Claude Code's `!` bash directives run in a non-interactive, non-login shell that doesn't source `~/.zshrc`, leaving the freshly-installed `uv` at `~/.local/bin` invisible until the user manually re-sources their rc.
- Route the four commands through a new `plugin/scripts/cli.sh` wrapper that bootstraps `PATH` the same way `hook_entry.sh` does, and short-circuits with the recorded reason when `~/.claude-smart/install-failed` is present so a broken Setup hook surfaces a useful message instead of "uv not found".
- Adapter rename: switch the two internal calls from `client.search_profiles` to `client.search_user_profiles` to match the canonical method on `ReflexioClient` (the old name is deprecated upstream).
- Bump the reflexio submodule pointer to `0c1eced` (single-loop agentic extraction/search v2), which is where the `search_user_profiles` rename landed.
- Also picks up `18db3e4` (release `Makefile` gate on `npm whoami`), which had been sitting unpushed on local `main`.

## Changes

### Slash command wrapper
- `plugin/scripts/cli.sh` *(new)* — bash wrapper that sources `_lib.sh`, calls `claude_smart_source_login_path` + `claude_smart_prepend_astral_bins`, honors the `install-failed` marker, then `exec`s `uv run --project "$PLUGIN_ROOT" --quiet python -m claude_smart.cli "$@"`.
- `plugin/commands/{clear-all,learn,restart,show}.md` — `allowed-tools` switched from `Bash(uv run:*)` to `Bash(bash:*)`; the `!` directive now invokes `bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" <subcommand> ...`.

### Adapter
- `plugin/src/claude_smart/reflexio_adapter.py` — rename two `client.search_profiles(...)` call sites and their debug log strings to `search_user_profiles`. Adapter's own public method `Adapter.search_profiles` is unchanged — only the underlying client call.

### Submodule
- `reflexio` — pointer moved from `9143d1b` → `0c1eced` (agentic extraction + search v2).

### Release tooling (carried in from local main)
- `Makefile` — `check-npm-auth` target gates `release` so an unauthenticated `npm publish` fails fast, before any version bump / commit / tag.

## Test Plan
- [ ] Fresh install in a new shell where `~/.local/bin` is not on the inherited PATH: confirm `/learn`, `/show`, `/restart`, `/clear-all` all run successfully.
- [ ] With `~/.claude-smart/install-failed` present, confirm a slash command prints the recorded message (not "uv not found") and exits 1.
- [ ] Run a session that triggers `Adapter.fetch_project_profiles` / `Adapter.search_profiles` against a reflexio backend at `0c1eced`+: confirm no `AttributeError` and profiles come back.
- [ ] `make release` against a logged-out npm: confirm it stops at `check-npm-auth` before bumping.

## Notes for reviewer
- The PR includes one prior chore commit (`18db3e4`) that was sitting unpushed on local `main`. Squash-merging this PR will collapse both into one commit on `main`.
- The reflexio working tree is locally `-dirty` (a deprecated `search_profiles` alias added on top of `0c1eced` for backward compat experimentation), but the gitlink recorded here is the clean `0c1eced` SHA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added npm authentication verification to the release flow to ensure valid publish credentials before releasing.
  * Added a Bash CLI wrapper and updated plugin command execution to use it for more reliable local invocations.
  * Updated an internal subproject reference.

* **Documentation**
  * Updated command docs to reflect the new Bash wrapper and adjusted allowed-tool patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->