### PR TITLE
feat: bootstrap private Node.js for dashboard with non-fatal failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.db
 
 # Claude Code local settings
 .claude/settings.local.json
+/AGENTS.md
 
 # Makefile sed backups
 *.bak

--- a/README.md
+++ b/README.md
@@ -79,14 +79,19 @@ Four ways this changes what Claude Code can do for you:
 ## Quick Start
 
 ```bash
-npx claude-smart install     # or: uvx claude-smart install
-```
-
-Or run the equivalent marketplace commands directly via the Claude Code CLI:
-
-```bash
 claude plugin marketplace add ReflexioAI/claude-smart
 claude plugin install claude-smart@reflexioai
+```
+
+The plugin Setup hook installs its own `uv`, Python 3.12 environment, and
+private Node.js/npm runtime under `~/.claude-smart/` when they are missing, so
+you do not need to install Python or Node globally for the plugin/dashboard.
+
+If you already have Node.js or uv, these convenience wrappers are equivalent
+but require their own runtime to already exist:
+
+```bash
+npx claude-smart install     # or: uvx claude-smart install
 ```
 
 Then restart Claude Code.
@@ -94,13 +99,13 @@ Then restart Claude Code.
 To uninstall:
 
 ```bash
-npx claude-smart uninstall     # or: uvx claude-smart uninstall
+claude plugin uninstall claude-smart@reflexioai
 ```
 
-Or run the equivalent command directly via the Claude Code CLI:
+Or, if you already have Node.js or uv:
 
 ```bash
-claude plugin uninstall claude-smart@reflexioai
+npx claude-smart uninstall     # or: uvx claude-smart uninstall
 ```
 
 Local data under `~/.reflexio/` and `~/.claude-smart/` is left in place — remove manually if desired.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -12,6 +12,15 @@ Check `~/.claude-smart/sessions/`. If your current session's JSONL has no `User`
 **Hooks appear to time out.**
 Each hook is capped at 10–60s (see `plugin/hooks/hooks.json`). If you see long pauses, check `uv` is on PATH — hooks shell out to `uv run`.
 
+**Dashboard says npm or Node is missing.**
+The Setup hook should install a private Node.js/npm runtime under `~/.claude-smart/node/current` when no suitable global Node.js is available. If private Node setup or dashboard build fails, claude-smart writes the non-fatal marker `~/.claude-smart/dashboard-unavailable`; `/claude-smart:dashboard` prints that file before log tails. Restart Claude Code to retry Setup, or install Node.js 20.9+ manually and run `/claude-smart:restart`.
+
+**Install reports `install-failed`.**
+`~/.claude-smart/install-failed` is reserved for core setup failures such as `uv` installation or `uv sync --locked --python 3.12`. Fix the reported issue, delete the marker, then restart Claude Code so Setup can retry. Dashboard-only issues should appear in `~/.claude-smart/dashboard-unavailable` instead.
+
+**Where are private install tools stored?**
+`uv` is installed into the standard Astral locations (`~/.local/bin` or `~/.cargo/bin`). The private dashboard runtime is at `~/.claude-smart/node/current`. Set `CLAUDE_SMART_NODE_LTS_MAJOR=22` to choose the Node LTS major used by the private bootstrap.
+
 **A different LLM is being used.**
 Reflexio's provider priority is `claude-code > local > anthropic > gemini > ... > openai`. If you have `CLAUDE_SMART_USE_LOCAL_CLI=1` *and* an Anthropic key set, claude-code still wins for generation; `local` sits above openai/gemini for embeddings. Check the startup log line `Primary provider for generation: <name>` and `Embedding provider: <name>` to confirm.
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -7,21 +7,27 @@ This directory is the published Python package (`claude-smart` on PyPI) and the 
 ## Install
 
 ```bash
-npx claude-smart install   # or: uvx claude-smart install
+claude plugin marketplace add ReflexioAI/claude-smart
+claude plugin install claude-smart@reflexioai
 ```
+
+The Setup hook bootstraps `uv`, Python 3.12, and a private Node.js/npm runtime
+under `~/.claude-smart/` when they are missing. If Node.js is already installed,
+`npx claude-smart install` is equivalent; if uv is already installed,
+`uvx claude-smart install` is equivalent.
 
 Then restart Claude Code.
 
 ## Uninstall
 
 ```bash
-npx claude-smart uninstall   # or: uvx claude-smart uninstall
+claude plugin uninstall claude-smart@reflexioai
 ```
 
