### PR TITLE
feat: optimizer assistant subprocess + safe clear-all reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ local-marketplace/
 
 # Scheduled tasks lock
 .claude/scheduled_tasks.lock
+.coverage

--- a/plugin/commands/clear-all.md
+++ b/plugin/commands/clear-all.md
@@ -1,5 +1,5 @@
 ---
-description: Delete ALL reflexio interactions, profiles, and user playbooks (destructive)
+description: Delete ALL local reflexio data and restart the backend (destructive)
 allowed-tools: Bash(bash:*)
 ---
 

--- a/plugin/commands/learn.md
+++ b/plugin/commands/learn.md
@@ -1,10 +1,9 @@
 ---
-description: Flag the last turn as a correction so reflexio learns from it
+description: Force reflexio to extract learnings from this session now
 allowed-tools: Bash(bash:*)
-argument-hint: [note]
 ---
 
-Flag the user's previous turn as a correction and force reflexio to run extraction on this session's interactions now.
+Force reflexio to run extraction on this session's interactions now.
 Run the bash command below and show its output verbatim.
 
-!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" learn "$ARGUMENTS"`
+!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" learn`

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -5,7 +5,7 @@ description = "Self-improving Claude Code plugin — learns from corrections via
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "reflexio-ai>=0.2.20",
+    "reflexio-ai>=0.2.21",
     # Used by reflexio's local embedding provider (ONNXMiniLM_L6_V2).
     # Pulls in onnxruntime + tokenizers; the ~80 MB ONNX model itself is
     # downloaded on first use, not at install time.
