### PR TITLE
[codex] Enable learn notes and agent playbook rollups

### DIFF
--- a/plugin/commands/learn.md
+++ b/plugin/commands/learn.md
@@ -9,4 +9,4 @@ note is provided after the command, it is appended as a neutral User turn
 before extraction so reflexio can learn from it directly.
 Run the bash command below and show its output verbatim.
 
-!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" learn ${ARGUMENTS:+--note "$ARGUMENTS"}`
+!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" learn --note "$ARGUMENTS"`

--- a/plugin/commands/learn.md
+++ b/plugin/commands/learn.md
@@ -1,9 +1,12 @@
 ---
 description: Force reflexio to extract learnings from this session now
+argument-hint: [optional note to capture]
 allowed-tools: Bash(bash:*)
 ---
 
-Force reflexio to run extraction on this session's interactions now.
+Force reflexio to run extraction on this session's interactions now. If a
+note is provided after the command, it is appended as a neutral User turn
+before extraction so reflexio can learn from it directly.
 Run the bash command below and show its output verbatim.
 
-!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" learn`
+!`bash "$HOME/.reflexio/plugin-root/scripts/cli.sh" learn ${ARGUMENTS:+--note "$ARGUMENTS"}`

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -218,11 +218,16 @@ def cmd_learn(args: argparse.Namespace) -> int:
 
     Publishes unpublished interactions with ``force_extraction=True`` so
     extraction runs immediately rather than at the next batch interval.
+    When ``args.note`` is provided, the note is appended to the session
+    buffer as a neutral User turn before publishing — letting the user
+    capture an explicit insight, preference, or workflow note alongside
+    whatever has already been buffered.
 
     Args:
         args (argparse.Namespace): Parsed CLI args. Honors ``args.session``
-            (defaults to most-recent) and ``args.project`` (defaults to
-            ``ids.resolve_project_id()``).
+            (defaults to most-recent), ``args.project`` (defaults to
+            ``ids.resolve_project_id()``), and ``args.note`` (free-form
+            text appended as a User turn before publish).
 
     Returns:
         int: 0 on success or no-op (no active session, or nothing to
@@ -233,15 +238,29 @@ def cmd_learn(args: argparse.Namespace) -> int:
         sys.stdout.write("No active claude-smart session buffer found.\n")
         return 0
     project_id = args.project or ids.resolve_project_id()
+
+    note = (args.note or "").strip()
+    if note:
+        state.append(
+            session_id,
+            {
+                "ts": int(time.time()),
+                "role": "User",
+                "content": note,
+                "user_id": project_id,
+            },
+        )
+
     status, count = publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
         force_extraction=True,
-        skip_aggregation=True,
+        skip_aggregation=False,
     )
     if status == "ok":
+        suffix = " (including your note)" if note else ""
         sys.stdout.write(
-            f"Forced extraction on session `{session_id}` over {count} interactions.\n"
+            f"Forced extraction on session `{session_id}` over {count} interactions{suffix}.\n"
         )
         return 0
     if status == "nothing":
@@ -755,6 +774,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ln.add_argument("--session", help="Session id (defaults to latest)")
     ln.add_argument("--project", help="Override project id")
+    ln.add_argument(
+        "--note",
+        default=None,
+        help=(
+            "Free-form note to publish as a User turn before extraction "
+            "(e.g. an insight, preference, or workflow rule)"
+        ),
+    )
     ln.set_defaults(func=cmd_learn)
 
     ca = sub.add_parser(

--- a/plugin/src/claude_smart/events/session_end.py
+++ b/plugin/src/claude_smart/events/session_end.py
@@ -16,5 +16,5 @@ def handle(payload: dict[str, Any]) -> None:
         session_id=session_id,
         project_id=project_id,
         force_extraction=False,
-        skip_aggregation=True,
+        skip_aggregation=False,
     )

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -375,5 +375,5 @@ def handle(payload: dict[str, Any]) -> None:
         session_id=session_id,
         project_id=project_id,
         force_extraction=False,
-        skip_aggregation=True,
+        skip_aggregation=False,
     )