-Or run the equivalent command directly via the Claude Code CLI:
+Or, if Node.js or uv is already installed:
 
 ```bash
-claude plugin uninstall claude-smart@reflexioai
+npx claude-smart uninstall   # or: uvx claude-smart uninstall
 ```
 
 Local data under `~/.reflexio/` and `~/.claude-smart/` is left in place — remove manually if desired.

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -5,6 +5,7 @@
 # PATH the same way claude-mem does so hook-spawned scripts find them without
 # the user having to mutate their global PATH. Best-effort — failures silent.
 claude_smart_source_login_path() {
+  local _SHELL_PATH
   if [ -n "${SHELL:-}" ] && [ -x "$SHELL" ]; then
     if _SHELL_PATH="$("$SHELL" -lc 'printf %s "$PATH"' 2>/dev/null)"; then
       [ -n "$_SHELL_PATH" ] && export PATH="$_SHELL_PATH:$PATH"
@@ -19,6 +20,64 @@ claude_smart_source_login_path() {
 # under `set -u`.
 claude_smart_prepend_astral_bins() {
   export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+}
+
+# Prepend claude-smart's private Node.js install, if present. The Setup
+# hook installs Node here when the user does not already have a suitable
+# node/npm on PATH, so later hook-spawned dashboard scripts can run without
+# requiring nvm/brew/global npm to be visible from Claude Code's shell.
+claude_smart_prepend_node_bins() {
+  local _CS_NODE_ROOT
+  _CS_NODE_ROOT="$HOME/.claude-smart/node/current"
+  export PATH="$_CS_NODE_ROOT/bin:$_CS_NODE_ROOT:$PATH"
+}
+
+claude_smart_dashboard_unavailable_marker() {
+  printf '%s\n' "$HOME/.claude-smart/dashboard-unavailable"
+}
+
+claude_smart_node_recovery_hint() {
+  cat <<'EOF'
+Recovery:
+  1. Restart Claude Code to let claude-smart retry its private Node.js install.
+  2. If the retry is blocked by your network or OS policy, install Node.js 20.9+ manually:
+EOF
+  if claude_smart_is_windows; then
+    cat <<'EOF'
+     - winget install OpenJS.NodeJS.LTS
+     - or download the LTS installer from https://nodejs.org/
+EOF
+  elif [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    cat <<'EOF'
+     - brew install node
+     - or download the LTS installer from https://nodejs.org/
+EOF
+  else
+    cat <<'EOF'
+     - use your distro package manager for nodejs/npm
+     - or download the LTS archive from https://nodejs.org/
+EOF
+  fi
+  cat <<'EOF'
+  3. Run /claude-smart:restart, then /claude-smart:dashboard.
+EOF
+}
+
+claude_smart_write_dashboard_unavailable() {
+  local reason marker
+  reason="$1"
+  marker="$(claude_smart_dashboard_unavailable_marker)"
+  mkdir -p "$(dirname "$marker")"
+  {
+    printf 'claude-smart dashboard is unavailable: %s\n\n' "$reason"
+    printf 'The learning backend and hooks can still work; only the dashboard UI is affected.\n\n'
+    printf 'Private Node.js location: %s\n\n' "$HOME/.claude-smart/node/current"
+    claude_smart_node_recovery_hint
+  } > "$marker"
+}
+
+claude_smart_clear_dashboard_unavailable() {
+  rm -f "$(claude_smart_dashboard_unavailable_marker)"
 }
 
 # Return 0 (true) if running under a Windows-flavoured bash (Git Bash,
@@ -56,6 +115,122 @@ claude_smart_resolve_python() {
     fi
   done
   return 1
+}
+
+claude_smart_download() {
+  local url dest src _CS_PY
+  url="$1"
+  dest="$2"
+  mkdir -p "$(dirname "$dest")"
+  case "$url" in
+    file://*)
+      src="${url#file://}"
+      cp "$src" "$dest"
+      return $?
+      ;;
+  esac
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$dest"
+    return $?
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -q -O "$dest" "$url"
+    return $?
+  fi
+  if command -v powershell >/dev/null 2>&1; then
+    URL="$url" DEST="$dest" powershell -NoProfile -ExecutionPolicy Bypass -Command \
+      '$ProgressPreference="SilentlyContinue"; Invoke-WebRequest -Uri $env:URL -OutFile $env:DEST'
+    return $?
+  fi
+  if command -v pwsh >/dev/null 2>&1; then
+    URL="$url" DEST="$dest" pwsh -NoProfile -Command \
+      '$ProgressPreference="SilentlyContinue"; Invoke-WebRequest -Uri $env:URL -OutFile $env:DEST'
+    return $?
+  fi
+  _CS_PY=$(claude_smart_resolve_python || true)
+  if [ -n "$_CS_PY" ]; then
+    "$_CS_PY" - "$url" "$dest" <<'PY'
+import sys
+import urllib.request
+
+url, dest = sys.argv[1], sys.argv[2]
+with urllib.request.urlopen(url, timeout=60) as response:
+    data = response.read()
+with open(dest, "wb") as fh:
+    fh.write(data)
+PY
+    return $?
+  fi
+  return 1
+}
+
+claude_smart_sha256_file() {
+  local path _CS_PY
+  path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+    return ${PIPESTATUS[0]}
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+    return ${PIPESTATUS[0]}
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$path" | awk '{print $NF}'
+    return ${PIPESTATUS[0]}
+  fi
+  _CS_PY=$(claude_smart_resolve_python || true)
+  if [ -n "$_CS_PY" ]; then
+    "$_CS_PY" - "$path" <<'PY'
+import hashlib
+import sys
+
+h = hashlib.sha256()
+with open(sys.argv[1], "rb") as fh:
+    for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+        h.update(chunk)
+print(h.hexdigest())
+PY
+    return $?
+  fi
+  return 1
+}
+
+# Return 0 if `node` exists and satisfies the minimum major/minor pair.
+# Patch versions are intentionally ignored because our requirement is a
+# floor, not an exact runtime pin.
+claude_smart_node_satisfies() {
+  local min_major min_minor version major minor
+  min_major="$1"
+  min_minor="$2"
+  command -v node >/dev/null 2>&1 || return 1
+  version=$(node -v 2>/dev/null | sed 's/^v//') || return 1
+  major=$(printf '%s' "$version" | awk -F. '{print $1}')
+  minor=$(printf '%s' "$version" | awk -F. '{print $2}')
+  [ -n "$major" ] && [ -n "$minor" ] || return 1
+  case "$major:$minor" in
+    *[!0-9:]*|:*|*:) return 1 ;;
+  esac
+  [ "$major" -gt "$min_major" ] && return 0
+  [ "$major" -eq "$min_major" ] && [ "$minor" -ge "$min_minor" ]
+}
+
+claude_smart_resolve_npm() {
+  local cand
+  for cand in npm npm.cmd; do
+    if command -v "$cand" >/dev/null 2>&1; then
+      command -v "$cand"
+      return 0
+    fi
+  done
+  return 1
+}
+
+claude_smart_npm_available() {
+  local npm_bin
+  npm_bin=$(claude_smart_resolve_npm || true)
+  [ -n "$npm_bin" ] || return 1
+  "$npm_bin" --version >/dev/null 2>&1
 }
 
 # Spawn a command fully detached from the current shell so a hook timeout

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -21,6 +21,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
 claude_smart_source_login_path
+claude_smart_prepend_astral_bins
 
 CMD="${1:-start}"
 PORT=8071

--- a/plugin/scripts/cli.sh
+++ b/plugin/scripts/cli.sh
@@ -14,6 +14,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 . "$HERE/_lib.sh"
 claude_smart_source_login_path
 claude_smart_prepend_astral_bins
+claude_smart_prepend_node_bins
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 

--- a/plugin/scripts/dashboard-build.sh
+++ b/plugin/scripts/dashboard-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the Next.js dashboard ($PLUGIN_ROOT/dashboard) in two steps:
-#   1. npm install (skipped if node_modules exists and is newer than
-#      package.json)
+#   1. npm ci (skipped if node_modules exists and is newer than package.json
+#      and package-lock.json)
 #   2. npm run build (skipped if .next exists and is newer than
 #      package.json)
 #
@@ -24,6 +24,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
 claude_smart_source_login_path
+claude_smart_prepend_node_bins
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 DASHBOARD_DIR="$PLUGIN_ROOT/dashboard"
@@ -40,8 +41,11 @@ if [ ! -d "$DASHBOARD_DIR" ]; then
   log "dashboard build: no $DASHBOARD_DIR; nothing to do"
   exit 0
 fi
-if ! command -v npm >/dev/null 2>&1; then
-  log "dashboard build: npm not on PATH; cannot build"
+NPM_BIN=$(claude_smart_resolve_npm || true)
+if [ -z "$NPM_BIN" ] || ! "$NPM_BIN" --version >/dev/null 2>&1; then
+  reason="npm is not on PATH; dashboard dependencies cannot be installed"
+  log "dashboard build: $reason"
+  claude_smart_write_dashboard_unavailable "$reason"
   exit 1
 fi
 
@@ -89,19 +93,27 @@ trap on_interrupt INT TERM
 cd "$DASHBOARD_DIR"
 
 # Cheap freshness check: skip reinstall when node_modules is newer than
-# package.json. Avoids re-downloading the dep tree on every SessionStart
-# while still picking up version bumps when the plugin updates.
-# Note: lockfile-only or next.config-only edits won't trigger a rebuild —
-# bump package.json (or `rm -rf .next`) in that case.
+# package.json and package-lock.json. Avoids re-downloading the dep tree
+# on every SessionStart while still picking up version bumps when the
+# plugin updates.
 needs_install=1
 if [ -d node_modules ] && [ node_modules -nt package.json ]; then
-  needs_install=0
+  if [ ! -f package-lock.json ] || [ node_modules -nt package-lock.json ]; then
+    needs_install=0
+  fi
 fi
 if [ "$needs_install" = "1" ]; then
-  log "dashboard build: running npm install..."
-  if ! npm install --silent --no-fund --no-audit >>"$LOG_FILE" 2>&1; then
+  if [ -f package-lock.json ]; then
+    install_cmd="ci"
+  else
+    install_cmd="install"
+  fi
+  log "dashboard build: running npm $install_cmd..."
+  if ! "$NPM_BIN" "$install_cmd" --silent --no-fund --no-audit >>"$LOG_FILE" 2>&1; then
     rm -rf "$DASHBOARD_DIR/node_modules"
-    log "dashboard build: npm install failed; removed partial node_modules; see $LOG_FILE"
+    reason="npm $install_cmd failed; removed partial node_modules; see $LOG_FILE"
+    log "dashboard build: $reason"
+    claude_smart_write_dashboard_unavailable "$reason"
     exit 1
   fi
 fi
@@ -112,12 +124,16 @@ if [ -d .next ] && [ .next -nt package.json ]; then
 fi
 if [ "$needs_build" = "1" ]; then
   log "dashboard build: running next build (this can take 1-2 min)..."
-  if ! npm run build >>"$LOG_FILE" 2>&1; then
+  if ! "$NPM_BIN" run build >>"$LOG_FILE" 2>&1; then
     rm -rf "$DASHBOARD_DIR/.next"
-    log "dashboard build: next build failed; see $LOG_FILE"
+    reason="next build failed; see $LOG_FILE"
+    log "dashboard build: $reason"
+    claude_smart_write_dashboard_unavailable "$reason"
     exit 1
   fi
+  claude_smart_clear_dashboard_unavailable
   log "dashboard build: complete"
 else
+  claude_smart_clear_dashboard_unavailable
   log "dashboard build: .next is up-to-date; skipping"
 fi

--- a/plugin/scripts/dashboard-open.sh
+++ b/plugin/scripts/dashboard-open.sh
@@ -11,10 +11,13 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS="$HERE"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
+claude_smart_source_login_path
+claude_smart_prepend_node_bins
 
 STATE_DIR="$HOME/.claude-smart"
 BACKEND_LOG="$STATE_DIR/backend.log"
 DASHBOARD_LOG="$STATE_DIR/dashboard.log"
+DASHBOARD_UNAVAILABLE="$(claude_smart_dashboard_unavailable_marker)"
 
 # Capture start-command output so we can surface fatal errors (e.g. uv/npm
 # missing, port collisions, .next not built) rather than silently swallow
@@ -74,6 +77,11 @@ if [ "$dashboard_status" = "not running" ]; then
     else
         echo "ERROR: dashboard failed to start on http://localhost:3001"
         [ -n "$dashboard_start_out" ] && echo "$dashboard_start_out"
+        if [ -f "$DASHBOARD_UNAVAILABLE" ]; then
+            echo ""
+            echo "--- dashboard availability ($DASHBOARD_UNAVAILABLE) ---"
+            cat "$DASHBOARD_UNAVAILABLE" 2>/dev/null || true
+        fi
         show_log_tail "dashboard" "$DASHBOARD_LOG"
     fi
 fi
@@ -84,4 +92,16 @@ if [ "$failed" = "1" ]; then
     exit 1
 fi
 
-python3 -m webbrowser "http://localhost:3001" && echo "Opened http://localhost:3001"
+URL="http://localhost:3001"
+PY_BIN=$(claude_smart_resolve_python || true)
+if [ -n "$PY_BIN" ] && "$PY_BIN" -m webbrowser "$URL"; then
+    echo "Opened $URL"
+elif command -v open >/dev/null 2>&1 && open "$URL"; then
+    echo "Opened $URL"
+elif command -v xdg-open >/dev/null 2>&1 && xdg-open "$URL"; then
+    echo "Opened $URL"
+elif command -v powershell >/dev/null 2>&1 && powershell -NoProfile -Command "Start-Process '$URL'"; then
+    echo "Opened $URL"
+else
+    echo "Dashboard is running at $URL"
+fi

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -22,6 +22,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
 claude_smart_source_login_path
+claude_smart_prepend_node_bins
 
 CMD="${1:-start}"
 PORT=3001
@@ -91,13 +92,16 @@ case "$CMD" in
       emit_ok; exit 0
     fi
     if [ ! -d "$DASHBOARD_DIR" ]; then emit_ok; exit 0; fi
-    if is_our_dashboard_running; then emit_ok; exit 0; fi
+    if is_our_dashboard_running; then claude_smart_clear_dashboard_unavailable; emit_ok; exit 0; fi
     if port_occupied; then
       echo "[claude-smart] dashboard: port $PORT held by another process; skipping" >>"$LOG_FILE"
       emit_ok; exit 0
     fi
-    if ! command -v npm >/dev/null 2>&1; then
-      echo "[claude-smart] dashboard: npm not on PATH; skipping" >>"$LOG_FILE"
+    NPM_BIN=$(claude_smart_resolve_npm || true)
+    if [ -z "$NPM_BIN" ] || ! "$NPM_BIN" --version >/dev/null 2>&1; then
+      reason="npm is not on PATH; dashboard cannot start"
+      echo "[claude-smart] dashboard: $reason; skipping" >>"$LOG_FILE"
+      claude_smart_write_dashboard_unavailable "$reason"
       emit_ok; exit 0
     fi
 
@@ -125,13 +129,25 @@ case "$CMD" in
     #   - Windows: nohup alone (no process groups; tree-kill via taskkill).
     # Caller-side `>>file 2>&1` redirection is honoured before the child
     # detaches, so per-OS log paths stay identical.
-    claude_smart_spawn_detached npm run start >>"$LOG_FILE" 2>&1
+    claude_smart_spawn_detached "$NPM_BIN" run start >>"$LOG_FILE" 2>&1
     dash_pid=$!
     # Record the spawned pid, not a pgid sampled with ps. On POSIX,
     # setsid/python os.setsid make this pid the new process group leader;
     # sampling immediately can race and capture the caller's pgid instead.
     # On Windows, claude_smart_kill_tree translates the MSYS pid to WINPID.
     echo "$dash_pid" > "$PID_FILE"
+    dashboard_ready=0
+    for _ in 1 2 3 4 5; do
+      if marker_responds; then
+        dashboard_ready=1
+        claude_smart_clear_dashboard_unavailable
+        break
+      fi
+      sleep 1
+    done
+    if [ "$dashboard_ready" != "1" ]; then
+      claude_smart_write_dashboard_unavailable "dashboard process spawned but did not respond on http://127.0.0.1:$PORT within 5s; see $LOG_FILE"
+    fi
     emit_ok
     ;;
   stop)

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -12,6 +12,8 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
 claude_smart_source_login_path
+claude_smart_prepend_astral_bins
+claude_smart_prepend_node_bins
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
@@ -22,11 +24,217 @@ mkdir -p "$MARKER_DIR"
 rm -f "$FAILURE_MARKER"
 
 write_failure() {
-  printf '%s\n' "$1" > "$FAILURE_MARKER"
-  echo "[claude-smart] install failed: $1" >&2
+  local reason
+  reason="$1"
+  printf '%s\n' "$reason" > "$FAILURE_MARKER"
+  echo "[claude-smart] install failed: $reason" >&2
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 }
+
+install_private_node() {
+  local NODE_MIN_MAJOR NODE_MIN_MINOR NODE_LTS_MAJOR
+  local node_os archive_ext reason node_arch node_platform base_url node_root
+  local tmp_dir shasums_path archive_name ext_re install_dir archive_path
+  local expected_hash actual_hash archive_win dest_win candidate_path next_link
+
+  NODE_MIN_MAJOR=20
+  NODE_MIN_MINOR=9
+  NODE_LTS_MAJOR="${CLAUDE_SMART_NODE_LTS_MAJOR:-22}"
+
+  if claude_smart_node_satisfies "$NODE_MIN_MAJOR" "$NODE_MIN_MINOR" \
+    && claude_smart_npm_available; then
+    claude_smart_clear_dashboard_unavailable
+    return 0
+  fi
+
+  case "$(uname -s 2>/dev/null)" in
+    Darwin*) node_os="darwin"; archive_ext="tar.gz" ;;
+    Linux*) node_os="linux"; archive_ext="tar.gz" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      node_os="win"
+      archive_ext="zip"
+      if ! command -v powershell >/dev/null 2>&1; then
+        reason="PowerShell is not on PATH, so claude-smart could not extract private Node.js on Windows."
+        echo "[claude-smart] WARNING: $reason" >&2
+        claude_smart_write_dashboard_unavailable "$reason"
+        return 1
+      fi
+      ;;
+    *)
+      reason="unsupported OS for private Node.js install: $(uname -s 2>/dev/null || echo unknown)"
+      echo "[claude-smart] WARNING: $reason" >&2
+      claude_smart_write_dashboard_unavailable "$reason"
+      return 1
+      ;;
+  esac
+
+  case "$(uname -m 2>/dev/null)" in
+    x86_64|amd64) node_arch="x64" ;;
+    arm64|aarch64) node_arch="arm64" ;;
+    *)
+      reason="unsupported CPU for private Node.js install: $(uname -m 2>/dev/null || echo unknown)"
+      echo "[claude-smart] WARNING: $reason" >&2
+      claude_smart_write_dashboard_unavailable "$reason"
+      return 1
+      ;;
+  esac
+
+  node_platform="$node_os-$node_arch"
+  base_url="${CLAUDE_SMART_NODE_BASE_URL:-https://nodejs.org/dist/latest-v${NODE_LTS_MAJOR}.x}"
+  echo "[claude-smart] Node.js >=20.9 with npm not found — installing private Node.js from nodejs.org..." >&2
+  node_root="$HOME/.claude-smart/node"
+  mkdir -p "$node_root"
+  tmp_dir=$(mktemp -d "$node_root/tmp.XXXXXX") || {
+    reason="could not create temporary directory under $node_root"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  }
+  shasums_path="$tmp_dir/SHASUMS256.txt"
+
+  if ! claude_smart_download "$base_url/SHASUMS256.txt" "$shasums_path"; then
+    rm -rf "$tmp_dir"
+    reason="could not download Node.js checksums from $base_url/SHASUMS256.txt"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  ext_re=$(printf '%s' "$archive_ext" | sed 's/\./\\./g')
+  archive_name=$(
+    awk -v platform="$node_platform" -v ext="$ext_re" \
+          '$2 ~ ("^node-v[0-9][^ ]*-" platform "\\." ext "$") { print $2; exit }' \
+      "$shasums_path"
+  ) || archive_name=""
+  if [ -z "$archive_name" ]; then
+    rm -rf "$tmp_dir"
+    reason="could not resolve Node.js archive for $node_platform from $base_url"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  install_dir="$node_root/${archive_name%.$archive_ext}"
+  archive_path="$tmp_dir/$archive_name"
+  expected_hash=$(awk -v name="$archive_name" '$2 == name { print $1; exit }' "$shasums_path")
+  if [ -z "$expected_hash" ]; then
+    rm -rf "$tmp_dir"
+    reason="Node.js checksums did not include $archive_name"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  if ! claude_smart_download "$base_url/$archive_name" "$archive_path"; then
+    rm -rf "$tmp_dir"
+    reason="Node.js download failed from $base_url/$archive_name"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  actual_hash=$(claude_smart_sha256_file "$archive_path" || true)
+  if [ -z "$actual_hash" ] || [ "$actual_hash" != "$expected_hash" ]; then
+    rm -rf "$tmp_dir"
+    reason="Node.js checksum verification failed for $archive_name"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  rm -rf "$install_dir" "$node_root/current.next"
+  if [ "$archive_ext" = "zip" ]; then
+    archive_win="$archive_path"
+    dest_win="$node_root"
+    if command -v cygpath >/dev/null 2>&1; then
+      archive_win=$(cygpath -w "$archive_path")
+      dest_win=$(cygpath -w "$node_root")
+    fi
+    if ! ARCHIVE_PATH="$archive_win" DEST_DIR="$dest_win" powershell -NoProfile -ExecutionPolicy Bypass -Command \
+      '$ProgressPreference="SilentlyContinue"; Expand-Archive -LiteralPath $env:ARCHIVE_PATH -DestinationPath $env:DEST_DIR -Force' >&2; then
+      rm -rf "$tmp_dir" "$install_dir"
+      reason="Node.js archive extraction failed for $archive_name"
+      echo "[claude-smart] WARNING: $reason" >&2
+      claude_smart_write_dashboard_unavailable "$reason"
+      return 1
+    fi
+  elif ! tar -xzf "$archive_path" -C "$node_root"; then
+    rm -rf "$tmp_dir" "$install_dir"
+    reason="Node.js archive extraction failed for $archive_name"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  if [ ! -d "$install_dir" ]; then
+    rm -rf "$tmp_dir"
+    reason="Node.js archive extracted without expected directory $install_dir"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  if [ -x "$install_dir/bin/node" ]; then
+    candidate_path="$install_dir/bin:$PATH"
+  elif [ -x "$install_dir/node.exe" ] || [ -x "$install_dir/node" ]; then
+    candidate_path="$install_dir:$PATH"
+  else
+    rm -rf "$tmp_dir"
+    reason="Node.js archive extracted without a node executable"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  if claude_smart_node_satisfies "$NODE_MIN_MAJOR" "$NODE_MIN_MINOR" \
+    && claude_smart_npm_available; then
+    : # existing PATH unexpectedly became suitable; keep going
+  elif PATH="$candidate_path" claude_smart_node_satisfies "$NODE_MIN_MAJOR" "$NODE_MIN_MINOR" \
+    && PATH="$candidate_path" claude_smart_npm_available; then
+    : # candidate install is suitable
+  else
+    rm -rf "$tmp_dir"
+    reason="private Node.js install completed but node/npm are still not usable"
+    echo "[claude-smart] WARNING: $reason" >&2
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+
+  next_link="$node_root/current.next.$$"
+  if ln -s "$install_dir" "$next_link" 2>/dev/null; then
+    if mv -Tf "$next_link" "$node_root/current" 2>/dev/null; then
+      :
+    elif mv -hf "$next_link" "$node_root/current" 2>/dev/null; then
+      :
+    else
+      rm -rf "$node_root/current"
+      mv "$next_link" "$node_root/current"
+    fi
+  else
+    rm -rf "$next_link" "$node_root/current"
+    mv "$install_dir" "$node_root/current"
+  fi
+
+  rm -rf "$tmp_dir"
+  claude_smart_prepend_node_bins
+  if claude_smart_node_satisfies "$NODE_MIN_MAJOR" "$NODE_MIN_MINOR" \
+    && claude_smart_npm_available; then
+    claude_smart_clear_dashboard_unavailable
+    echo "[claude-smart] installed private $(node -v) at $node_root/current" >&2
+    return 0
+  fi
+
+  reason="private Node.js install completed but current node/npm are still not usable"
+  echo "[claude-smart] WARNING: $reason" >&2
+  claude_smart_write_dashboard_unavailable "$reason"
+  return 1
+}
+
+if [ "${CLAUDE_SMART_INSTALL_PRIVATE_NODE_ONLY:-}" = "1" ]; then
+  install_private_node
+  exit $?
+fi
 
 # Dev-mode only: when running from a git checkout, pull the reflexio
 # submodule so tests/benchmarks can use its sources. In install mode the