@@ -15,6 +15,7 @@ dependencies = [
 [project.scripts]
 claude-smart-hook = "claude_smart.hook:main"
 claude-smart = "claude_smart.cli:main"
+claude-smart-optimizer-assistant = "claude_smart.optimizer_assistant:main"
 
 # NOTE: LOCAL DEV ONLY — do not commit this block to main.
 # Published installs must resolve reflexio-ai from PyPI. This override

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -11,9 +11,8 @@ Exposes the following subcommands:
   in place.
 - ``show``: print the current project playbook and project user profiles
   (as markdown).
-- ``learn "<note>"``: append a ``[correction]``-prefixed turn to the active
-  session buffer (default note: "the previous answer was wrong"), then
-  publish unpublished interactions and force reflexio extraction now.
+- ``learn``: publish unpublished interactions and force reflexio
+  extraction now over the active session buffer.
 - ``restart``: stop and restart the reflexio backend + dashboard services
   (rebuilding the dashboard bundle) so local edits under the ``reflexio``
   submodule or ``plugin/dashboard/`` take effect without restarting Claude
@@ -208,41 +207,25 @@ def cmd_show(args: argparse.Namespace) -> int:
 
 
 def cmd_learn(args: argparse.Namespace) -> int:
-    """Flag the previous turn as a correction and force reflexio extraction.
+    """Force reflexio extraction over the active session's interactions.
 
-    Appends a ``[correction]``-prefixed user turn to the active session's
-    JSONL buffer so reflexio's extractor sees the signal, then publishes
-    unpublished interactions with ``force_extraction=True`` so extraction
-    runs immediately rather than at the next batch interval.
+    Publishes unpublished interactions with ``force_extraction=True`` so
+    extraction runs immediately rather than at the next batch interval.
 
     Args:
-        args (argparse.Namespace): Parsed CLI args. Honors ``args.note``
-            (defaults to "the previous answer was wrong" when empty),
-            ``args.session`` (defaults to most-recent), and ``args.project``
-            (defaults to ``ids.resolve_project_id()``).
+        args (argparse.Namespace): Parsed CLI args. Honors ``args.session``
+            (defaults to most-recent) and ``args.project`` (defaults to
+            ``ids.resolve_project_id()``).
 
     Returns:
-        int: 0 on success or no-op (no active session, or correction recorded
-            but nothing to publish), 1 if reflexio is unreachable. When
-            reflexio is unreachable, the ``[correction]`` row is still
-            appended to the local JSONL — only the publish/extraction step
-            is skipped, so the next successful publish drains it.
+        int: 0 on success or no-op (no active session, or nothing to
+            publish), 1 if reflexio is unreachable.
     """
     session_id = args.session or _latest_session_id()
     if not session_id:
         sys.stdout.write("No active claude-smart session buffer found.\n")
         return 0
     project_id = args.project or ids.resolve_project_id()
-    note = args.note or "the previous answer was wrong"
-    state.append(
-        session_id,
-        {
-            "ts": int(time.time()),
-            "role": "User",
-            "content": f"[correction] {note}",
-            "user_id": project_id,
-        },
-    )
     status, count = publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
@@ -251,12 +234,14 @@ def cmd_learn(args: argparse.Namespace) -> int:
     )
     if status == "ok":
         sys.stdout.write(
-            f"Recorded correction on session `{session_id}` and forced extraction "
+            f"Forced extraction on session `{session_id}` "
             f"over {count} interactions.\n"
         )
         return 0
     if status == "nothing":
-        sys.stdout.write(f"Recorded correction on session `{session_id}`.\n")
+        sys.stdout.write(
+            f"No unpublished interactions on session `{session_id}`.\n"
+        )
         return 0
     sys.stdout.write(_REFLEXIO_UNREACHABLE_MSG)
     return 1
@@ -496,9 +481,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
     ln = sub.add_parser(
         "learn",
-        help="Flag the last turn as a correction and force reflexio extraction now",
+        help="Force reflexio extraction over the active session now",
     )
-    ln.add_argument("note", nargs="?", default="", help="Correction description")
     ln.add_argument("--session", help="Session id (defaults to latest)")
     ln.add_argument("--project", help="Override project id")
     ln.set_defaults(func=cmd_learn)

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -22,10 +22,13 @@ Exposes the following subcommands:
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from claude_smart import context_format, ids, publish, state
@@ -45,6 +48,10 @@ _SCRIPTS_DIR = _PLUGIN_ROOT / "scripts"
 _DASHBOARD_DIR = _PLUGIN_ROOT / "dashboard"
 _BACKEND_SCRIPT = _SCRIPTS_DIR / "backend-service.sh"
 _DASHBOARD_SCRIPT = _SCRIPTS_DIR / "dashboard-service.sh"
+_REFLEXIO_DIR = Path.home() / ".reflexio"
+_DEFAULT_STORAGE_ROOT = _REFLEXIO_DIR / "data"
+_REFLEXIO_CONFIG_PATH = _REFLEXIO_DIR / "configs" / "config_self-host-org.json"
+_LOCAL_STORAGE_ENV = "LOCAL_STORAGE_PATH"
 
 
 def _latest_session_id() -> str | None:
@@ -234,14 +241,11 @@ def cmd_learn(args: argparse.Namespace) -> int:
     )
     if status == "ok":
         sys.stdout.write(
-            f"Forced extraction on session `{session_id}` "
-            f"over {count} interactions.\n"
+            f"Forced extraction on session `{session_id}` over {count} interactions.\n"
         )
         return 0
     if status == "nothing":
-        sys.stdout.write(
-            f"No unpublished interactions on session `{session_id}`.\n"
-        )
+        sys.stdout.write(f"No unpublished interactions on session `{session_id}`.\n")
         return 0
     sys.stdout.write(_REFLEXIO_UNREACHABLE_MSG)
     return 1
@@ -295,6 +299,219 @@ def _service_status(script: Path, wait_ready_s: float = 3.0) -> str:
         if status != "not running" or time.monotonic() >= deadline:
             return status
         time.sleep(0.2)
+
+
+class _ClearAllError(RuntimeError):
+    """Raised when a destructive clear-all target is unsafe or unsupported."""
+
+
+@dataclass(frozen=True)
+class _ClearAllTarget:
+    """One filesystem target removed by ``clear-all``."""
+
+    path: Path
+    kind: str
+    label: str
+
+
+def _is_running_status(status: str) -> bool:
+    return status.startswith("running on ")
+
+
+def _read_dotenv_value(env_path: Path, key: str) -> str | None:
+    """Read one simple KEY=VALUE binding from a dotenv file."""
+    if not env_path.is_file():
+        return None
+    try:
+        lines = env_path.read_text().splitlines()
+    except OSError:
+        return None
+    prefix = f"{key}="
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        if not line.startswith(prefix):
+            continue
+        value = line[len(prefix) :].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        return value.strip()
+    return None
+
+
+def _resolve_absolute_path(raw_path: str | Path, *, source: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        raise _ClearAllError(f"{source} must be an absolute path: {raw_path}")
+    return path
+
+
+def _effective_storage_root() -> Path:
+    raw = os.environ.get(_LOCAL_STORAGE_ENV, "").strip()
+    if not raw:
+        raw = _read_dotenv_value(_REFLEXIO_ENV_PATH, _LOCAL_STORAGE_ENV) or ""
+    return _resolve_absolute_path(
+        raw or _DEFAULT_STORAGE_ROOT, source=_LOCAL_STORAGE_ENV
+    )
+
+
+def _load_reflexio_config() -> dict[str, object] | None:
+    if not _REFLEXIO_CONFIG_PATH.is_file():
+        return None
+    try:
+        loaded = json.loads(_REFLEXIO_CONFIG_PATH.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise _ClearAllError(
+            f"could not read reflexio config {_REFLEXIO_CONFIG_PATH}: {exc}"
+        ) from exc
+    if not isinstance(loaded, dict):
+        raise _ClearAllError(
+            f"reflexio config {_REFLEXIO_CONFIG_PATH} is not a JSON object"
+        )
+    return loaded
+
+
+def _storage_config_kind(storage_config: dict[str, object]) -> str:
+    if storage_config.get("managed_by") == "platform":
+        return "remote"
+    explicit_type = str(
+        storage_config.get("type") or storage_config.get("storage_type") or ""
+    ).lower()
+    if explicit_type in {"supabase", "postgres"}:
+        return "remote"
+    if explicit_type == "disk":
+        return "disk"
+    if explicit_type == "sqlite":
+        return "sqlite"
+    if (
+        "url" in storage_config
+        and "key" in storage_config
+        and "db_url" in storage_config
+    ):
+        return "remote"
+    if "db_url" in storage_config:
+        return "remote"
+    if "dir_path" in storage_config:
+        return "disk"
+    if "db_path" in storage_config or not storage_config:
+        return "sqlite"
+    raise _ClearAllError(
+        "unsupported reflexio storage_config shape; refusing to delete local data"
+    )
+
+
+def _dangerous_clear_all_paths() -> set[Path]:
+    home = Path.home().resolve(strict=False)
+    reflexio_dir = _resolve_absolute_path(_REFLEXIO_DIR, source="reflexio dir")
+    return {
+        Path("/").resolve(strict=False),
+        home,
+        reflexio_dir.resolve(strict=False),
+        _resolve_absolute_path(
+            reflexio_dir / "configs", source="reflexio configs"
+        ).resolve(strict=False),
+        _PLUGIN_ROOT.resolve(strict=False),
+        _PLUGIN_ROOT.parent.resolve(strict=False),
+    }
+
+
+def _validate_deletion_target(path: Path) -> None:
+    if path.exists() and path.is_symlink():
+        raise _ClearAllError(f"refusing to delete symlink target: {path}")
+    resolved = path.resolve(strict=False)
+    if resolved in _dangerous_clear_all_paths():
+        raise _ClearAllError(f"refusing to delete dangerous path: {resolved}")
+
+
+def _disk_org_targets(base_dir: Path) -> list[_ClearAllTarget]:
+    if base_dir.exists() and base_dir.is_symlink():
+        raise _ClearAllError(
+            f"refusing to inspect symlink disk storage dir: {base_dir}"
+        )
+    if not base_dir.exists():
+        return []
+    if not base_dir.is_dir():
+        raise _ClearAllError(
+            f"configured disk storage path is not a directory: {base_dir}"
+        )
+    targets: list[_ClearAllTarget] = []
+    for child in sorted(base_dir.glob("disk_*")):
+        targets.append(_ClearAllTarget(child, "dir", "disk org data"))
+    return targets
+
+
+def _resolve_clear_all_targets() -> list[_ClearAllTarget]:
+    targets = [
+        _ClearAllTarget(_effective_storage_root(), "dir", "managed local storage root")
+    ]
+
+    config = _load_reflexio_config()
+    storage_config = config.get("storage_config") if config else None
+    if storage_config is not None:
+        if not isinstance(storage_config, dict):
+            raise _ClearAllError("reflexio storage_config is not a JSON object")
+        kind = _storage_config_kind(storage_config)
+        if kind == "remote":
+            raise _ClearAllError(
+                "clear-all only resets local Reflexio storage; "
+                "remote Supabase/Postgres storage is not supported"
+            )
+        if kind == "sqlite":
+            raw_db_path = storage_config.get("db_path")
+            if isinstance(raw_db_path, str) and raw_db_path.strip():
+                db_path = _resolve_absolute_path(
+                    raw_db_path.strip(), source="configured SQLite db_path"
+                )
+                for suffix in ("", "-wal", "-shm", "-journal"):
+                    targets.append(
+                        _ClearAllTarget(
+                            Path(f"{db_path}{suffix}"),
+                            "file",
+                            "configured SQLite data",
+                        )
+                    )
+        elif kind == "disk":
+            raw_dir_path = storage_config.get("dir_path")
+            if not isinstance(raw_dir_path, str) or not raw_dir_path.strip():
+                raise _ClearAllError("configured disk storage is missing dir_path")
+            disk_base = _resolve_absolute_path(
+                raw_dir_path.strip(), source="configured disk dir_path"
+            )
+            targets.extend(_disk_org_targets(disk_base))
+
+    deduped: list[_ClearAllTarget] = []
+    seen: set[Path] = set()
+    for target in targets:
+        _validate_deletion_target(target.path)
+        resolved = target.path.resolve(strict=False)
+        if resolved in seen:
+            continue
+        deduped.append(_ClearAllTarget(resolved, target.kind, target.label))
+        seen.add(resolved)
+    return deduped
+
+
+def _remove_clear_all_target(target: _ClearAllTarget) -> bool:
+    """Remove a target. Returns True when something was actually removed."""
+    path = target.path
+    if not path.exists():
+        return False
+    if target.kind == "dir":
+        if not path.is_dir():
+            raise _ClearAllError(
+                f"expected directory target but found non-directory: {path}"
+            )
+        shutil.rmtree(path)
+        return True
+    if target.kind == "file":
+        if not path.is_file():
+            raise _ClearAllError(f"expected file target but found non-file: {path}")
+        path.unlink()
+        return True
+    raise _ClearAllError(f"unknown clear-all target kind: {target.kind}")
 
 
 def cmd_restart(args: argparse.Namespace) -> int:
@@ -406,31 +623,64 @@ def cmd_restart(args: argparse.Namespace) -> int:
 
 
 def cmd_clear_all(args: argparse.Namespace) -> int:
-    """Delete all interactions, profiles, and user playbooks from reflexio.
+    """Delete all local reflexio data and claude-smart session buffers.
 
-    Also removes local session JSONL buffers under ``state_dir()`` so
-    claude-smart starts from a clean slate. Requires ``--yes`` to proceed.
+    Stops the managed backend first when it is running, wipes local Reflexio
+    data targets, removes local session JSONL buffers under ``state_dir()``,
+    then restarts the backend if it was running before. Requires ``--yes``.
 
     Args:
         args (argparse.Namespace): Parsed CLI args. Honors ``args.yes``
             (skip the confirmation prompt).
 
     Returns:
-        int: 0 on success, 1 if reflexio is unreachable or the user aborts.
+        int: 0 on success, 1 if reset is unsafe, unsupported, or fails.
     """
+    try:
+        targets = _resolve_clear_all_targets()
+    except _ClearAllError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+
     if not args.yes:
+        target_lines = "\n".join(
+            f"  - {target.path} ({target.label})" for target in targets
+        )
         sys.stdout.write(
-            "This will permanently delete ALL interactions, profiles, and "
-            "user playbooks from reflexio, plus local session buffers under "
-            f"{state.state_dir()}.\nRe-run with --yes to confirm.\n"
+            "This will permanently delete ALL local reflexio data at:\n"
+            f"{target_lines}\n"
+            f"and local session buffers under {state.state_dir()}.\n"
+            "If the reflexio backend is running, it will be stopped first "
+            "and restarted afterward.\n"
+            "Re-run with --yes to confirm.\n"
         )
         return 1
 
-    result = Adapter().delete_all()
-    if result is None:
-        sys.stdout.write(_REFLEXIO_UNREACHABLE_MSG)
+    was_running = _is_running_status(_service_status(_BACKEND_SCRIPT, wait_ready_s=0.0))
+    if was_running:
+        sys.stdout.write("Stopping reflexio backend…\n")
+        stop_rc = _run_service(_BACKEND_SCRIPT, "stop")
+        if stop_rc != 0:
+            sys.stderr.write(
+                f"error: reflexio backend failed to stop (exit {stop_rc})\n"
+            )
+            return stop_rc or 1
+        stopped_status = _service_status(_BACKEND_SCRIPT, wait_ready_s=0.0)
+        if _is_running_status(stopped_status):
+            sys.stderr.write(
+                "error: reflexio backend is still running after stop; "
+                "aborting without deleting data\n"
+            )
+            return 1
+
+    removed_targets = 0
+    try:
+        for target in targets:
+            if _remove_clear_all_target(target):
+                removed_targets += 1
+    except (OSError, _ClearAllError) as exc:
+        sys.stderr.write(f"error: could not remove reflexio data: {exc}\n")
         return 1
-    counts, errors = result
 
     removed_buffers = 0
     root = state.state_dir()
@@ -442,16 +692,36 @@ def cmd_clear_all(args: argparse.Namespace) -> int:
             except OSError as exc:
                 sys.stderr.write(f"warning: could not remove {buf}: {exc}\n")
 
+    start_rc = 0
+    backend_status = "not running"
+    if was_running:
+        sys.stdout.write("Starting reflexio backend…\n")
+        start_rc = _run_service(_BACKEND_SCRIPT, "start")
+        backend_status = _service_status(_BACKEND_SCRIPT)
+        if start_rc != 0:
+            sys.stderr.write(
+                f"error: reflexio backend failed to start (exit {start_rc})\n"
+            )
+        elif not _is_running_status(backend_status):
+            sys.stderr.write(
+                f"error: reflexio backend did not report running: {backend_status}\n"
+            )
+            start_rc = 1
+
+    target_summary = (
+        f"removed {removed_targets} data target(s)"
+        if removed_targets
+        else "nothing to wipe"
+    )
     sys.stdout.write(
-        "Cleared reflexio: "
-        f"{counts.get('interactions', 0)} interactions, "
-        f"{counts.get('profiles', 0)} profiles, "
-        f"{counts.get('user_playbooks', 0)} user playbooks. "
+        f"Cleared reflexio: {target_summary}. "
         f"Removed {removed_buffers} local session buffer(s).\n"
     )
-    for entity, err in errors:
-        sys.stderr.write(f"warning: delete {entity} failed: {err}\n")
-    return 1 if errors else 0
+    if was_running:
+        sys.stdout.write(f"reflexio backend: {backend_status}\n")
+    else:
+        sys.stdout.write("reflexio backend was not running; left stopped.\n")
+    return start_rc or 0
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -489,7 +759,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     ca = sub.add_parser(
         "clear-all",
-        help="Delete all interactions, profiles, and user playbooks from reflexio",
+        help="Delete all local reflexio data and restart the backend",
     )
     ca.add_argument(
         "--yes",

--- a/plugin/src/claude_smart/events/session_start.py
+++ b/plugin/src/claude_smart/events/session_start.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
 from claude_smart import context_format, cs_cite, hook, ids, state
@@ -15,6 +17,8 @@ from claude_smart.reflexio_adapter import Adapter
 # on every SessionStart via Adapter.apply_extraction_defaults.
 _CLAUDE_SMART_WINDOW_SIZE = 5
 _CLAUDE_SMART_STRIDE_SIZE = 3
+_ENABLE_OPTIMIZER_ENV = "CLAUDE_SMART_ENABLE_OPTIMIZER"
+_OPTIMIZER_TIMEOUT_SECONDS = 300
 
 
 def handle(payload: dict[str, Any]) -> None:
@@ -30,6 +34,11 @@ def handle(payload: dict[str, Any]) -> None:
         window_size=_CLAUDE_SMART_WINDOW_SIZE,
         stride_size=_CLAUDE_SMART_STRIDE_SIZE,
     )
+    if os.environ.get(_ENABLE_OPTIMIZER_ENV) == "1":
+        adapter.apply_optimizer_defaults(
+            script_path=_optimizer_assistant_path(),
+            timeout_seconds=_OPTIMIZER_TIMEOUT_SECONDS,
+        )
     playbooks, profiles = adapter.fetch_both(
         project_id=project_id,
         playbook_top_k=1,
@@ -62,3 +71,9 @@ def handle(payload: dict[str, Any]) -> None:
         )
     )
     sys.stdout.write("\n")
