### PR TITLE
feat: add Codex CLI runtime support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "reflexioai",
+  "interface": {
+    "displayName": "ReflexioAI"
+  },
+  "plugins": [
+    {
+      "name": "claude-smart",
+      "source": {
+        "source": "local",
+        "path": "./plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "claude-smart",
+  "version": "0.2.22",
+  "description": "Self-improving coding assistant plugin — learns from corrections across sessions via reflexio",
+  "author": {
+    "name": "Yi Lu"
+  },
+  "homepage": "https://github.com/ReflexioAI/claude-smart#readme",
+  "repository": "https://github.com/ReflexioAI/claude-smart",
+  "license": "Apache-2.0",
+  "keywords": [
+    "claude",
+    "codex",
+    "plugin",
+    "reflexio",
+    "self-improvement",
+    "playbook",
+    "learning"
+  ],
+  "hooks": "./hooks/codex-hooks.json",
+  "interface": {
+    "displayName": "claude-smart",
+    "shortDescription": "Persistent learning across coding sessions",
+    "longDescription": "claude-smart captures user preferences and project-specific skills into a local reflexio backend, then injects relevant learnings back into future Claude Code and Codex sessions.",
+    "developerName": "ReflexioAI",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/ReflexioAI/claude-smart",
+    "brandColor": "#2563EB",
+    "screenshots": []
+  }
+}

--- a/plugin/hooks/codex-hooks.json
+++ b/plugin/hooks/codex-hooks.json
@@ -1,0 +1,67 @@
+{
+  "description": "claude-smart hooks for Codex — learn from sessions via reflexio",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/ensure-plugin-root.sh\" \"$_R\" || true",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/backend-service.sh\" start",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/dashboard-service.sh\" start",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex session-start",
+            "timeout": 30,
+            "statusMessage": "Loading claude-smart context"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex user-prompt",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex post-tool",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex stop",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -24,7 +24,7 @@
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" session-start",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" claude-code session-start",
             "timeout": 30
           },
           {
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" user-prompt",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" claude-code user-prompt",
             "timeout": 15
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" pre-tool",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" claude-code pre-tool",
             "timeout": 10
           }
         ]
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" post-tool",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" claude-code post-tool",
             "timeout": 15
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" stop",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" claude-code stop",
             "timeout": 30
           }
         ]