@@ -58,7 +266,11 @@ if ! command -v uv >/dev/null 2>&1; then
       write_failure "uv install via PowerShell failed — install manually from https://docs.astral.sh/uv/"
     fi
   else
-    if ! curl -LsSf https://astral.sh/uv/install.sh | sh >&2; then
+    UV_INSTALLER="$MARKER_DIR/uv-install.sh"
+    if ! claude_smart_download https://astral.sh/uv/install.sh "$UV_INSTALLER"; then
+      write_failure "uv installer download failed — install manually from https://docs.astral.sh/uv/"
+    fi
+    if ! sh "$UV_INSTALLER" >&2; then
       write_failure "uv install failed — install manually from https://docs.astral.sh/uv/"
     fi
   fi
@@ -81,8 +293,8 @@ fi
 
 cd "$PLUGIN_ROOT"
 echo "[claude-smart] running uv sync..." >&2
-if ! uv sync --quiet >&2; then
-  write_failure "uv sync failed in $PLUGIN_ROOT — run 'uv sync' there to diagnose"
+if ! uv sync --locked --python 3.12 --quiet >&2; then
+  write_failure "uv sync failed in $PLUGIN_ROOT — run 'uv sync --locked --python 3.12' there to diagnose"
 fi
 
 # Reflexio's CLI reads ~/.reflexio/.env (see reflexio/cli/env_loader.py);