+
+
+def _optimizer_assistant_path() -> str:
+    executable = Path(sys.executable)
+    suffix = ".exe" if os.name == "nt" else ""
+    return str(executable.with_name(f"claude-smart-optimizer-assistant{suffix}"))

--- a/plugin/src/claude_smart/optimizer_assistant.py
+++ b/plugin/src/claude_smart/optimizer_assistant.py
@@ -1,0 +1,205 @@
+"""Local-script assistant backend for Reflexio playbook optimization.
+
+Reflexio's ``LocalScriptAssistant`` sends one JSON payload on stdin and expects
+one JSON object on stdout. This module bridges that protocol to a guarded
+``claude -p`` subprocess so candidate playbooks can be evaluated against Claude
+Code without re-entering claude-smart/reflexio hooks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+from claude_smart import internal_call
+
+_ENV_ENABLE_OPTIMIZER = "CLAUDE_SMART_ENABLE_OPTIMIZER"
+_CLAUDE_TIMEOUT_SECONDS = 300
+_READ_ONLY_TOOLS = "Read,Grep,Glob,LS"
+_MUTATING_TOOLS = "Bash,Edit,Write,MultiEdit,NotebookEdit"
+
+
+class OptimizerAssistantError(Exception):
+    """Raised for any local assistant protocol or Claude CLI failure."""
+
+
+def main() -> int:
+    """Console-script entrypoint for ``claude-smart-optimizer-assistant``."""
+    try:
+        payload = _read_payload()
+        messages = _validated_list(payload, "messages")
+        playbooks = _validated_list(payload, "playbooks")
+        prompt, system_prompt = _build_prompt(messages, playbooks)
+        content = _run_claude(prompt=prompt, system_prompt=system_prompt)
+    except Exception as exc:  # noqa: BLE001 - script errors become LocalScript failures.
+        sys.stderr.write(f"{type(exc).__name__}: {exc}\n")
+        return 1
+
+    json.dump({"content": content}, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _read_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise OptimizerAssistantError("stdin must be a JSON object") from exc
+    if not isinstance(payload, dict):
+        raise OptimizerAssistantError("stdin must be a JSON object")
+    return payload
+
+
+def _validated_list(payload: dict[str, Any], field: str) -> list[Any]:
+    value = payload.get(field)
+    if not isinstance(value, list):
+        raise OptimizerAssistantError(f"payload.{field} must be a list")
+    return value
+
+
+def _build_prompt(messages: list[Any], playbooks: list[Any]) -> tuple[str, str]:
+    normalized = [_normalize_message(message) for message in messages]
+    normalized = [message for message in normalized if message["content"]]
+    if not normalized:
+        raise OptimizerAssistantError("payload.messages must contain content")
+
+    final_message = normalized[-1]
+    prior_messages = normalized[:-1]
+
+    system_sections = [_render_playbooks(playbooks)]
+    existing_system = [
+        message["content"] for message in normalized if message["role"] == "system"
+    ]
+    if existing_system:
+        system_sections.append(
+            "## Existing system context\n" + "\n\n".join(existing_system)
+        )
+
+    prior_dialogue = [
+        message
+        for message in prior_messages
+        if message["role"] in {"user", "assistant"}
+    ]
+    if prior_dialogue:
+        system_sections.append(
+            "## Conversation so far\n" + _render_transcript(prior_dialogue)
+        )
+
+    prompt = final_message["content"]
+    if final_message["role"] != "user":
+        prompt = _render_transcript([final_message])
+    system_prompt = "\n\n".join(section for section in system_sections if section)
+    return prompt, system_prompt
+
+
+def _normalize_message(message: Any) -> dict[str, str]:
+    if not isinstance(message, dict):
+        raise OptimizerAssistantError("each message must be an object")
+    role = str(message.get("role") or "user").strip().lower()
+    if role not in {"user", "assistant", "system"}:
+        role = "user"
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise OptimizerAssistantError("each message.content must be a string")
+    return {"role": role, "content": content.strip()}
+
+
+def _render_playbooks(playbooks: list[Any]) -> str:
+    if not playbooks:
+        return ""
+    lines = ["## Candidate playbook rules"]
+    for index, playbook in enumerate(playbooks, start=1):
+        if not isinstance(playbook, dict):
+            raise OptimizerAssistantError("each playbook must be an object")
+        content = playbook.get("content")
+        if not isinstance(content, str) or not content.strip():
+            raise OptimizerAssistantError("each playbook.content must be a string")
+        trigger = playbook.get("trigger")
+        suffix = ""
+        if isinstance(trigger, str) and trigger.strip():
+            suffix = f" (when: {trigger.strip()})"
+        lines.append(f"{index}. {content.strip()}{suffix}")
+    return "\n".join(lines)
+
+
+def _render_transcript(messages: list[dict[str, str]]) -> str:
+    labels = {"user": "User", "assistant": "Assistant", "system": "System"}
+    return "\n\n".join(
+        f"{labels.get(message['role'], 'User')}: {message['content']}"
+        for message in messages
+    )
+
+
+def _run_claude(*, prompt: str, system_prompt: str) -> str:
+    cli_path = shutil.which("claude") or "claude"
+    # This is an evaluation rollout, not a real user session: allow local
+    # inspection, but prevent filesystem, shell, MCP, and session mutations.
+    cmd = [
+        cli_path,
+        "-p",
+        "--output-format",
+        "json",
+        "--permission-mode",
+        "plan",
+        "--tools",
+        _READ_ONLY_TOOLS,
+        "--disallowedTools",
+        _MUTATING_TOOLS,
+        "--no-session-persistence",
+        "--mcp-config",
+        '{"mcpServers": {}}',
+        "--strict-mcp-config",
+    ]
+    if system_prompt:
+        cmd.extend(["--append-system-prompt", system_prompt])
+
+    env = os.environ.copy()
+    env[internal_call._ENV_MARKER] = "1"  # noqa: SLF001 - shared guard constant.
+    env[internal_call._ENTRYPOINT_VAR] = "optimizer"  # noqa: SLF001
+    env[_ENV_ENABLE_OPTIMIZER] = "0"
+
+    try:
+        proc = subprocess.run(  # noqa: S603 - command is fixed plus resolved executable.
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=_CLAUDE_TIMEOUT_SECONDS,
+            check=False,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise OptimizerAssistantError(
+            f"claude CLI timed out after {_CLAUDE_TIMEOUT_SECONDS}s"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise OptimizerAssistantError("claude CLI not found on PATH") from exc
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise OptimizerAssistantError(
+            f"claude CLI exited {proc.returncode}: {stderr[:500]}"
+        )
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise OptimizerAssistantError("claude CLI returned non-JSON output") from exc
+    if not isinstance(data, dict):
+        raise OptimizerAssistantError("claude CLI JSON output must be an object")
+
+    content = data.get("result")
+    if not isinstance(content, str):
+        content = data.get("response")
+    if not isinstance(content, str):
+        raise OptimizerAssistantError("claude CLI JSON output missing result/response")
+    return content
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -88,39 +88,6 @@ class Adapter:
             _LOGGER.warning("publish_interaction failed: %s", exc)
             return False
 
-    def delete_all(self) -> tuple[dict[str, int], list[tuple[str, str]]] | None:
-        """Delete all interactions, profiles, and user playbooks from reflexio.
-
-        Returns:
-            tuple[dict[str, int], list[tuple[str, str]]] | None: A
-                ``(counts, errors)`` pair on reachable reflexio, or ``None``
-                if the client could not be constructed at all. ``counts``
-                maps entity name → deleted row count (``0`` for entities
-                whose delete raised). ``errors`` is a list of
-                ``(entity_name, exception_message)`` tuples for every
-                individual failure, so the caller can distinguish "deleted
-                nothing" from "delete raised" and surface it to the user.
-        """
-        client = self._get_client()
-        if client is None:
-            return None
-        counts: dict[str, int] = {}
-        errors: list[tuple[str, str]] = []
-        for name, method in (
-            ("interactions", "delete_all_interactions"),
-            ("profiles", "delete_all_profiles"),
-            ("user_playbooks", "delete_all_user_playbooks"),
-        ):
-            try:
-                response = getattr(client, method)()
-            except Exception as exc:  # noqa: BLE001 — adapter must never raise.
-                _LOGGER.warning("%s failed: %s", method, exc)
-                counts[name] = 0
-                errors.append((name, str(exc)))
-                continue
-            counts[name] = getattr(response, "deleted_count", 0) or 0
-        return counts, errors
-
     def apply_extraction_defaults(self, *, window_size: int, stride_size: int) -> bool:
         """Push claude-smart's preferred extraction defaults to the reflexio server.
 