@@ -91,7 +91,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" session-end",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" claude-code session-end",
             "timeout": 60
           },
           {

--- a/plugin/scripts/_codex_env.sh
+++ b/plugin/scripts/_codex_env.sh
@@ -1,0 +1,27 @@
+# Shared bootstrap for Codex hook commands. This file is sourced by hook
+# entries after a tiny root-discovery step, so keep it POSIX-shell compatible.
+
+_HP=$(printenv PATH 2>/dev/null || true)
+if [ -z "$_HP" ] && [ -n "${SHELL:-}" ]; then
+  _HP=$("$SHELL" -lc 'printf %s "$PATH"' 2>/dev/null || true)
+fi
+_HP=$(printf '%s' "$_HP" | tr ' ' ':')
+export PATH="${_HP:+$_HP:}$PATH"
+
+if [ -z "${_R:-}" ]; then
+  _R="${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}"
+fi
+if [ -z "$_R" ]; then
+  _R=$(ls -dt "$HOME/plugins/claude-smart" \
+    "$HOME/.codex/plugins/cache/reflexioai/claude-smart"/*/ \
+    2>/dev/null | head -n 1)
+fi
+if [ -z "$_R" ]; then
+  echo "claude-smart: plugin root not found" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+_R="${_R%/}"
+export _R
+export PLUGIN_ROOT="$_R"
+export CLAUDE_PLUGIN_ROOT="$_R"

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Dispatch a Claude Code hook event to the claude_smart Python package.
+# Dispatch a Claude Code or Codex hook event to the claude_smart Python package.
 # CLAUDE_PLUGIN_ROOT points at the plugin dir (dev: <repo>/plugin;
 # installed: ~/.claude/plugins/cache/reflexioai/claude-smart/<version>),
 # which is also the Python project root with pyproject.toml + uv.lock.
@@ -10,7 +10,14 @@
 # message instead of trying to run uv and failing silently.
 set -eu
 
+HOST="claude-code"
 EVENT="${1:-}"
+case "$EVENT" in
+  claude-code|codex)
+    HOST="$EVENT"
+    EVENT="${2:-}"
+    ;;
+esac
 if [ -z "$EVENT" ]; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
@@ -40,7 +47,7 @@ print(json.dumps({
         "hookEventName": "SessionStart",
         "additionalContext": (
             f"> **claude-smart is not installed correctly:** {msg}\n"
-            "> Re-run the plugin's Setup (restart Claude Code) "
+            "> Re-run the plugin's Setup (restart your coding assistant) "
             "or fix the underlying issue and delete "
             "`~/.claude-smart/install-failed` to retry."
         ),
@@ -60,4 +67,4 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 
 # Stdin is the hook payload JSON — stream it through to the Python CLI.
-exec uv run --project "$PLUGIN_ROOT" --quiet python -m claude_smart.hook "$EVENT"
+exec uv run --project "$PLUGIN_ROOT" --quiet python -m claude_smart.hook "$HOST" "$EVENT"

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -37,6 +38,9 @@ from claude_smart.reflexio_adapter import Adapter
 _REFLEXIO_ENV_PATH = Path.home() / ".reflexio" / ".env"
 _DEFAULT_MARKETPLACE_SOURCE = "ReflexioAI/claude-smart"
 _PLUGIN_SPEC = "claude-smart@reflexioai"
+_CODEX_MARKETPLACE_NAME = "reflexioai"
+_CODEX_CONFIG_PATH = Path.home() / ".codex" / "config.toml"
+_CODEX_CLI_TIMEOUT_SECONDS = 30
 _REFLEXIO_UNREACHABLE_MSG = (
     "Failed to reach reflexio. Check ~/.claude-smart/backend.log "
     "or restart Claude Code.\n"
@@ -44,6 +48,7 @@ _REFLEXIO_UNREACHABLE_MSG = (
 
 _THIS_DIR = Path(__file__).resolve().parent
 _PLUGIN_ROOT = _THIS_DIR.parents[1]  # plugin/src/claude_smart/ -> plugin/
+_REPO_ROOT = _PLUGIN_ROOT.parent
 _SCRIPTS_DIR = _PLUGIN_ROOT / "scripts"
 _DASHBOARD_DIR = _PLUGIN_ROOT / "dashboard"
 _BACKEND_SCRIPT = _SCRIPTS_DIR / "backend-service.sh"
@@ -52,6 +57,12 @@ _REFLEXIO_DIR = Path.home() / ".reflexio"
 _DEFAULT_STORAGE_ROOT = _REFLEXIO_DIR / "data"
 _REFLEXIO_CONFIG_PATH = _REFLEXIO_DIR / "configs" / "config_self-host-org.json"
 _LOCAL_STORAGE_ENV = "LOCAL_STORAGE_PATH"
+_CODEX_REQUIRED_FILES = (
+    Path(".agents/plugins/marketplace.json"),
+    Path("plugin/.codex-plugin/plugin.json"),
+    Path("plugin/hooks/codex-hooks.json"),
+    Path("plugin/scripts/_codex_env.sh"),
+)
 
 
 def _latest_session_id() -> str | None:
@@ -84,6 +95,169 @@ def _seed_reflexio_env() -> list[str]:
     return missing
 
 
+def _missing_codex_marketplace_files(root: Path) -> list[Path]:
+    return [entry for entry in _CODEX_REQUIRED_FILES if not (root / entry).is_file()]
+
+
+def _run_codex(args: list[str]) -> subprocess.CompletedProcess[str]:
+    command = ["codex", *args]
+    try:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_CODEX_CLI_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            command,
+            124,
+            "",
+            f"Codex CLI timed out after {_CODEX_CLI_TIMEOUT_SECONDS}s: {' '.join(command)}",
+        )
+
+
+def _set_toml_feature(path: Path, feature: str, value: bool) -> bool:
+    """Set one boolean under ``[features]`` in a minimal TOML file."""
+    desired = f"{feature} = {'true' if value else 'false'}"
+    section_re = re.compile(r"^\s*\[([^\]]+)\]\s*(?:#.*)?$")
+    feature_re = re.compile(rf"^\s*{re.escape(feature)}\s*=")
+    try:
+        text = path.read_text() if path.exists() else ""
+    except OSError:
+        return False
+
+    lines = text.splitlines()
+    in_features = False
+    features_idx: int | None = None
+    insert_idx: int | None = None
+    changed = False
+    out: list[str] = []
+
+    for line in lines:
+        section_match = section_re.match(line)
+        if section_match:
+            if in_features and insert_idx is None:
+                insert_idx = len(out)
+            in_features = section_match.group(1).strip() == "features"
+            if in_features:
+                features_idx = len(out)
+            out.append(line)
+            continue
+        if in_features and feature_re.match(line):
+            out.append(desired)
+            changed = changed or line != desired
+            continue
+        out.append(line)
+
+    if features_idx is None:
+        if out and out[-1].strip():
+            out.append("")
+        out.extend(["[features]", desired])
+        changed = True
+    else:
+        section_end = insert_idx if insert_idx is not None else len(out)
+        if not any(
+            feature_re.match(line) for line in out[features_idx + 1 : section_end]
+        ):
+            idx = insert_idx if insert_idx is not None else len(out)
+            out.insert(idx, desired)
+            changed = True
+
+    if not changed and text.endswith("\n"):
+        return True
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join(out) + "\n")
+    except OSError:
+        return False
+    return True
+
+
+def _enable_codex_plugin_hooks() -> tuple[bool, str]:
+    result = _run_codex(["features", "enable", "plugin_hooks"])
+    if result.returncode == 0:
+        return True, "codex features enable plugin_hooks"
+    if _set_toml_feature(_CODEX_CONFIG_PATH, "plugin_hooks", True):
+        return True, f"set plugin_hooks = true in {_CODEX_CONFIG_PATH}"
+    return False, (
+        result.stderr or result.stdout or "could not update Codex config"
+    ).strip()
+
+
+def _register_codex_marketplace(root: Path) -> tuple[bool, str]:
+    result = _run_codex(["plugin", "marketplace", "add", str(root)])
+    if result.returncode == 0:
+        upgrade = _run_codex(
+            ["plugin", "marketplace", "upgrade", _CODEX_MARKETPLACE_NAME]
+        )
+        suffix = " and refreshed cache" if upgrade.returncode == 0 else ""
+        return True, f"registered Codex marketplace{suffix}"
+    output = (result.stderr or result.stdout or "").strip()
+    if "different source" in output:
+        removed = _run_codex(
+            ["plugin", "marketplace", "remove", _CODEX_MARKETPLACE_NAME]
+        )
+        if removed.returncode == 0:
+            added = _run_codex(["plugin", "marketplace", "add", str(root)])
+            if added.returncode == 0:
+                return True, "replaced stale Codex marketplace registration"
+    return False, output or "Codex CLI does not expose plugin marketplace commands"
+
+
+def cmd_install_codex(_args: argparse.Namespace) -> int:
+    """Install the local claude-smart plugin marketplace for Codex."""
+    if not shutil.which("codex"):
+        sys.stderr.write("error: 'codex' CLI not found on PATH. Install Codex first.\n")
+        return 1
+    if not shutil.which("uv"):
+        sys.stderr.write(
+            "error: 'uv' not found on PATH. Install uv or restart your shell.\n"
+        )
+        return 1
+
+    missing = _missing_codex_marketplace_files(_REPO_ROOT)
+    if missing:
+        formatted = ", ".join(str(path) for path in missing)
+        sys.stderr.write(f"error: Codex marketplace files missing: {formatted}\n")
+        return 1
+
+    added = _seed_reflexio_env()
+    if added:
+        sys.stdout.write(f"Seeded {_REFLEXIO_ENV_PATH} with {', '.join(added)}.\n")
+
+    hooks_ok, hooks_msg = _enable_codex_plugin_hooks()
+    if hooks_ok:
+        sys.stdout.write(f"Enabled Codex plugin hooks ({hooks_msg}).\n")
+    else:
+        sys.stderr.write(f"warning: could not enable Codex plugin hooks: {hooks_msg}\n")
+
+    registered, registration_msg = _register_codex_marketplace(_REPO_ROOT)
+    if registered:
+        sys.stdout.write(f"{registration_msg}.\n")
+    else:
+        sys.stderr.write(f"warning: {registration_msg}\n")
+
+    if registered:
+        sys.stdout.write(
+            "\nclaude-smart Codex support is prepared.\n"
+            "Open Codex in this repo, run /plugins, install claude-smart from "
+            "the claude-smart (local) marketplace if it is not already installed, "
+            "then restart Codex so hooks reload. Uninstall removes the marketplace "
+            "registration but leaves shared claude-smart data and Codex's global "
+            "plugin_hooks feature intact.\n"
+        )
+    else:
+        sys.stdout.write(
+            "\nCodex hooks enabled; marketplace registration failed.\n"
+            f"Install manually with `codex plugin marketplace add {_REPO_ROOT}`, "
+            "then open Codex, run /plugins, install claude-smart from the "
+            "claude-smart (local) marketplace, and restart Codex so hooks reload.\n"
+        )
+    return 0 if hooks_ok and registered else 1
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Install claude-smart into Claude Code via the native plugin CLI.
 
@@ -98,6 +272,9 @@ def cmd_install(args: argparse.Namespace) -> int:
     Returns:
         int: 0 on success, non-zero if the ``claude`` CLI is missing or fails.
     """
+    if getattr(args, "host", "claude-code") == "codex":
+        return cmd_install_codex(args)
+
     if not shutil.which("claude"):
         sys.stderr.write(
             "error: 'claude' CLI not found on PATH. "
@@ -164,6 +341,9 @@ def cmd_uninstall(_args: argparse.Namespace) -> int:
     Returns:
         int: 0 on success, non-zero if the ``claude`` CLI is missing or fails.
     """
+    if getattr(_args, "host", "claude-code") == "codex":
+        return cmd_uninstall_codex(_args)
+
     if not shutil.which("claude"):
         sys.stderr.write(
             "error: 'claude' CLI not found on PATH. "
@@ -182,6 +362,27 @@ def cmd_uninstall(_args: argparse.Namespace) -> int:
         "\nclaude-smart uninstalled. Restart Claude Code to apply.\n"
         "Local data in ~/.reflexio/ and ~/.claude-smart/ was left in place — "
         "remove manually if desired.\n"
+    )
+    return 0
+
+
+def cmd_uninstall_codex(_args: argparse.Namespace) -> int:
+    if not shutil.which("codex"):
+        sys.stdout.write("Codex CLI not found; skipping marketplace removal.\n")
+        return 0
+    result = _run_codex(["plugin", "marketplace", "remove", _CODEX_MARKETPLACE_NAME])
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        sys.stderr.write(
+            "warning: Codex marketplace removal failed"
+            + (f": {output}" if output else "")
+            + "\n"
+        )
+        return 1
+    sys.stdout.write(
+        "claude-smart Codex marketplace removed. Restart Codex to apply. "
+        "Codex's global plugin_hooks feature and local data under ~/.reflexio "
+        "and ~/.claude-smart were left in place.\n"
     )
     return 0
 
@@ -755,7 +956,13 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="claude-smart")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    inst = sub.add_parser("install", help="Install claude-smart into Claude Code")
+    inst = sub.add_parser("install", help="Install claude-smart")
+    inst.add_argument(
+        "--host",
+        choices=("claude-code", "codex"),
+        default="claude-code",
+        help="Install target host",
+    )
     inst.add_argument(
         "--source",
         default=_DEFAULT_MARKETPLACE_SOURCE,
@@ -766,7 +973,13 @@ def _build_parser() -> argparse.ArgumentParser:
     upd = sub.add_parser("update", help="Update claude-smart to the latest version")
     upd.set_defaults(func=cmd_update)
 
-    uni = sub.add_parser("uninstall", help="Remove claude-smart from Claude Code")
+    uni = sub.add_parser("uninstall", help="Remove claude-smart")
+    uni.add_argument(
+        "--host",
+        choices=("claude-code", "codex"),
+        default="claude-code",
+        help="Uninstall target host",
+    )
     uni.set_defaults(func=cmd_uninstall)
 
     sh = sub.add_parser(

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -1,17 +1,18 @@
-"""Support helpers for the ``cs-cite`` citation channel.
+"""Support helpers for claude-smart citation tracking.
 
 Context injected by UserPromptSubmit / PreToolUse tags each skill and
 preference bullet with a rank-based id fingerprinted by the underlying
 real id (``[cs:s1-1a2b]`` for the first skill whose
 ``user_playbook_id`` starts with ``1a2b``, ``[cs:p2-c3d4]`` for the
-second preference). The injected instruction asks Claude to
-end impactful replies with a call like::
+second preference). The injected instruction asks the assistant to end
+impactful replies with a marker like::
 
-    cs-cite p1-c3d4,s2-1a2b
+    ✨ 1 claude-smart learning applied [cs:s1-1a2b]
 
-via the Bash tool. The Stop hook later scans the session transcript for
-those tool calls and resolves the ids against a per-session registry
-persisted at ``~/.claude-smart/sessions/<session_id>.injected.jsonl``.
+The Stop hook later scans the assistant text for those markers and resolves
+the ids against a per-session registry persisted at
+``~/.claude-smart/sessions/<session_id>.injected.jsonl``. Legacy ``cs-cite``
+Bash tool calls are still accepted as a fallback for older instructions.
 
 Why rank + fingerprint: rank alone resets at every injection, so a
 later injection's ``s1`` would silently overwrite an earlier entry in
@@ -26,11 +27,11 @@ This module holds:
 - ``rank_id``: ``p{n}-{fp}`` / ``s{n}-{fp}`` tag for a given
   (kind, rank, real_id) tuple. Fingerprint is omitted when no real id
   is available. ``p`` is preference, ``s`` is skill.
-- ``CITATION_CMD_RE``: regex matching a valid ``cs-cite`` command line.
+- ``CITATION_CMD_RE``: regex matching a valid legacy ``cs-cite`` command line.
 - ``ensure_installed``: idempotent copy of ``plugin/bin/cs-cite`` to
   ``~/.claude-smart/bin/cs-cite`` with the executable bit set.
-- ``CITATION_INSTRUCTION``: the trailer text appended to injected
-  context so Claude knows when and how to call the tool.
+- ``CITATION_INSTRUCTION``: the trailer text appended to injected context
+  so the assistant knows when and how to emit the citation marker.
 """
 
 from __future__ import annotations
@@ -70,26 +71,28 @@ CITATION_CMD_RE = re.compile(
 )
 _CLEAN_ID_RE = re.compile(r"^(?i:cs:)?((?i:[ps])\d+(?:-(?i:[a-z0-9]){1,4})?)$")
 _SPLIT_RE = re.compile(_ID_SEP)
+_TEXT_CITATION_LINE_RE = re.compile(
+    r"(?im)^\s*✨\s+\d+\s+claude-smart learning(?:s)? applied\s+"
+    r"\[cs:(?P<ids>[^\]]+)\]\s*$"
+)
 
 CITATION_INSTRUCTION = (
     "_First, fully answer the user — citation does not change what or how "
     "you reply. Then, as a final step, consider whether to cite: if — and "
     "only if — an injected `[cs:…]` item materially changed your reply "
     "(different wording, action, or conclusion than you would have produced "
-    "without it), call `cs-cite <id>` via the Bash tool. Ids come verbatim "
+    "without it), append exactly one final citation line after your answer. "
+    "Do not call `cs-cite` or any other tool for citations. Ids come verbatim "
     "from the `[cs:…]` tags — keep the leading `p` (preference) or `s` "
-    "(skill) and the `-<fp>` suffix, e.g. `cs-cite s1-ab12`. List "
-    "multiple ids only when each shaped a different part of the answer, "
-    "e.g. `cs-cite s1-ab12,p2-cd34`. Ids only, no prose, one Bash call. "
+    "(skill) and the `-<fp>` suffix. Use this exact format for one id: "
+    "`✨ 1 claude-smart learning applied [cs:s1-ab12]`. Use this exact format "
+    "for multiple ids: `✨ 2 claude-smart learnings applied [cs:s1-ab12,p2-cd34]`, "
+    "where the number is the count of ids in the brackets. "
     "Default is to skip. If an item is merely on-topic, confirms what you "
     "already planned, or your reply would read the same without it, do not "
-    "cite — end the turn normally with your reply. When unsure, skip. "
-    "The `cs-cite` Bash call produces no stdout output. After it returns, "
-    "emit exactly one short line as the final content of your assistant "
-    "message, then stop: `✨ N claude-smart learning applied` when N=1, or "
-    "`✨ N claude-smart learnings applied` when N>1, where N is the count "
-    "of ids you passed. Do not add any other text, tool calls, or role "
-    "markers after that line._"
+    "cite — end the turn normally with your reply. When unsure, skip. Do "
+    "not add any other text, tool calls, or role markers after the final "
+    "citation line._"
 )
 
 
@@ -170,8 +173,27 @@ def parse_citation_command(command: str) -> list[str]:
     match = CITATION_CMD_RE.match(command or "")
     if not match:
         return []
+    return _parse_id_tokens(match.group(1))
+
+
+def parse_text_citations(text: str) -> list[str]:
+    """Extract Codex text-only citation ids from a final learning marker line.
+
+    The parser intentionally only accepts lines containing the visual
+    ``claude-smart learning(s) applied`` marker, so ordinary references to
+    injected ``[cs:...]`` ids inside an answer do not count as citations.
+    When multiple matching lines exist, the last one wins because the
+    instruction requires the citation marker to be final.
+    """
+    matches = list(_TEXT_CITATION_LINE_RE.finditer(text or ""))
+    if not matches:
+        return []
+    return _parse_id_tokens(matches[-1].group("ids"))
+
+
+def _parse_id_tokens(raw_ids: str) -> list[str]:
     ids: list[str] = []
-    for tok in _SPLIT_RE.split(match.group(1).strip()):
+    for tok in _SPLIT_RE.split(raw_ids.strip()):
         if clean := _CLEAN_ID_RE.match(tok):
             ids.append(clean.group(1).lower())
     return ids
@@ -195,7 +217,12 @@ def ensure_installed() -> Path:
         Path: Target path, whether or not install succeeded.
     """
     try:
-        if INSTALL_PATH.is_file() and INSTALL_PATH.stat().st_mode & stat_.S_IXUSR:
+        if (
+            INSTALL_PATH.is_file()
+            and INSTALL_PATH.stat().st_mode & stat_.S_IXUSR
+            and _SOURCE_SCRIPT.is_file()
+            and INSTALL_PATH.read_bytes() == _SOURCE_SCRIPT.read_bytes()
+        ):
             return INSTALL_PATH
         _INSTALL_DIR.mkdir(parents=True, exist_ok=True)
         if _SOURCE_SCRIPT.is_file():

--- a/plugin/src/claude_smart/events/pre_tool.py
+++ b/plugin/src/claude_smart/events/pre_tool.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from claude_smart import context_inject, hook, ids, query_compose
+from claude_smart import context_inject, hook, ids, query_compose, runtime
 
 _LOGGER = logging.getLogger(__name__)
 _TOP_K = 3
@@ -20,6 +20,10 @@ _TOP_K = 3
 
 def handle(payload: dict[str, Any]) -> None:
     """PreToolUse dispatcher — never raises; degrades to ``emit_continue``."""
+    if runtime.is_codex():
+        hook.emit_continue()
+        return
+
     session_id = payload.get("session_id")
     tool_name = payload.get("tool_name")
     tool_input = payload.get("tool_input") or {}

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from claude_smart import cs_cite, ids, publish, state
+from claude_smart import cs_cite, ids, publish, runtime, state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -250,7 +250,9 @@ def _parse_plan_decision(text: str) -> str | None:
         _, sep, tail = text.partition(_PLAN_REJECTION_COMMENT_MARKER)
         comment = tail.strip() if sep else ""
         return (
-            f"Rejected the plan. Instead: {comment}" if comment else "Rejected the plan."
+            f"Rejected the plan. Instead: {comment}"
+            if comment
+            else "Rejected the plan."
         )
     return None
 
@@ -348,8 +350,17 @@ def handle(payload: dict[str, Any]) -> None:
         if path.is_file():
             entries = _load_transcript_with_retry(path)
 
-    assistant_text = _scan_transcript_for_assistant_text(entries)
-    cited_ids = _scan_transcript_for_cs_cite_ids(entries)
+    last_assistant_message = payload.get("last_assistant_message")
+    assistant_text = (
+        last_assistant_message
+        if runtime.is_codex()
+        and isinstance(last_assistant_message, str)
+        and last_assistant_message
+        else _scan_transcript_for_assistant_text(entries)
+    )
+    transcript_cited_ids = _scan_transcript_for_cs_cite_ids(entries)
+    text_cited_ids = cs_cite.parse_text_citations(assistant_text)
+    cited_ids = [*text_cited_ids, *transcript_cited_ids]
     cited_items = _resolve_cited_items(session_id, cited_ids)
     plan_decisions = _scan_transcript_for_plan_decisions(entries)
 

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -1,10 +1,10 @@
-"""Dispatch table for Claude Code hook events.
+"""Dispatch table for claude-smart hook events.
 
-The plugin's ``hook_entry.sh`` calls ``python -m claude_smart.hook <event>``
-once per hook invocation. This module reads the hook JSON from stdin,
-routes to the matching handler in ``claude_smart.events``, and makes sure
-no unhandled exception ever propagates (that would break the user's
-session).
+The plugin's ``hook_entry.sh`` calls either
+``python -m claude_smart.hook <event>`` (legacy Claude Code shape) or
+``python -m claude_smart.hook <host> <event>`` once per hook invocation.
+This module reads the hook JSON from stdin, routes to the matching handler,
+and makes sure no unhandled exception ever propagates.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import logging
 import sys
 from typing import Any, Callable
 
+from claude_smart import runtime
 from claude_smart.internal_call import is_internal_invocation
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,19 +59,32 @@ def _read_stdin_json() -> dict[str, Any]:
 
 def emit_continue() -> None:
     """Fallback stdout — tells Claude Code to keep going without injection."""
-    sys.stdout.write(json.dumps({"continue": True, "suppressOutput": True}))
+    payload = {"continue": True}
+    if not runtime.is_codex():
+        payload["suppressOutput"] = True
+    sys.stdout.write(json.dumps(payload))
     sys.stdout.write("\n")
+
+
+def _parse_args(argv: list[str]) -> tuple[str, str]:
+    """Return ``(host, event)`` for old and new hook argv shapes."""
+    if not argv:
+        return runtime.HOST_CLAUDE_CODE, ""
+    if len(argv) >= 2 and argv[0] in runtime.VALID_HOSTS:
+        return argv[0], argv[1]
+    return runtime.HOST_CLAUDE_CODE, argv[0]
 
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point used by ``python -m claude_smart.hook`` and the console script."""
     argv = argv if argv is not None else sys.argv[1:]
-    if not argv:
+    host, event = _parse_args(argv)
+    runtime.set_host(host)
+    if not event:
         _LOGGER.warning("hook dispatcher called with no event name")
         emit_continue()
         return 0
 
-    event = argv[0]
     payload = _read_stdin_json()
 
     # Self-feedback guard: when this hook fires inside reflexio's own

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -37,7 +37,8 @@ import os
 from pathlib import Path
 from typing import Any
 
-_ENV_MARKER = "CLAUDE_SMART_INTERNAL"
+from claude_smart import runtime
+
 _ENTRYPOINT_VAR = "CLAUDE_CODE_ENTRYPOINT"
 _INTERACTIVE_ENTRYPOINT = "cli"
 
@@ -69,7 +70,7 @@ def is_internal_invocation(payload: dict[str, Any]) -> bool:
             the reflexio submodule. False otherwise, including when
             ``cwd`` is missing or unresolvable.
     """
-    if os.environ.get(_ENV_MARKER) == "1":
+    if runtime.is_internal_invocation_env():
         return True
     entrypoint = os.environ.get(_ENTRYPOINT_VAR)
     if entrypoint and entrypoint != _INTERACTIVE_ENTRYPOINT:

--- a/plugin/src/claude_smart/optimizer_assistant.py
+++ b/plugin/src/claude_smart/optimizer_assistant.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 from typing import Any
 
-from claude_smart import internal_call
+from claude_smart import internal_call, runtime
 
 _CLAUDE_TIMEOUT_SECONDS = 300
 _READ_ONLY_TOOLS = "Read,Grep,Glob,LS"
@@ -158,7 +158,7 @@ def _run_claude(*, prompt: str, system_prompt: str) -> str:
         cmd.extend(["--append-system-prompt", system_prompt])
 
     env = os.environ.copy()
-    env[internal_call._ENV_MARKER] = "1"  # noqa: SLF001 - shared guard constant.
+    env[runtime.INTERNAL_ENV] = "1"
     env[internal_call._ENTRYPOINT_VAR] = "optimizer"  # noqa: SLF001
 
     try:

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -12,11 +12,12 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+from claude_smart import runtime
+
 _LOGGER = logging.getLogger(__name__)
 
 _ENV_URL = "REFLEXIO_URL"
 _DEFAULT_URL = "http://localhost:8071/"
-_AGENT_VERSION = "claude-code"
 _SEARCH_MODE_HYBRID = "hybrid"  # reflexio.models.config_schema.SearchMode.HYBRID
 _UNIFIED_ENTITY_TYPES = ("profiles", "user_playbooks", "agent_playbooks")
 _AGENT_PLAYBOOK_APPROVAL_STATUSES = ("pending", "approved")
@@ -81,7 +82,7 @@ class Adapter:
             client.publish_interaction(
                 user_id=project_id,
                 interactions=list(interactions),
-                agent_version=_AGENT_VERSION,
+                agent_version=runtime.agent_version(),
                 session_id=session_id,
                 wait_for_response=False,
                 force_extraction=force_extraction,
@@ -225,7 +226,7 @@ class Adapter:
             return []
         try:
             response = client.search_agent_playbooks(
-                agent_version=_AGENT_VERSION,
+                agent_version=runtime.agent_version(),
                 status_filter=[None],
                 top_k=top_k,
             )
@@ -285,7 +286,7 @@ class Adapter:
             response = client.search(
                 query=query,
                 user_id=project_id,
-                agent_version=_AGENT_VERSION,
+                agent_version=runtime.agent_version(),
                 entity_types=list(_UNIFIED_ENTITY_TYPES),
                 agent_playbook_status_filter=list(_AGENT_PLAYBOOK_APPROVAL_STATUSES),
                 enable_agent_answer=False,

--- a/plugin/src/claude_smart/runtime.py
+++ b/plugin/src/claude_smart/runtime.py
@@ -1,0 +1,52 @@
+"""Host/runtime state shared by claude-smart entrypoints.
+
+The plugin can be loaded by Claude Code or Codex, but v1 intentionally keeps
+one memory namespace. The host value is for payload quirks and install UX; the
+Reflexio agent version remains shared so both hosts see the same learned rules.
+"""
+
+from __future__ import annotations
+
+import os
+
+HOST_ENV = "CLAUDE_SMART_HOST"
+INTERNAL_ENV = "CLAUDE_SMART_INTERNAL"
+
+HOST_CLAUDE_CODE = "claude-code"
+HOST_CODEX = "codex"
+VALID_HOSTS = frozenset({HOST_CLAUDE_CODE, HOST_CODEX})
+
+_SHARED_AGENT_VERSION = "claude-code"
+_current_host: str | None = None
+
+
+def set_host(value: str | None) -> str:
+    """Set the current host, returning the normalized value."""
+    global _current_host
+    host = value if value in VALID_HOSTS else HOST_CLAUDE_CODE
+    _current_host = host
+    os.environ[HOST_ENV] = host
+    return host
+
+
+def host() -> str:
+    """Return the current host, defaulting to Claude Code for compatibility."""
+    if _current_host is not None:
+        return _current_host
+    value = os.environ.get(HOST_ENV)
+    return value if value in VALID_HOSTS else HOST_CLAUDE_CODE
+
+
+def is_codex() -> bool:
+    """True when the current hook invocation came from Codex."""
+    return host() == HOST_CODEX
+
+
+def agent_version() -> str:
+    """Reflexio agent version used for shared learning across hosts."""
+    return _SHARED_AGENT_VERSION
+
+
+def is_internal_invocation_env() -> bool:
+    """Generic recursion guard used by local assistant subprocesses."""
+    return os.environ.get(INTERNAL_ENV) == "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,14 @@ def session_dir(tmp_path, monkeypatch):
 def clear_optimizer_opt_in(monkeypatch):
     """Keep env-gated optimizer setup from leaking into unrelated tests."""
     monkeypatch.delenv("CLAUDE_SMART_ENABLE_OPTIMIZER", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_host(monkeypatch):
+    """Keep host-specific tests from leaking runtime state."""
+    from claude_smart import runtime
+
+    monkeypatch.delenv("CLAUDE_SMART_HOST", raising=False)
+    runtime.set_host(runtime.HOST_CLAUDE_CODE)
+    yield
+    runtime.set_host(runtime.HOST_CLAUDE_CODE)

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -1,0 +1,354 @@
+"""Tests for Codex plugin packaging and host-specific hook behavior."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from claude_smart import cli, cs_cite, hook, runtime, state
+from claude_smart.events import post_tool, pre_tool, stop
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_json(path: str) -> dict[str, Any]:
+    return json.loads((REPO_ROOT / path).read_text())
+
+
+def _command_hooks(path: str) -> list[str]:
+    parsed = _read_json(path)
+    commands: list[str] = []
+    for entries in (parsed.get("hooks") or {}).values():
+        for entry in entries:
+            for hook_def in entry.get("hooks") or []:
+                if hook_def.get("type") == "command":
+                    commands.append(str(hook_def.get("command") or ""))
+    return commands
+
+
+def test_codex_manifest_points_at_codex_hooks() -> None:
+    manifest = _read_json("plugin/.codex-plugin/plugin.json")
+    assert manifest["name"] == "claude-smart"
+    assert manifest["hooks"] == "./hooks/codex-hooks.json"
+    assert manifest["interface"]["displayName"] == "claude-smart"
+
+
+def test_codex_marketplace_points_at_plugin_root() -> None:
+    marketplace = _read_json(".agents/plugins/marketplace.json")
+    entry = marketplace["plugins"][0]
+    assert entry["name"] == "claude-smart"
+    assert entry["source"]["path"] == "./plugin"
+    assert entry["policy"]["installation"] == "AVAILABLE"
+
+
+def test_hook_commands_pass_explicit_host() -> None:
+    claude_commands = [
+        c for c in _command_hooks("plugin/hooks/hooks.json") if "hook_entry.sh" in c
+    ]
+    codex_commands = _command_hooks("plugin/hooks/codex-hooks.json")
+    assert claude_commands
+    assert codex_commands
+    assert all('hook_entry.sh" claude-code ' in c for c in claude_commands)
+    assert all(
+        'hook_entry.sh" codex ' in c for c in codex_commands if "hook_entry.sh" in c
+    )
+
+
+def test_codex_hooks_use_expected_events_and_marketplace_fallback() -> None:
+    hooks = _read_json("plugin/hooks/codex-hooks.json")["hooks"]
+    assert set(hooks) == {"SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"}
+    assert "PreToolUse" not in hooks
+    for command in _command_hooks("plugin/hooks/codex-hooks.json"):
+        assert "_codex_env.sh" in command
+        assert "printenv PATH" not in command
+        assert command.find("$HOME/plugins/claude-smart") < command.find(
+            ".codex/plugins/cache/reflexioai/claude-smart"
+        )
+        assert ".codex/plugins/cache/reflexioai/claude-smart" in command
+
+
+def test_hook_main_accepts_legacy_and_host_argv(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_read() -> dict[str, Any]:
+        return {"session_id": "s1"}
+
+    def fake_handlers():
+        return {"stop": lambda _payload: calls.append((runtime.host(), "stop"))}
+
+    monkeypatch.setattr(hook, "_read_stdin_json", fake_read)
+    monkeypatch.setattr(hook, "_load_handlers", fake_handlers)
+
+    assert hook.main(["stop"]) == 0
+    assert hook.main(["codex", "stop"]) == 0
+    assert calls == [("claude-code", "stop"), ("codex", "stop")]
+
+
+def test_codex_pre_tool_does_not_inject_context(monkeypatch) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    called = False
+
+    def fail_emit(**_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(pre_tool.context_inject, "emit_context", fail_emit)
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+
+    pre_tool.handle(
+        {
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "uv run pytest"},
+        }
+    )
+
+    assert called is False
+    assert json.loads(buf.getvalue()) == {"continue": True}
+
+
+def test_codex_citation_instruction_uses_text_marker_not_tool_call() -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+
+    instruction = cs_cite.CITATION_INSTRUCTION
+
+    assert "Do not call `cs-cite`" in instruction
+    assert "✨ 1 claude-smart learning applied [cs:s1-ab12]" in instruction
+
+
+def test_codex_stop_prefers_last_assistant_message(session_dir, monkeypatch) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        stop.publish, "publish_unpublished", lambda **kw: calls.append(kw)
+    )
+    monkeypatch.setattr(stop.ids, "resolve_project_id", lambda *_a, **_kw: "demo")
+
+    stop.handle(
+        {
+            "session_id": "s1",
+            "cwd": str(REPO_ROOT),
+            "last_assistant_message": "final answer from codex",
+            "transcript_path": "/does/not/exist.jsonl",
+        }
+    )
+
+    records = state.read_all("s1")
+    assert records[-1]["role"] == "Assistant"
+    assert records[-1]["content"] == "final answer from codex"
+    assert calls and calls[0]["project_id"] == "demo"
+
+
+def test_codex_stop_resolves_text_citations_from_last_assistant_message(
+    session_dir, monkeypatch
+) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    monkeypatch.setattr(stop.publish, "publish_unpublished", lambda **_kw: ("ok", 1))
+    monkeypatch.setattr(stop.ids, "resolve_project_id", lambda *_a, **_kw: "demo")
+    state.append_injected(
+        "s1",
+        [
+            {
+                "id": "s2-17",
+                "real_id": "17",
+                "kind": "playbook",
+                "source_kind": "user_playbook",
+                "title": "Check editable installs",
+            }
+        ],
+    )
+
+    stop.handle(
+        {
+            "session_id": "s1",
+            "cwd": str(REPO_ROOT),
+            "last_assistant_message": (
+                "The answer stays visible.\n\n"
+                "✨ 1 claude-smart learning applied [cs:s2-17]"
+            ),
+            "transcript_path": "/does/not/exist.jsonl",
+        }
+    )
+
+    records = state.read_all("s1")
+    assert records[-1]["cited_items"] == [
+        {
+            "id": "s2-17",
+            "real_id": "17",
+            "kind": "playbook",
+            "source_kind": "user_playbook",
+            "title": "Check editable installs",
+        }
+    ]
+
+
+def test_codex_post_tool_records_apply_patch_payload(session_dir) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+
+    post_tool.handle(
+        {
+            "session_id": "s1",
+            "tool_name": "apply_patch",
+            "tool_input": {"patch": "*** Begin Patch\n*** End Patch"},
+            "tool_response": {"stdout": "ok"},
+        }
+    )
+
+    record = state.read_all("s1")[0]
+    assert record["tool_name"] == "apply_patch"
+    assert record["tool_input"]["patch"].startswith("*** Begin Patch")
+    assert record["tool_output"] == "ok"
+
+
+def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    env_path = tmp_path / "reflexio" / ".env"
+    config_path = tmp_path / ".codex" / "config.toml"
+    monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+
+    calls: list[list[str]] = []
+
+    def fake_run_codex(args: list[str]):
+        calls.append(args)
+        if args == ["features", "enable", "plugin_hooks"]:
+            return type(
+                "Result", (), {"returncode": 1, "stdout": "", "stderr": "unsupported"}
+            )()
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(cli, "_run_codex", fake_run_codex)
+
+    rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
+
+    assert rc == 0
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in env_path.read_text()
+    assert "plugin_hooks = true" in config_path.read_text()
+    assert ["plugin", "marketplace", "add", str(cli._REPO_ROOT)] in calls
+    assert "run /plugins" in capsys.readouterr().out
+
+
+def test_codex_install_fails_when_marketplace_registration_fails(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    env_path = tmp_path / "reflexio" / ".env"
+    config_path = tmp_path / ".codex" / "config.toml"
+    monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+
+    def fake_run_codex(args: list[str]):
+        return type(
+            "Result", (), {"returncode": 1, "stdout": "", "stderr": "unsupported"}
+        )()
+
+    monkeypatch.setattr(cli, "_run_codex", fake_run_codex)
+
+    rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
+
+    assert rc == 1
+    assert "plugin_hooks = true" in config_path.read_text()
+    assert "marketplace registration failed" in capsys.readouterr().out
+
+
+def test_codex_install_fails_when_required_files_missing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(cli, "_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+
+    rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
+
+    assert rc == 1
+
+
+def test_codex_install_fails_when_codex_cli_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cli.shutil, "which", lambda name: None if name == "codex" else f"/bin/{name}"
+    )
+
+    rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
+
+    assert rc == 1
+
+
+def test_run_codex_times_out(monkeypatch) -> None:
+    def fake_run(*_args, **_kwargs):
+        raise cli.subprocess.TimeoutExpired(cmd=["codex", "features"], timeout=30)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    result = cli._run_codex(["features", "enable", "plugin_hooks"])
+
+    assert result.returncode == 124
+    assert "timed out" in result.stderr
+
+
+def test_set_toml_feature_updates_existing_spacing_variants(tmp_path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "[features] # user comment\n"
+        "plugin_hooks=false\n"
+        "other = true\n"
+        "[model]\n"
+        'name = "gpt"\n'
+    )
+
+    assert cli._set_toml_feature(config, "plugin_hooks", True) is True
+
+    text = config.read_text()
+    assert text.count("plugin_hooks") == 1
+    assert "plugin_hooks = true" in text
+    assert text.index("plugin_hooks = true") < text.index("[model]")
+
+
+def test_set_toml_feature_inserts_before_next_section(tmp_path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[features]\nother = true\n\n[model]\nname = "gpt"\n')
+
+    assert cli._set_toml_feature(config, "plugin_hooks", True) is True
+
+    text = config.read_text()
+    assert text.index("plugin_hooks = true") < text.index("[model]")
+
+
+def test_register_codex_marketplace_replaces_stale_source(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_codex(args: list[str]):
+        calls.append(args)
+        if args[:3] == ["plugin", "marketplace", "add"]:
+            code = 1 if len(calls) == 1 else 0
+            return type(
+                "Result",
+                (),
+                {
+                    "returncode": code,
+                    "stdout": "",
+                    "stderr": (
+                        "marketplace 'reflexioai' is already added "
+                        "from a different source"
+                        if code
+                        else ""
+                    ),
+                },
+            )()
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(cli, "_run_codex", fake_run_codex)
+
+    ok, message = cli._register_codex_marketplace(Path("/tmp/marketplace"))
+
+    assert ok is True
+    assert "replaced stale" in message
+    assert calls == [
+        ["plugin", "marketplace", "add", "/tmp/marketplace"],
+        ["plugin", "marketplace", "remove", "reflexioai"],
+        ["plugin", "marketplace", "add", "/tmp/marketplace"],
+    ]

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from claude_smart import context_format, cs_cite
+from claude_smart import context_format, cs_cite, runtime
 
 
 def test_render_with_registry_empty_returns_empty_tuple() -> None:
@@ -99,6 +99,23 @@ def test_render_with_registry_emits_citation_instruction() -> None:
         agent_playbooks=[],
         profiles=[],
     )
+    assert cs_cite.CITATION_INSTRUCTION in md
+    assert "Do not call `cs-cite`" in md
+    assert "✨ 1 claude-smart learning applied [cs:s1-ab12]" in md
+    assert "✨ 2 claude-smart learnings applied [cs:s1-ab12,p2-cd34]" in md
+    assert "`✨ N claude-smart" not in md
+
+
+def test_render_with_registry_uses_same_citation_instruction_for_codex() -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+
+    md, _ = context_format.render_with_registry(
+        project_id="demo",
+        user_playbooks=[{"content": "x"}],
+        agent_playbooks=[],
+        profiles=[],
+    )
+
     assert cs_cite.CITATION_INSTRUCTION in md
 
 

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -36,6 +36,28 @@ def test_parse_citation_command_accepts_absolute_path_prefix() -> None:
     assert cs_cite.parse_citation_command(cmd) == ["s3-abcd"]
 
 
+def test_parse_text_citations_accepts_codex_learning_marker() -> None:
+    text = (
+        "The real answer remains visible.\n\n"
+        "✨ 2 claude-smart learnings applied [cs:s2-cd34,p1-ab12]"
+    )
+    assert cs_cite.parse_text_citations(text) == ["s2-cd34", "p1-ab12"]
+
+
+def test_parse_text_citations_ignores_plain_inline_tags() -> None:
+    text = "This mentions [cs:s2-cd34] but has no learning marker."
+    assert cs_cite.parse_text_citations(text) == []
+
+
+def test_parse_text_citations_uses_last_marker_line() -> None:
+    text = (
+        "✨ 1 claude-smart learning applied [cs:s1-1111]\n"
+        "answer\n"
+        "✨ 1 claude-smart learning applied [cs:p2-2222]"
+    )
+    assert cs_cite.parse_text_citations(text) == ["p2-2222"]
+
+
 def test_parse_citation_command_rejects_chained_commands() -> None:
     assert cs_cite.parse_citation_command("cs-cite p1-ab12 && echo ok") == []
     assert cs_cite.parse_citation_command("cs-cite p1-ab12 | cat") == []
@@ -158,6 +180,20 @@ def test_ensure_installed_is_idempotent_and_executable(tmp_path, monkeypatch) ->
     # copy2 preserves the source mtime, so the file's mtime should be stable
     # across repeated calls (guards against a re-download/re-build loop).
     assert target.stat().st_mtime_ns == first_mtime
+
+
+def test_ensure_installed_refreshes_stale_executable(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(cs_cite, "_INSTALL_DIR", tmp_path / "bin")
+    monkeypatch.setattr(cs_cite, "INSTALL_PATH", tmp_path / "bin" / "cs-cite")
+    target = tmp_path / "bin" / "cs-cite"
+    target.parent.mkdir()
+    target.write_text("#!/bin/sh\nexit 1\n")
+    target.chmod(0o755)
+
+    cs_cite.ensure_installed()
+
+    assert target.read_bytes() == cs_cite._SOURCE_SCRIPT.read_bytes()
+    assert target.stat().st_mode & stat.S_IXUSR
 
 
 def test_ensure_installed_tolerates_readonly_target_parent(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1062,6 +1062,50 @@ def test_stop_records_cs_cite_ids_as_cited_items(
     ]
 
 
+def test_stop_records_text_marker_ids_as_cited_items(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    """The current citation path resolves ids from the final assistant marker."""
+    _prime_injected_registry("s1")
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {"type": "user", "message": {"content": "do the thing"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "Done.\n\n"
+                                "✨ 2 claude-smart learnings applied [cs:s1-42,p1-uuid]"
+                            ),
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
+    )
+    stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
+    records = state.read_all("s1")
+    assert records[-1]["content"] == (
+        "Done.\n\n✨ 2 claude-smart learnings applied [cs:s1-42,p1-uuid]"
+    )
+    assert records[-1].get("cited_items") == [
+        {"id": "s1-42", "kind": "playbook", "title": "use pathlib", "real_id": "42"},
+        {
+            "id": "p1-uuid",
+            "kind": "profile",
+            "title": "prefers anyio",
+            "real_id": "uuid-anyio",
+        },
+    ]
+
+
 def test_stop_preserves_cited_item_source_kind(
     session_dir, tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -7,14 +7,32 @@ import subprocess
 from claude_smart import ids
 
 
-def test_resolve_uses_git_toplevel_basename(tmp_path) -> None:
+_GIT_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+)
+
+
+def _isolate_git_env(monkeypatch) -> None:
+    # Pre-commit/rebase contexts inherit GIT_DIR + friends that would override
+    # cwd-based discovery in subprocess git calls and break tmp_path isolation.
+    for name in _GIT_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_resolve_uses_git_toplevel_basename(tmp_path, monkeypatch) -> None:
+    _isolate_git_env(monkeypatch)
     subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
     subdir = tmp_path / "packages" / "core"
     subdir.mkdir(parents=True)
     assert ids.resolve_project_id(subdir) == tmp_path.name
 
 
-def test_resolve_falls_back_to_cwd_basename_outside_git(tmp_path) -> None:
+def test_resolve_falls_back_to_cwd_basename_outside_git(tmp_path, monkeypatch) -> None:
+    _isolate_git_env(monkeypatch)
     # tmp_path from pytest is not inside a git repo.
     assert ids.resolve_project_id(tmp_path) == tmp_path.name
 


### PR DESCRIPTION
## Summary
- Make claude-smart a dual-runtime plugin: the same Python package, reflexio store, and learning corpus run under both Claude Code and the Codex CLI.
- Pass the host (`claude-code` | `codex`) as an explicit argv argument from each runtime's hook manifest into the shared `hook_entry.sh`, then into a new `runtime` module — no env-var toggling, no host guessing.
- Adapt only what genuinely differs per host: citation channel (text marker vs Bash tool call), PreToolUse (Codex has no contract), Stop payload shape (Codex provides `last_assistant_message`), apply_patch tool input, and the install flow.

## Changes
**Codex plugin packaging**
- `plugin/.codex-plugin/plugin.json` — Codex manifest pointing at `./hooks/codex-hooks.json`.
- `plugin/hooks/codex-hooks.json` — `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `Stop` (no `PreToolUse`).
- `plugin/scripts/_codex_env.sh` — shared PATH + plugin-root bootstrap sourced by every Codex hook.
- `.agents/plugins/marketplace.json` — local Codex marketplace (`claude-smart-local`).

**Shared runtime**
- `plugin/src/claude_smart/runtime.py` — `set_host` / `host` / `is_codex` / `agent_version` / `is_internal_invocation_env`. Agent version stays `claude-code` for both hosts so the learning corpus is shared across runtimes.
- `plugin/scripts/hook_entry.sh` accepts `claude-code | codex` as first argv and forwards `<host> <event>` to `python -m claude_smart.hook`. Legacy single-arg `<event>` invocation still works.
- `plugin/src/claude_smart/hook.py` argv parser handles both forms; `plugin/hooks/hooks.json` now passes `claude-code` explicitly.

**Host-specific event behavior**
- `events/pre_tool.py`: Codex has no PreToolUse contract; emit `{"continue": true}` without injection.
- `events/stop.py`: under Codex, prefer `last_assistant_message` payload; resolve text-marker citations.
- `cs_cite.py`: Codex citation channel is a text marker (`✨ N claude-smart learning(s) applied [cs:…]`); legacy `cs-cite` Bash call kept as fallback for Claude transcripts.

**Codex install command**
- `cli.py`: `claude-smart install --host codex` seeds `~/.reflexio/.env`, enables `plugin_hooks` (`codex features enable plugin_hooks` with a TOML-edit fallback to `~/.codex/config.toml`), and registers the local marketplace, auto-recovering from "different source" by removing and re-adding.
- `_set_toml_feature` handles existing values, spacing variants, and inserts before the next section.

**Tests**
- `tests/test_codex_support.py` (new): manifest schema, hook argv contract, legacy + new argv parsing, Codex-specific pre-tool / stop / post-tool behavior, citation text format, install success/failure paths, TOML helper edge cases, stale-marketplace replacement.
- Updates to `conftest.py`, `test_context_format.py`, `test_cs_cite.py`, `test_events.py` for the new citation format and host state.
- `test_ids.py` sanitizes inherited `GIT_DIR` / `GIT_INDEX_FILE` so the toplevel-resolution tests stay correct when invoked from a pre-commit hook.

## Test Plan
- [x] `uv run --project plugin pytest tests/` — 234 passed locally (including the new file and the pre-commit-context fix).
- [x] `ruff check` clean on `plugin/src` + `tests`.
- [ ] Manual: in Claude Code, restart a session — SessionStart still injects context, citations still emit via the existing channel.
- [ ] Manual: `claude-smart install --host codex` succeeds against a real Codex CLI; `codex features` shows `plugin_hooks = true`; `codex plugin marketplace list` includes `claude-smart-local`; a Codex session loads context and the Stop hook records the final assistant message.
- [ ] Manual: a Codex session that cites an injected `[cs:…]` id emits the text marker exactly once at the end of the reply and the Stop hook resolves it against the per-session injected registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing the plugin on Codex
  * Implemented text-based citation tracking system
  * Plugin now supports multi-host environments with host-aware behavior

* **Tests**
  * Added comprehensive test suite for Codex integration and host-specific functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/18)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->