@@ -176,11 +388,16 @@ fi
 # if .next is still missing, and dashboard-open.sh detects the build-pid
 # file to surface a "still building" message instead of a generic error.
 DASHBOARD_DIR="$PLUGIN_ROOT/dashboard"
-if [ -d "$DASHBOARD_DIR" ] && command -v npm >/dev/null 2>&1; then
+if [ -d "$DASHBOARD_DIR" ]; then
+  install_private_node || true
+fi
+if [ -d "$DASHBOARD_DIR" ] && claude_smart_npm_available; then
   echo "[claude-smart] starting dashboard build in background (~1-2 min on first install)" >&2
   claude_smart_spawn_detached bash "$HERE/dashboard-build.sh" >/dev/null 2>&1
 elif [ -d "$DASHBOARD_DIR" ]; then
-  echo "[claude-smart] WARNING: npm not on PATH — dashboard will be unavailable until npm is installed" >&2
+  reason="npm is not on PATH after private Node.js bootstrap"
+  echo "[claude-smart] WARNING: $reason" >&2
+  [ -f "$(claude_smart_dashboard_unavailable_marker)" ] || claude_smart_write_dashboard_unavailable "$reason"
 fi
 
 # Point ~/.reflexio/plugin-root at this install so slash commands can

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -352,18 +352,25 @@ def cmd_restart(args: argparse.Namespace) -> int:
         else:
             next_bin = _DASHBOARD_DIR / "node_modules" / ".bin" / "next"
             if not next_bin.exists():