@@ -160,6 +127,46 @@ class Adapter:
             return True
         except Exception as exc:  # noqa: BLE001 — adapter must never raise.
             _LOGGER.warning("apply_extraction_defaults failed: %s", exc)
+            return False
+
+    def apply_optimizer_defaults(
+        self, *, script_path: str, timeout_seconds: int = 300
+    ) -> bool:
+        """Push claude-smart's opt-in playbook optimizer defaults to reflexio.
+
+        The caller is responsible for gating this behind
+        ``CLAUDE_SMART_ENABLE_OPTIMIZER=1``. This method only performs an
+        idempotent compare-then-write against reflexio's config.
+        """
+        client = self._get_client()
+        if client is None:
+            return False
+        try:
+            config = client.get_config()
+            opt = getattr(config, "playbook_optimizer_config", None)
+            if opt is None:
+                return False
+
+            desired = {
+                "enabled": True,
+                "optimize_user_playbooks": True,
+                "optimize_agent_playbooks": False,
+                "auto_update_user_playbooks": True,
+                "min_commit_windows": 1,
+                "max_metric_calls": 5,
+                "assistant_script_path": script_path,
+                "assistant_script_args": [],
+                "webhook_url": None,
+                "webhook_timeout_seconds": timeout_seconds,
+            }
+            if all(getattr(opt, key, None) == value for key, value in desired.items()):
+                return True
+            for key, value in desired.items():
+                setattr(opt, key, value)
+            client.set_config(config)
+            return True
+        except Exception as exc:  # noqa: BLE001 — adapter must never raise.
+            _LOGGER.warning("apply_optimizer_defaults failed: %s", exc)
             return False
 
     # -----------------------------------------------------------------

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -434,7 +434,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "chromadb", specifier = ">=0.5" },
-    { name = "reflexio-ai", specifier = ">=0.2.20" },
+    { name = "reflexio-ai", specifier = ">=0.2.21" },
 ]
 
 [package.metadata.requires-dev]
@@ -1158,6 +1158,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "json-repair"
+version = "0.59.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/67/eba7fad54ff6f5cce6db4e01f596fc68156b5c7e864af0aa07ad48e880a1/json_repair-0.59.5.tar.gz", hash = "sha256:bb886ee054e99066be8a337b67a986b6a50d79be9a5ad37ae81966e698990784", size = 48632, upload-time = "2026-04-24T11:41:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/aa/0529dee460b745b93f6abc97b56b7527314c5167ba29ab7a5bd5c08de01f/json_repair-0.59.5-py3-none-any.whl", hash = "sha256:6869965bd1cc1aaaa04dc85865c26fbb76d9a2d83a20010f5eae2563b1567827", size = 47282, upload-time = "2026-04-24T11:41:36.653Z" },
 ]
 
 [[package]]