--- a/plugin/src/claude_smart/ids.py
+++ b/plugin/src/claude_smart/ids.py
@@ -7,9 +7,11 @@ Two identifiers matter to reflexio:
   turns remain attributable to their conversation, but it is no longer
   the scope key for extracted profiles.
 - ``project_id``: a stable, cross-session name for the project. We use
-  this as both ``agent_version`` (playbooks roll up at the project level)
-  and reflexio's ``user_id`` for profiles, so user preferences extracted
-  in one session are visible to every later session in the same repo.
+  this as reflexio's ``user_id`` for profiles, so user preferences
+  extracted in one session are visible to every later session in the
+  same repo. ``agent_version`` is hardcoded to ``"claude-code"`` in the
+  adapter so playbooks roll up globally across all projects rather than
+  per project.
 """
 
 from __future__ import annotations

--- a/plugin/src/claude_smart/publish.py
+++ b/plugin/src/claude_smart/publish.py
@@ -28,15 +28,21 @@ def publish_unpublished(
 
     Args:
         session_id (str): Claude Code session id, attached to each interaction.
-        project_id (str): Stable project name; used as both reflexio
-            ``agent_version`` (playbooks) and ``user_id`` (profiles), so both
-            entities accumulate at the project level across sessions.
+        project_id (str): Stable project name; used as reflexio's
+            ``user_id`` (profiles) so profiles accumulate at the project
+            level across sessions. ``agent_version`` is hardcoded to
+            ``"claude-code"`` in the adapter so playbooks roll up
+            globally per agent rather than per project.
         force_extraction (bool): Whether to ask reflexio to run extraction
             synchronously instead of queuing for the next sweep.
         skip_aggregation (bool): When True, reflexio extracts profiles and
             raw playbook entries but skips the rollup into agent-level
-            project playbooks. Every claude-smart publish path (Stop,
-            SessionEnd, /learn) passes True.
+            project playbooks. claude-smart passes False on every publish
+            path so user_playbooks roll up into agent_playbooks; aggregation
+            additionally requires `aggregation_config` to be set on
+            reflexio's `user_playbook_extractor_configs[0]` and
+            `optimize_agent_playbooks=true` at the top level — otherwise
+            the rollup silently no-ops.
         adapter (Adapter | None): Injection point for tests; a fresh
             ``Adapter()`` is constructed when omitted.
 

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _ENV_URL = "REFLEXIO_URL"
 _DEFAULT_URL = "http://localhost:8071/"
+_AGENT_VERSION = "claude-code"
 _SEARCH_MODE_HYBRID = "hybrid"  # reflexio.models.config_schema.SearchMode.HYBRID
 
 
@@ -77,7 +78,7 @@ class Adapter:
             client.publish_interaction(
                 user_id=project_id,
                 interactions=list(interactions),
-                agent_version="claude-code",
+                agent_version=_AGENT_VERSION,
                 session_id=session_id,
                 wait_for_response=False,
                 force_extraction=force_extraction,

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -77,7 +77,7 @@ class Adapter:
             client.publish_interaction(
                 user_id=project_id,
                 interactions=list(interactions),
-                agent_version=project_id,
+                agent_version="claude-code",
                 session_id=session_id,
                 wait_for_response=False,
                 force_extraction=force_extraction,
@@ -149,8 +149,8 @@ class Adapter:
 
             desired = {
                 "enabled": True,
-                "optimize_user_playbooks": True,
-                "optimize_agent_playbooks": False,
+                "optimize_user_playbooks": False,
+                "optimize_agent_playbooks": True,
                 "auto_update_user_playbooks": True,
                 "min_commit_windows": 1,
                 "max_metric_calls": 5,

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -56,7 +56,7 @@ def test_publish_returns_true_on_success() -> None:
     # ``user_id`` is the project slug and ``session_id`` is sent separately.
     assert client.published_kwargs["user_id"] == "p1"
     assert client.published_kwargs["session_id"] == "s1"
-    assert client.published_kwargs["agent_version"] == "p1"
+    assert client.published_kwargs["agent_version"] == "claude-code"
     assert client.published_kwargs["force_extraction"] is True
 
 
@@ -331,8 +331,8 @@ def test_apply_optimizer_defaults_writes_required_fields() -> None:
     assert len(client.set_calls) == 1
     opt = client.set_calls[0].playbook_optimizer_config
     assert opt.enabled is True
-    assert opt.optimize_user_playbooks is True
-    assert opt.optimize_agent_playbooks is False
+    assert opt.optimize_user_playbooks is False
+    assert opt.optimize_agent_playbooks is True
     assert opt.auto_update_user_playbooks is True
     assert opt.min_commit_windows == 1
     assert opt.max_metric_calls == 5
@@ -345,8 +345,8 @@ def test_apply_optimizer_defaults_writes_required_fields() -> None:
 def test_apply_optimizer_defaults_skips_set_when_values_match() -> None:
     opt = SimpleNamespace(
         enabled=True,
-        optimize_user_playbooks=True,
-        optimize_agent_playbooks=False,
+        optimize_user_playbooks=False,
+        optimize_agent_playbooks=True,
         auto_update_user_playbooks=True,
         min_commit_windows=1,
         max_metric_calls=5,

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -11,7 +11,7 @@ from claude_smart import cli, state
 
 
 def _make_args(**overrides: Any) -> argparse.Namespace:
-    defaults = {"session": None, "project": "test-project"}
+    defaults = {"session": None, "project": "test-project", "note": None}
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
 
@@ -44,7 +44,7 @@ def test_cmd_learn_publishes_with_force_extraction(
             "session_id": "s1",
             "project_id": "test-project",
             "force_extraction": True,
-            "skip_aggregation": True,
+            "skip_aggregation": False,
         }
     ]
     out = capsys.readouterr().out
@@ -101,3 +101,34 @@ def test_cmd_learn_nothing_to_publish_returns_zero(
 
     assert rc == 0
     assert "No unpublished interactions on session `s1`" in capsys.readouterr().out
+
+
+def test_cmd_learn_with_note_appends_user_turn(
+    session_dir, fake_publish, capsys
+) -> None:
+    state.append("s1", {"role": "User", "content": "hi"})
+    state.append("s1", {"role": "Assistant", "content": "answer"})
+    calls, _ = fake_publish
+
+    rc = cli.cmd_learn(_make_args(note="prefer ruamel.yaml over PyYAML"))
+
+    assert rc == 0
+    records = state.read_all("s1")
+    assert records[-1]["role"] == "User"
+    assert records[-1]["content"] == "prefer ruamel.yaml over PyYAML"
+    assert records[-1]["user_id"] == "test-project"
+    assert "[correction]" not in records[-1]["content"]
+    assert calls and calls[0]["force_extraction"] is True
+    out = capsys.readouterr().out
+    assert "Forced extraction on session `s1`" in out
+    assert "including your note" in out
+
+
+def test_cmd_learn_blank_note_is_ignored(session_dir, fake_publish) -> None:
+    state.append("s1", {"role": "User", "content": "hi"})
+    state.append("s1", {"role": "Assistant", "content": "answer"})
+
+    rc = cli.cmd_learn(_make_args(note="   "))
+
+    assert rc == 0
+    assert len(state.read_all("s1")) == 2


### PR DESCRIPTION
## Summary

- Add optional note support to `/claude-smart:learn`, publishing the supplied note as a neutral User turn before forced extraction.
- Enable aggregation on all publish paths so user playbooks can roll up into agent playbooks.
- Publish interactions under the global `claude-code` agent version and update optimizer defaults for agent playbook optimization.
- Update tests and docs for the new behavior.

## Impact

Users can now run `/claude-smart:learn <note>` to explicitly capture a preference or workflow note, and learning output rolls up at the agent-playbook level instead of staying scoped to per-project user playbooks only.

## Validation

- `uv run --project plugin pytest tests/test_adapter.py tests/test_cli_learn.py` - 29 passed
- `uv run --project plugin pytest tests` - 202 passed
- Pre-commit pytest hook during commit - 202 passed

Note: bare `uv run --project plugin pytest` still hits the repo known vendored `reflexio` collection conflict (`tests.conftest` import mismatch), so the repo-local suite was run explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `learn` command now accepts an optional note argument that is included with the session before extraction.

* **Improvements**
  * Modified extraction and aggregation behavior across session handling.
  * Updated optimizer configuration to enhance agent playbook optimization while adjusting user playbook handling.
  * Clarified project-level data accumulation and global playbook rollup behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/16)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->