+                install_cmd = (
+                    ["npm", "ci", "--no-audit", "--no-fund"]
+                    if (_DASHBOARD_DIR / "package-lock.json").exists()
+                    else ["npm", "install", "--no-audit", "--no-fund"]
+                )
+                install_label = " ".join(install_cmd)
                 sys.stdout.write(
-                    "Installing dashboard dependencies (npm install, may take a minute)…\n"
+                    "Installing dashboard dependencies "
+                    f"({install_label}, may take a minute)…\n"
                 )
                 try:
                     subprocess.run(
-                        ["npm", "install", "--no-audit", "--no-fund"],
+                        install_cmd,
                         cwd=_DASHBOARD_DIR,
                         check=True,
                     )
                 except subprocess.CalledProcessError as exc:
                     sys.stderr.write(
-                        f"error: npm install failed (exit {exc.returncode}); "
+                        f"error: {install_label} failed (exit {exc.returncode}); "
                         "not starting dashboard.\n"
                     )
                     if do_backend:

--- a/tests/test_cli_restart.py
+++ b/tests/test_cli_restart.py
@@ -140,3 +140,12 @@ def test_restart_no_rebuild_flag_skips_npm(fake_services) -> None:
     rc = cli.cmd_restart(_make_args(no_rebuild=True))
     assert rc == 0
     assert build_calls == []