@@ -2598,7 +2607,7 @@ wheels = [
 
 [[package]]
 name = "reflexio-ai"
-version = "0.2.20"
+version = "0.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2612,6 +2621,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "hdbscan" },
     { name = "httpx" },
+    { name = "json-repair" },
     { name = "litellm" },
     { name = "nltk" },
     { name = "openai" },
@@ -2633,9 +2643,9 @@ dependencies = [
     { name = "websocket-client" },
     { name = "xlsxwriter" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/b2/3fc4d63fba1b554e1009382052a9201a2df448de33dbe48f9520a90e080d/reflexio_ai-0.2.20.tar.gz", hash = "sha256:cef108a9f3654be2b70ebfee2b4d4fedf8df120504204bc2781e3f93540b9b30", size = 646967, upload-time = "2026-05-03T18:31:52.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/f5/8e0f08be5aee55425fa31f5b888e8f2f45c6d27f0fa69b2c46bdc0df878c/reflexio_ai-0.2.21.tar.gz", hash = "sha256:758b132b562f4aa18c7dd42136e0cc7b2cd0c3881364960078d504fa61fdad0d", size = 650558, upload-time = "2026-05-06T16:49:39.356Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/dd/44c706b4cd95842283557bb22b23dd0813c60c223e32d1a43de7e2b1cca2/reflexio_ai-0.2.20-py3-none-any.whl", hash = "sha256:a86485896569311a28137ef92cab595d5c87bba69a80dc96839a1f8da3b68198", size = 868958, upload-time = "2026-05-03T18:31:53.891Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7d/5708a4d7062ec0cef90cc0b2c8fda7ed3c61cfdc2cf292bde66a50f58014/reflexio_ai-0.2.21-py3-none-any.whl", hash = "sha256:cd79513502ad7a4e30f7a70dc6a8bcdc2d10337608d4db628b90f36c5c6a51d5", size = 872892, upload-time = "2026-05-06T16:49:37.57Z" },
 ]
 
 [[package]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,9 @@ def session_dir(tmp_path, monkeypatch):
     """Redirect the state dir to a per-test tmp path."""
     monkeypatch.setenv("CLAUDE_SMART_STATE_DIR", str(tmp_path))
     return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def clear_optimizer_opt_in(monkeypatch):
+    """Keep env-gated optimizer setup from leaking into unrelated tests."""
+    monkeypatch.delenv("CLAUDE_SMART_ENABLE_OPTIMIZER", raising=False)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -285,3 +285,94 @@ def test_apply_extraction_defaults_absorbs_get_config_errors() -> None:
         _ConfigClient(window_size=10, stride_size=5, get_raises=RuntimeError("down"))
     )
     assert a.apply_extraction_defaults(window_size=5, stride_size=3) is False
+
+
+# -----------------------------------------------------------------------------
+# apply_optimizer_defaults — opt-in Reflexio optimizer wiring
+# -----------------------------------------------------------------------------
+
+
+class _OptimizerConfigClient:
+    def __init__(self, *, opt=None, get_raises=None):
+        self._config = SimpleNamespace(
+            playbook_optimizer_config=opt
+            or SimpleNamespace(
+                enabled=False,
+                optimize_user_playbooks=False,
+                optimize_agent_playbooks=True,
+                auto_update_user_playbooks=False,
+                min_commit_windows=2,
+                assistant_script_path=None,
+                assistant_script_args=["old"],
+                webhook_url="https://example.test/assistant",
+                webhook_timeout_seconds=60,
+            )
+        )
+        self._get_raises = get_raises
+        self.set_calls: list[Any] = []
+
+    def get_config(self):
+        if self._get_raises is not None:
+            raise self._get_raises
+        return self._config
+
+    def set_config(self, config):
+        self.set_calls.append(config)
+        self._config = config
+        return {"ok": True}
+
+
+def test_apply_optimizer_defaults_writes_required_fields() -> None:
+    client = _OptimizerConfigClient()
+    a = _adapter_with(client)
+
+    assert a.apply_optimizer_defaults(script_path="/venv/bin/assistant") is True
+
+    assert len(client.set_calls) == 1
+    opt = client.set_calls[0].playbook_optimizer_config
+    assert opt.enabled is True
+    assert opt.optimize_user_playbooks is True
+    assert opt.optimize_agent_playbooks is False
+    assert opt.auto_update_user_playbooks is True
+    assert opt.min_commit_windows == 1
+    assert opt.max_metric_calls == 5
+    assert opt.assistant_script_path == "/venv/bin/assistant"
+    assert opt.assistant_script_args == []
+    assert opt.webhook_url is None
+    assert opt.webhook_timeout_seconds == 300
+
+
+def test_apply_optimizer_defaults_skips_set_when_values_match() -> None:
+    opt = SimpleNamespace(
+        enabled=True,
+        optimize_user_playbooks=True,
+        optimize_agent_playbooks=False,
+        auto_update_user_playbooks=True,
+        min_commit_windows=1,
+        max_metric_calls=5,
+        assistant_script_path="/venv/bin/assistant",
+        assistant_script_args=[],
+        webhook_url=None,
+        webhook_timeout_seconds=300,
+    )
+    client = _OptimizerConfigClient(opt=opt)
+    a = _adapter_with(client)
+
+    assert a.apply_optimizer_defaults(script_path="/venv/bin/assistant") is True
+
+    assert client.set_calls == []
+
+
+def test_apply_optimizer_defaults_returns_false_when_client_unavailable(
+    monkeypatch,
+) -> None:
+    a = reflexio_adapter.Adapter()
+    monkeypatch.setattr(a, "_get_client", lambda: None)
+
+    assert a.apply_optimizer_defaults(script_path="/venv/bin/assistant") is False
+
+
+def test_apply_optimizer_defaults_absorbs_get_config_errors() -> None:
+    a = _adapter_with(_OptimizerConfigClient(get_raises=RuntimeError("down")))
+
+    assert a.apply_optimizer_defaults(script_path="/venv/bin/assistant") is False

--- a/tests/test_cli_clear_all.py
+++ b/tests/test_cli_clear_all.py
@@ -1,0 +1,299 @@
+"""Tests for ``claude_smart.cli.cmd_clear_all``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from claude_smart import cli
+
+
+def _args(*, yes: bool) -> argparse.Namespace:
+    return argparse.Namespace(yes=yes)
+
+
+@pytest.fixture
+def clear_all_harness(monkeypatch, tmp_path):
+    """Isolate clear-all paths and service calls from the real user machine."""
+    reflexio_dir = tmp_path / "reflexio"
+    env_path = reflexio_dir / ".env"
+    config_path = reflexio_dir / "configs" / "config_self-host-org.json"
+    plugin_root = tmp_path / "plugin"
+    backend_script = plugin_root / "scripts" / "backend-service.sh"
+    backend_script.parent.mkdir(parents=True)
+    backend_script.write_text("#!/bin/sh\n")
+    plugin_root.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(cli, "_REFLEXIO_DIR", reflexio_dir)
+    monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
+    monkeypatch.setattr(cli, "_DEFAULT_STORAGE_ROOT", reflexio_dir / "data")
+    monkeypatch.setattr(cli, "_REFLEXIO_CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_PLUGIN_ROOT", plugin_root)
+    monkeypatch.setattr(cli, "_BACKEND_SCRIPT", backend_script)
+    monkeypatch.setenv("CLAUDE_SMART_STATE_DIR", str(tmp_path / "sessions"))
+    monkeypatch.delenv("LOCAL_STORAGE_PATH", raising=False)
+
+    calls: list[tuple[str, str]] = []
+    statuses: list[str] = ["not running"]
+
+    def fake_status(_script: Path, wait_ready_s: float = 3.0) -> str:  # noqa: ARG001
+        return statuses.pop(0) if statuses else "not running"
+
+    def fake_run_service(script: Path, subcmd: str) -> int:
+        calls.append((script.name, subcmd))
+        return 0
+
+    monkeypatch.setattr(cli, "_service_status", fake_status)
+    monkeypatch.setattr(cli, "_run_service", fake_run_service)
+
+    def write_config(storage_config: dict[str, Any]) -> None:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"storage_config": storage_config}))
+
+    return {
+        "tmp": tmp_path,
+        "reflexio_dir": reflexio_dir,
+        "env_path": env_path,
+        "config_path": config_path,
+        "storage_root": reflexio_dir / "data",
+        "state_dir": tmp_path / "sessions",
+        "calls": calls,
+        "statuses": statuses,
+        "write_config": write_config,
+    }
+
+
+def test_clear_all_without_yes_is_noop(clear_all_harness, capsys) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    (root / "reflexio.db").write_text("db")
+    state_dir = clear_all_harness["state_dir"]
+    state_dir.mkdir()
+    (state_dir / "session.jsonl").write_text("{}\n")
+
+    rc = cli.cmd_clear_all(_args(yes=False))
+
+    assert rc == 1
+    assert root.exists()
+    assert (state_dir / "session.jsonl").exists()
+    assert clear_all_harness["calls"] == []
+    assert "Re-run with --yes" in capsys.readouterr().out
+
+
+def test_clear_all_deletes_default_storage_root_from_env(
+    clear_all_harness, monkeypatch
+) -> None:
+    root = clear_all_harness["tmp"] / "custom-data"
+    root.mkdir()
+    (root / "reflexio.db").write_text("db")
+    state_dir = clear_all_harness["state_dir"]
+    state_dir.mkdir()
+    (state_dir / "session.jsonl").write_text("{}\n")
+    (state_dir / "keep.txt").write_text("keep")
+    monkeypatch.setenv("LOCAL_STORAGE_PATH", str(root))
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 0
+    assert not root.exists()
+    assert not (state_dir / "session.jsonl").exists()
+    assert (state_dir / "keep.txt").exists()
+
+
+def test_clear_all_reads_default_storage_root_from_reflexio_env(
+    clear_all_harness,
+) -> None:
+    root = clear_all_harness["tmp"] / "env-data"
+    root.mkdir()
+    (root / "reflexio.db").write_text("db")
+    env_path = clear_all_harness["env_path"]
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text(f'LOCAL_STORAGE_PATH="{root}"\n')
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 0
+    assert not root.exists()
+
+
+def test_clear_all_missing_storage_root_is_success(clear_all_harness, capsys) -> None:
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 0
+    assert "nothing to wipe" in capsys.readouterr().out
+
+
+def test_clear_all_stops_and_restarts_running_backend(clear_all_harness) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    (root / "reflexio.db").write_text("db")
+    clear_all_harness["statuses"][:] = [
+        "running on http://localhost:8071",
+        "not running",
+        "running on http://localhost:8071",
+    ]
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 0
+    assert clear_all_harness["calls"] == [
+        ("backend-service.sh", "stop"),
+        ("backend-service.sh", "start"),
+    ]
+    assert not root.exists()
+
+
+def test_clear_all_aborts_when_backend_stop_fails(
+    clear_all_harness, monkeypatch, capsys
+) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    clear_all_harness["statuses"][:] = ["running on http://localhost:8071"]
+
+    def fake_run_service(_script: Path, subcmd: str) -> int:
+        clear_all_harness["calls"].append(("backend-service.sh", subcmd))
+        return 7 if subcmd == "stop" else 0
+
+    monkeypatch.setattr(cli, "_run_service", fake_run_service)
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 7
+    assert root.exists()
+    assert clear_all_harness["calls"] == [("backend-service.sh", "stop")]
+    assert "failed to stop" in capsys.readouterr().err
+
+
+def test_clear_all_aborts_when_backend_still_running(clear_all_harness, capsys) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    clear_all_harness["statuses"][:] = [
+        "running on http://localhost:8071",
+        "running on http://localhost:8071",
+    ]
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 1
+    assert root.exists()
+    assert clear_all_harness["calls"] == [("backend-service.sh", "stop")]
+    assert "still running" in capsys.readouterr().err
+
+
+def test_clear_all_reports_start_failure_after_wipe(
+    clear_all_harness, monkeypatch, capsys
+) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    clear_all_harness["statuses"][:] = [
+        "running on http://localhost:8071",
+        "not running",
+        "not running",
+    ]
+
+    def fake_run_service(_script: Path, subcmd: str) -> int:
+        clear_all_harness["calls"].append(("backend-service.sh", subcmd))
+        return 9 if subcmd == "start" else 0
+
+    monkeypatch.setattr(cli, "_run_service", fake_run_service)
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 9
+    assert not root.exists()
+    assert "failed to start" in capsys.readouterr().err
+
+
+def test_clear_all_deletes_custom_sqlite_sidecars(clear_all_harness) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    db_path = clear_all_harness["tmp"] / "sqlite" / "custom.db"
+    db_path.parent.mkdir()
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        Path(f"{db_path}{suffix}").write_text("db")
+    clear_all_harness["write_config"]({"db_path": str(db_path)})
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 0
+    assert not root.exists()
+    assert db_path.parent.exists()
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        assert not Path(f"{db_path}{suffix}").exists()
+
+
+def test_clear_all_deletes_custom_disk_org_dirs_only(clear_all_harness) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    disk_base = clear_all_harness["tmp"] / "disk-store"
+    disk_org = disk_base / "disk_self-host-org"
+    other = disk_base / "not-reflexio"
+    disk_org.mkdir(parents=True)
+    other.mkdir()
+    (disk_org / "entity.md").write_text("x")
+    (other / "keep.txt").write_text("keep")
+    clear_all_harness["write_config"]({"dir_path": str(disk_base)})
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 0
+    assert not root.exists()
+    assert disk_base.exists()
+    assert not disk_org.exists()
+    assert other.exists()
+    assert clear_all_harness["config_path"].exists()
+
+
+def test_clear_all_refuses_remote_storage_config(clear_all_harness, capsys) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    state_dir = clear_all_harness["state_dir"]
+    state_dir.mkdir()
+    (state_dir / "session.jsonl").write_text("{}\n")
+    clear_all_harness["write_config"](
+        {"type": "postgres", "db_url": "postgres://example/db"}
+    )
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 1
+    assert root.exists()
+    assert (state_dir / "session.jsonl").exists()
+    assert clear_all_harness["calls"] == []
+    assert (
+        "remote Supabase/Postgres storage is not supported" in capsys.readouterr().err
+    )
+
+
+def test_clear_all_refuses_dangerous_storage_root(
+    clear_all_harness, monkeypatch, capsys
+) -> None:
+    reflexio_dir = clear_all_harness["reflexio_dir"]
+    reflexio_dir.mkdir(parents=True)
+    monkeypatch.setenv("LOCAL_STORAGE_PATH", str(reflexio_dir))
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 1
+    assert reflexio_dir.exists()
+    assert "refusing to delete dangerous path" in capsys.readouterr().err
+
+
+def test_clear_all_refuses_symlink_storage_root(
+    clear_all_harness, monkeypatch, tmp_path, capsys
+) -> None:
+    real_root = tmp_path / "real-data"
+    real_root.mkdir()
+    link_root = tmp_path / "linked-data"
+    link_root.symlink_to(real_root, target_is_directory=True)
+    monkeypatch.setenv("LOCAL_STORAGE_PATH", str(link_root))
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 1
+    assert real_root.exists()
+    assert "refusing to delete symlink target" in capsys.readouterr().err

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -1,11 +1,4 @@
-"""Tests for ``claude_smart.cli.cmd_learn``.
-
-The merged ``/learn`` command is the only path users have to mark a turn as
-a correction, so the regressions worth pinning are: the correction row is
-actually written, the default note kicks in for empty input, the no-active-
-session case is a clean no-op, and reflexio being unreachable still leaves
-the local correction on disk for the next drain.
-"""
+"""Tests for ``claude_smart.cli.cmd_learn``."""
 
 from __future__ import annotations
 
@@ -18,21 +11,13 @@ from claude_smart import cli, state
 
 
 def _make_args(**overrides: Any) -> argparse.Namespace:
-    """Build a Namespace matching the ``learn`` subparser defaults."""
-    defaults = {"note": "", "session": None, "project": "test-project"}
+    defaults = {"session": None, "project": "test-project"}
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
 
 
 @pytest.fixture
 def fake_publish(monkeypatch):
-    """Stub ``cli.publish.publish_unpublished`` and capture its kwargs.
-
-    Returns:
-        tuple[list[dict], dict]: ``(calls, control)`` — ``calls`` records
-            each invocation's kwargs in order; ``control`` is mutable so a
-            test can flip the canned ``return_value`` before the call.
-    """
     calls: list[dict[str, Any]] = []
     control: dict[str, Any] = {"return_value": ("ok", 3)}
 
@@ -44,21 +29,16 @@ def fake_publish(monkeypatch):
     return calls, control
 
 
-def test_cmd_learn_records_correction_and_publishes(
+def test_cmd_learn_publishes_with_force_extraction(
     session_dir, fake_publish, capsys
 ) -> None:
-    """Happy path: correction row appended, publish called, exit 0."""
     state.append("s1", {"role": "User", "content": "hi"})
-    state.append("s1", {"role": "Assistant", "content": "wrong answer"})
+    state.append("s1", {"role": "Assistant", "content": "answer"})
     calls, _ = fake_publish
 
-    rc = cli.cmd_learn(_make_args(note="please don't do that"))
+    rc = cli.cmd_learn(_make_args())
 
     assert rc == 0
-    records = state.read_all("s1")
-    assert records[-1]["role"] == "User"
-    assert records[-1]["content"] == "[correction] please don't do that"
-    assert records[-1]["user_id"] == "test-project"
     assert calls == [
         {
             "session_id": "s1",
@@ -68,25 +48,24 @@ def test_cmd_learn_records_correction_and_publishes(
         }
     ]
     out = capsys.readouterr().out
-    assert "Recorded correction on session `s1`" in out
-    assert "forced extraction" in out
+    assert "Forced extraction on session `s1`" in out
 
 
-def test_cmd_learn_default_note_when_empty(session_dir, fake_publish) -> None:
-    """Empty note → the literal default string is what extraction sees."""
+def test_cmd_learn_does_not_append_synthetic_turn(session_dir, fake_publish) -> None:
     state.append("s1", {"role": "User", "content": "hi"})
+    state.append("s1", {"role": "Assistant", "content": "answer"})
 
-    rc = cli.cmd_learn(_make_args(note=""))
+    rc = cli.cmd_learn(_make_args())
 
     assert rc == 0
-    last = state.read_all("s1")[-1]
-    assert last["content"] == "[correction] the previous answer was wrong"
+    records = state.read_all("s1")
+    assert len(records) == 2
+    assert all("[correction]" not in (r.get("content") or "") for r in records)
 
 
 def test_cmd_learn_no_active_session_returns_zero(
     session_dir, fake_publish, capsys
 ) -> None:
-    """Empty state dir → message + exit 0; no JSONL created, no publish call."""
     calls, _ = fake_publish
 
     rc = cli.cmd_learn(_make_args())
@@ -97,18 +76,28 @@ def test_cmd_learn_no_active_session_returns_zero(
     assert "No active claude-smart session buffer found" in capsys.readouterr().out
 
 
-def test_cmd_learn_reflexio_unreachable_still_persists_correction(
+def test_cmd_learn_reflexio_unreachable_returns_one(
     session_dir, fake_publish, capsys
 ) -> None:
-    """Publish ``failed`` → correction row stays on disk, exit 1."""
     state.append("s1", {"role": "User", "content": "hi"})
-    state.append("s1", {"role": "Assistant", "content": "wrong"})
+    state.append("s1", {"role": "Assistant", "content": "answer"})
     _, control = fake_publish
     control["return_value"] = ("failed", 2)
 
-    rc = cli.cmd_learn(_make_args(note="bad answer"))
+    rc = cli.cmd_learn(_make_args())
 
     assert rc == 1
-    last = state.read_all("s1")[-1]
-    assert last["content"] == "[correction] bad answer"
     assert "Failed to reach reflexio" in capsys.readouterr().out
+
+
+def test_cmd_learn_nothing_to_publish_returns_zero(
+    session_dir, fake_publish, capsys
+) -> None:
+    state.append("s1", {"role": "User", "content": "hi"})
+    _, control = fake_publish
+    control["return_value"] = ("nothing", 0)
+
+    rc = cli.cmd_learn(_make_args())
+
+    assert rc == 0
+    assert "No unpublished interactions on session `s1`" in capsys.readouterr().out

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1287,6 +1287,75 @@ def test_session_start_applies_claude_smart_extraction_defaults(
     assert applied == [{"window_size": 5, "stride_size": 3}]
 
 
+def test_session_start_does_not_apply_optimizer_defaults_without_opt_in(
+    session_dir, monkeypatch
+) -> None:
+    optimizer_calls: list[dict[str, Any]] = []
+
+    class Stub:
+        def apply_extraction_defaults(self, **_kw):
+            return True
+
+        def apply_optimizer_defaults(self, **kwargs):
+            optimizer_calls.append(kwargs)
+            return True
+
+        def fetch_both(self, **_kw):
+            return ([], [])
+
+    monkeypatch.setattr(
+        "claude_smart.events.session_start.Adapter", lambda *a, **kw: Stub()
+    )
+    monkeypatch.setattr(
+        "claude_smart.events.session_start.ids.resolve_project_id",
+        lambda *_a, **_kw: "demo",
+    )
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+
+    session_start.handle({"session_id": "s1", "source": "startup"})
+
+    assert optimizer_calls == []
+
+
+def test_session_start_applies_optimizer_defaults_when_opted_in(
+    session_dir, monkeypatch
+) -> None:
+    optimizer_calls: list[dict[str, Any]] = []
+
+    class Stub:
+        def apply_extraction_defaults(self, **_kw):
+            return True
+
+        def apply_optimizer_defaults(self, **kwargs):
+            optimizer_calls.append(kwargs)
+            return True
+
+        def fetch_both(self, **_kw):
+            return ([], [])
+
+    monkeypatch.setenv("CLAUDE_SMART_ENABLE_OPTIMIZER", "1")
+    monkeypatch.setattr(session_start.sys, "executable", "/tmp/venv/bin/python")
+    monkeypatch.setattr(
+        "claude_smart.events.session_start.Adapter", lambda *a, **kw: Stub()
+    )
+    monkeypatch.setattr(
+        "claude_smart.events.session_start.ids.resolve_project_id",
+        lambda *_a, **_kw: "demo",
+    )
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+
+    session_start.handle({"session_id": "s1", "source": "startup"})
+
+    assert optimizer_calls == [
+        {
+            "script_path": "/tmp/venv/bin/claude-smart-optimizer-assistant",
+            "timeout_seconds": 300,
+        }
+    ]
+
+
 def test_session_start_fetches_both_on_every_source(session_dir, monkeypatch) -> None:
     """Used to skip profile fetch unless source ∈ {resume,clear,compact}; now always both."""
     calls: list[dict[str, Any]] = []

--- a/tests/test_optimizer_assistant.py
+++ b/tests/test_optimizer_assistant.py
@@ -1,0 +1,163 @@
+"""Tests for the Reflexio LocalScriptAssistant bridge."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from claude_smart import optimizer_assistant
+
+
+def _run_main(monkeypatch, payload):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    raw = payload if isinstance(payload, str) else json.dumps(payload)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(raw))
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    rc = optimizer_assistant.main()
+    return rc, stdout.getvalue(), stderr.getvalue()
+
+
+@pytest.mark.parametrize("key", ["result", "response"])
+def test_optimizer_assistant_invokes_claude_and_emits_content(monkeypatch, key) -> None:
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({key: "assistant reply"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which", lambda _: "/bin/claude"
+    )
+    monkeypatch.setattr("claude_smart.optimizer_assistant.subprocess.run", fake_run)
+
+    rc, stdout, stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "seen"},
+                {"role": "user", "content": "answer now"},
+            ],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": "summaries"}],
+        },
+    )
+
+    assert rc == 0
+    assert stderr == ""
+    assert json.loads(stdout) == {"content": "assistant reply"}
+    cmd, kwargs = calls[0]
+    assert cmd[:3] == ["/bin/claude", "-p", "--output-format"]
+    assert cmd[cmd.index("--permission-mode") + 1] == "plan"
+    assert cmd[cmd.index("--tools") + 1] == "Read,Grep,Glob,LS"
+    assert (
+        cmd[cmd.index("--disallowedTools") + 1]
+        == "Bash,Edit,Write,MultiEdit,NotebookEdit"
+    )
+    assert "--no-session-persistence" in cmd
+    assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers": {}}'
+    assert "--strict-mcp-config" in cmd
+    assert "--dangerously-skip-permissions" not in cmd
+    assert "--allow-dangerously-skip-permissions" not in cmd
+    assert kwargs["input"] == "answer now"
+    assert kwargs["env"]["CLAUDE_SMART_INTERNAL"] == "1"
+    assert kwargs["env"]["CLAUDE_CODE_ENTRYPOINT"] == "optimizer"
+    assert kwargs["env"]["CLAUDE_SMART_ENABLE_OPTIMIZER"] == "0"
+    system_prompt = cmd[cmd.index("--append-system-prompt") + 1]
+    assert "Be concise." in system_prompt
+    assert "User: first" in system_prompt
+    assert "Assistant: seen" in system_prompt
+
+
+def test_optimizer_assistant_rejects_invalid_stdin(monkeypatch) -> None:
+    rc, stdout, stderr = _run_main(monkeypatch, "{not json")
+
+    assert rc == 1
+    assert stdout == ""
+    assert "stdin must be a JSON object" in stderr
+
+
+def test_optimizer_assistant_returns_nonzero_on_claude_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which", lambda _: "claude"
+    )
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.subprocess.run",
+        lambda *_a, **_kw: SimpleNamespace(
+            returncode=2,
+            stdout="",
+            stderr="boom",
+        ),
+    )
+
+    rc, stdout, stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": None}],
+        },
+    )
+
+    assert rc == 1
+    assert stdout == ""
+    assert "claude CLI exited 2" in stderr
+
+
+def test_optimizer_assistant_returns_nonzero_on_malformed_claude_json(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which", lambda _: "claude"
+    )
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.subprocess.run",
+        lambda *_a, **_kw: SimpleNamespace(
+            returncode=0,
+            stdout="not json",
+            stderr="",
+        ),
+    )
+
+    rc, stdout, stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": None}],
+        },
+    )
+
+    assert rc == 1
+    assert stdout == ""
+    assert "claude CLI returned non-JSON output" in stderr
+
+
+def test_optimizer_assistant_returns_nonzero_on_timeout(monkeypatch) -> None:
+    def fake_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=300)
+
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which", lambda _: "claude"
+    )
+    monkeypatch.setattr("claude_smart.optimizer_assistant.subprocess.run", fake_run)
+
+    rc, stdout, stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": None}],
+        },
+    )
+
+    assert rc == 1
+    assert stdout == ""
+    assert "claude CLI timed out after 300s" in stderr


### PR DESCRIPTION
## Summary

- New `claude-smart-optimizer-assistant` console script bridges Reflexio's `LocalScriptAssistant` stdin/stdout protocol to a guarded `claude -p` subprocess so candidate playbooks can be scored against Claude Code without re-entering claude-smart/reflexio hooks.
- Hardens `claude-smart clear-all` into a stop → wipe → restart flow with safety guards for remote/dangerous/symlink storage, plus configured-SQLite sidecar and disk-org cleanup.
- Bumps the `reflexio` submodule to pick up evaluation caching from companion PR **ReflexioAI/reflexio#58** (`feat(playbook-optimizer): cache evaluations per scenario window`) and floors `reflexio-ai>=0.2.21`.

## Changes

### Optimizer assistant subprocess
- `plugin/src/claude_smart/optimizer_assistant.py` (new): reads JSON `{messages, playbooks}` from stdin, spawns `claude -p` with `--permission-mode plan`, `--tools Read,Grep,Glob,LS`, `--disallowedTools Bash,Edit,Write,MultiEdit,NotebookEdit`, `--no-session-persistence`, and `--mcp-config '{"mcpServers": {}}' --strict-mcp-config`, then emits `{"content": ...}`. Sets `CLAUDE_SMART_INTERNAL=1`, `CLAUDE_CODE_ENTRYPOINT=optimizer`, and `CLAUDE_SMART_ENABLE_OPTIMIZER=0` in the child env to prevent recursive re-entry.
- `plugin/pyproject.toml`: registers `claude-smart-optimizer-assistant` console script and floors `reflexio-ai>=0.2.21`.
- `tests/test_optimizer_assistant.py` (new): covers happy path (both `result` and `response` keys), invalid stdin, missing message content, claude-CLI non-zero exit, timeout, and JSON-decode failures.