+
+
+def test_restart_uses_npm_ci_when_lockfile_exists(fake_services) -> None:
+    _, build_calls = fake_services
+    (cli._DASHBOARD_DIR / "package-lock.json").write_text("{}\n")
+    rc = cli.cmd_restart(_make_args())
+    assert rc == 0
+    assert build_calls[0] == ["npm", "ci", "--no-audit", "--no-fund"]
+    assert build_calls[1] == ["npm", "run", "build"]

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,207 @@
+"""Focused checks for shell install helpers used by claude-smart setup."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import stat
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LIB = REPO_ROOT / "plugin" / "scripts" / "_lib.sh"
+SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
+
+
+def _minimal_path(tmp_path: Path, *names: str) -> str:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name in names:
+        target = shutil.which(name)
+        if target:
+            (bin_dir / name).symlink_to(target)
+    return str(bin_dir)
+
+
+def _isolated_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["SHELL"] = "/bin/sh"
+    env.pop("BASH_ENV", None)
+    env.pop("ENV", None)
+    return env
+
+
+def _node_platform() -> str:
+    uname_s = subprocess.check_output(["uname", "-s"], text=True).strip()
+    uname_m = subprocess.check_output(["uname", "-m"], text=True).strip()
+    if uname_s.startswith("Darwin"):
+        node_os = "darwin"
+    elif uname_s.startswith("Linux"):
+        node_os = "linux"
+    else:
+        pytest.skip(f"unsupported private Node test OS: {uname_s}")
+    if uname_m in {"x86_64", "amd64"}:
+        node_arch = "x64"
+    elif uname_m in {"arm64", "aarch64"}:
+        node_arch = "arm64"
+    else:
+        pytest.skip(f"unsupported private Node test arch: {uname_m}")
+    return f"{node_os}-{node_arch}"
+
+
+def _fake_node_dist(tmp_path: Path, *, bad_checksum: bool = False) -> Path:
+    platform = _node_platform()
+    dist = tmp_path / "nodejs-dist"
+    source_root = tmp_path / f"node-v22.99.0-{platform}"
+    bin_dir = source_root / "bin"
+    bin_dir.mkdir(parents=True)
+    for name, output in {"node": "v22.99.0", "npm": "10.9.0"}.items():
+        executable = bin_dir / name
+        executable.write_text(f"#!/bin/sh\nprintf '%s\\n' '{output}'\n")
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+    dist.mkdir()
+    archive_name = f"{source_root.name}.tar.gz"
+    archive_path = dist / archive_name
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.add(source_root, arcname=source_root.name)
+
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    if bad_checksum:
+        digest = "0" * 64
+    (dist / "SHASUMS256.txt").write_text(f"{digest}  {archive_name}\n")
+    return dist
+
+
+def _run_private_node_install(tmp_path: Path, base_url: str) -> subprocess.CompletedProcess[str]:
+    env = _isolated_env(tmp_path)
+    env["CLAUDE_SMART_INSTALL_PRIVATE_NODE_ONLY"] = "1"
+    env["CLAUDE_SMART_NODE_BASE_URL"] = base_url
+    env["PATH"] = _minimal_path(
+        tmp_path,
+        "dirname",
+        "mkdir",
+        "rm",
+        "uname",
+        "mktemp",
+        "awk",
+        "sed",
+        "tar",
+        "ln",
+        "mv",
+        "cp",
+        "sha256sum",
+        "shasum",
+        "openssl",
+    )
+    return subprocess.run(
+        ["/bin/bash", str(SMART_INSTALL)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_dashboard_unavailable_marker_contains_recovery(tmp_path: Path) -> None:
+    env = _isolated_env(tmp_path)
+    script = (
+        f'. "{LIB}"; '
+        'claude_smart_write_dashboard_unavailable "simulated download failure"; '
+        'cat "$HOME/.claude-smart/dashboard-unavailable"'
+    )
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", "-c", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "simulated download failure" in result.stdout
+    assert "The learning backend and hooks can still work" in result.stdout
+    assert "/claude-smart:restart" in result.stdout
+    assert str(tmp_path / ".claude-smart" / "node" / "current") in result.stdout
+
+
+def test_resolve_npm_accepts_windows_cmd_shim(tmp_path: Path) -> None:
+    npm_cmd = tmp_path / "npm.cmd"
+    npm_cmd.write_text("#!/bin/sh\nprintf '10.0.0\\n'\n")
+    npm_cmd.chmod(npm_cmd.stat().st_mode | stat.S_IXUSR)
+    env = _isolated_env(tmp_path)
+    env["PATH"] = str(tmp_path)
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            f'. "{LIB}"; claude_smart_resolve_npm; claude_smart_npm_available',
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines()[0] == str(npm_cmd)
+
+
+def test_dashboard_build_writes_marker_when_npm_missing(tmp_path: Path) -> None:
+    env = _isolated_env(tmp_path)
+    env["PATH"] = _minimal_path(tmp_path, "dirname", "mkdir", "cat", "uname", "rm")
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(REPO_ROOT / "plugin" / "scripts" / "dashboard-build.sh"),
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    marker = tmp_path / ".claude-smart" / "dashboard-unavailable"
+    assert result.returncode == 1
+    assert marker.is_file()
+    assert "npm is not on PATH" in marker.read_text()
+
+
+def test_install_private_node_installs_from_verified_archive(tmp_path: Path) -> None:
+    dist = _fake_node_dist(tmp_path)
+    result = _run_private_node_install(tmp_path, f"file://{dist}")
+
+    assert result.returncode == 0, result.stderr
+    current = tmp_path / ".claude-smart" / "node" / "current"
+    assert current.exists()
+    assert (current / "bin" / "node").exists()
+    assert not (tmp_path / ".claude-smart" / "dashboard-unavailable").exists()
+    assert not (tmp_path / ".claude-smart" / "install-failed").exists()
+
+
+def test_install_private_node_checksum_failure_is_dashboard_only(tmp_path: Path) -> None:
+    dist = _fake_node_dist(tmp_path, bad_checksum=True)
+    result = _run_private_node_install(tmp_path, f"file://{dist}")
+
+    assert result.returncode == 1
+    marker = tmp_path / ".claude-smart" / "dashboard-unavailable"
+    assert marker.is_file()
+    assert "checksum verification failed" in marker.read_text()
+    assert not (tmp_path / ".claude-smart" / "install-failed").exists()
+
+
+def test_install_private_node_download_failure_is_dashboard_only(tmp_path: Path) -> None:
+    missing_dist = tmp_path / "missing-node-dist"
+    result = _run_private_node_install(tmp_path, f"file://{missing_dist}")
+
+    assert result.returncode == 1
+    marker = tmp_path / ".claude-smart" / "dashboard-unavailable"
+    assert marker.is_file()
+    assert "could not download Node.js checksums" in marker.read_text()
+    assert not (tmp_path / ".claude-smart" / "install-failed").exists()


### PR DESCRIPTION
## Summary
- Setup hook now provisions a private Node.js LTS into `~/.claude-smart/node/current` (with SHA256 verification against the official `SHASUMS256.txt`) when no suitable global `node`/`npm` is found, so the dashboard works without users installing Node themselves.
- Splits failure surfaces: dashboard-only problems (missing npm, build failure, runtime hang) write a non-fatal `~/.claude-smart/dashboard-unavailable` marker with recovery hints, while `install-failed` is reserved for core (`uv` / `uv sync`) failures. The learning backend keeps working when only the UI is broken.
- `dashboard-build.sh` and `cli.py cmd_restart` prefer `npm ci` when a lockfile is present and fall back to `npm install` otherwise.
- `dashboard-open.sh` no longer assumes `python3 -m webbrowser` works — falls through `open` / `xdg-open` / PowerShell `Start-Process` for the user's platform.
- Hook-spawned scripts source the private Node bin via `claude_smart_prepend_node_bins` so dashboard scripts find `node`/`npm` without nvm/brew on PATH.

## Changes
- `plugin/scripts/_lib.sh`: new helpers — `claude_smart_prepend_node_bins`, `claude_smart_download` (curl/wget/PowerShell/python fallbacks), `claude_smart_sha256_file`, `claude_smart_node_satisfies`, `claude_smart_resolve_npm`, `claude_smart_npm_available`, plus the dashboard-unavailable marker writer/clearer with platform-aware recovery hint.
- `plugin/scripts/smart-install.sh`: new `install_private_node` that downloads the LTS archive (configurable via `CLAUDE_SMART_NODE_LTS_MAJOR` / `CLAUDE_SMART_NODE_BASE_URL`), verifies SHA256, extracts to `~/.claude-smart/node/<release>`, and atomically swaps the `current` symlink. Tightens `uv sync --locked --python 3.12`. Routes Node failures to the dashboard-unavailable marker.
- `plugin/scripts/dashboard-build.sh` / `dashboard-service.sh` / `dashboard-open.sh` / `cli.sh` / `backend-service.sh`: resolve npm via the helper, prepend private Node bins, and write the dashboard-unavailable marker on failure with a 5s readiness check after spawn.
- `plugin/src/claude_smart/cli.py`: restart uses `npm ci` when `package-lock.json` exists, otherwise `npm install`.
- `tests/test_install_scripts.py`: new — exercises the marker writer, npm.cmd resolution, dashboard-build npm-missing path, and the private-Node install path against a fake `file://` mirror (verified-archive success, bad checksum, missing distribution).
- `tests/test_cli_restart.py`: covers the `npm ci` lockfile path.
- `README.md` / `plugin/README.md` / `TROUBLESHOOTING.md`: lead with the marketplace install commands; document the dashboard-unavailable vs install-failed distinction and `CLAUDE_SMART_NODE_LTS_MAJOR`.
- `.gitignore`: ignore `/AGENTS.md`; restore trailing newline.

## Test Plan
- [x] `uv run pytest` — all 174 tests pass, including new install-script suite.
- [ ] Smoke install on a clean macOS box without Node — verify `~/.claude-smart/node/current/bin/node` exists, dashboard reaches `http://localhost:3001`, and no `dashboard-unavailable` marker is left behind.
- [ ] Same on Windows (Git Bash) — exercises the `zip` extraction branch via PowerShell.
- [ ] Force a checksum mismatch (point `CLAUDE_SMART_NODE_BASE_URL` at a tampered mirror) and confirm `dashboard-unavailable` is written but `install-failed` is not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Private Node.js and Python 3.12 environment auto-installation under `~/.claude-smart/` when missing.
  * Dashboard failure recovery with clear guidance and unavailable markers.

* **Bug Fixes**
  * Improved npm/Node validation and resolution during setup.
  * Better error messaging when dashboard cannot start.

* **Documentation**
  * Updated installation with Claude marketplace flow.
  * Added troubleshooting for npm/Node and setup failures with recovery steps.

* **Tests**
  * Added comprehensive install script and dashboard behavior tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->