### Safe clear-all reset
- `plugin/src/claude_smart/cli.py`: rewrites `cmd_clear_all`. Stops the backend if running, resolves storage targets from `LOCAL_STORAGE_PATH` (env or `~/.reflexio/.env`) plus `~/.reflexio/configs/config_self-host-org.json` (`storage_config.type` of `sqlite` or `disk`), refuses remote Supabase/Postgres configs, refuses dangerous parents (`/`, `$HOME`, `~/.reflexio`, plugin root), refuses symlinked roots, deletes the configured SQLite db plus `-wal`/`-shm`/`-journal` sidecars, removes only `disk_*` org subdirs under a configured disk `dir_path`, removes session JSONL buffers, and restarts the backend only if it was running before.
- `plugin/commands/clear-all.md`: updates description.
- `tests/test_cli_clear_all.py` (new): 13 cases — confirmation prompt, env-driven and dotenv-driven storage roots, missing root no-op, stop+restart sequencing, stop-failure abort, still-running abort, start-failure post-wipe, custom SQLite sidecars, disk-org subdir scoping, remote-config refusal, dangerous-path refusal, symlink-root refusal.

### Submodule + companion
- `reflexio` pointer: `1c47220` → `decf277` (companion PR ReflexioAI/reflexio#58).
- `plugin/uv.lock`: re-locked against PyPI `reflexio-ai==0.2.21`.

### Misc
- `plugin/src/claude_smart/reflexio_adapter.py`, `plugin/src/claude_smart/events/session_start.py`, `tests/conftest.py`, `tests/test_adapter.py`, `tests/test_events.py`: small fixture and adapter tweaks consistent with the optimizer-assistant work.
- `.gitignore`: ignore `.coverage`.
- Two pre-existing local-`main` commits ride along on this branch (`e1ceb77 chore: bump reflexio submodule`, `37f326c refactor(learn): drop synthetic [correction] turn from /learn command`) — they were unpushed when this branch was cut.

## Companion submodule PR

- ReflexioAI/reflexio#58 — `feat(playbook-optimizer): cache evaluations per scenario window`. The submodule pointer in this PR points at the **head of that feature branch** (`decf277`). After #58 merges, the parent submodule pointer should be re-bumped to the merged-main SHA in a follow-up commit on this branch (or as a follow-up PR if this lands first).

## Test Plan

- [x] `uv run pytest tests/` — 200 passed locally.
- [ ] CI green on this PR (will install `reflexio-ai==0.2.21` from PyPI).
- [ ] Manual: run `claude-smart clear-all --yes` against a scratch `~/.reflexio` and confirm the stop/wipe/restart sequence and refusal messages on remote-config / dangerous-path / symlink-root scenarios.
- [ ] Manual: run an end-to-end playbook optimization and verify the optimizer-assistant subprocess does not write any files and only invokes Read/Grep/Glob/LS, then confirm `playbook_optimization_evaluation_cache_hit` lines appear in `~/.reflexio/logs/dev_server.log`.
