### PR TITLE
chore: rename /test-all skill to /check-and-test for clarity

### DIFF
--- a/.claude/commands/check-and-test/SKILL.md
+++ b/.claude/commands/check-and-test/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: check-and-test
-description: Run lint checks (ruff for Python, Biome for TS/JS), type checks (pyright for Python, tsc for TS/JS), and all tests including e2e tests and tests skipped during pre-commit. Investigates failures to determine if they are application bugs or test issues, and fixes application bugs rather than weakening tests.
+description: Run lint checks (ruff for Python, Biome for TS/JS), type checks (pyright for Python, tsc for TS/JS), and the standard pytest tiers (unit + e2e + tests skipped during pre-commit). Investigates failures to determine if they are application bugs or test issues, and fixes application bugs rather than weakening tests. Does not run paid-LLM real-API tests or scenario probes from the test-* command family.
 ---
 
 # Check and Test
 
-Run the complete test suite including tests that are normally skipped during pre-commit hooks.
+Run the standard check-and-test flow (lint + type-check + pytest tiers), including tests normally skipped during pre-commit hooks.
 
 ## Overview
 
-This command runs all tests in the repository:
+This command runs the standard check-and-test tiers:
 - **Python lint checks** via ruff (code quality, security, complexity)
 - **Python type checks** via pyright (type safety)
 - **TypeScript/JavaScript lint checks** via Biome (code quality, formatting, import sorting)

--- a/.claude/commands/check-and-test/SKILL.md
+++ b/.claude/commands/check-and-test/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: test-all
+name: check-and-test
 description: Run lint checks (ruff for Python, Biome for TS/JS), type checks (pyright for Python, tsc for TS/JS), and all tests including e2e tests and tests skipped during pre-commit. Investigates failures to determine if they are application bugs or test issues, and fixes application bugs rather than weakening tests.
 ---
 
-# Test All
+# Check and Test
 
 Run the complete test suite including tests that are normally skipped during pre-commit hooks.
 


### PR DESCRIPTION
## Why
The old `/test-all` name claimed completeness ("-all") but excluded real-API tests, stress tests, and paid-LLM tiers. Renamed for accuracy: `check-and-test` = lint + format + type-check + the standard pytest tiers. No completeness claim.

## Scope
- Renamed `.claude/commands/test-all/` -> `check-and-test/` in claude-smart's own skills.
- Updated `name:` frontmatter and `# Title` heading in `SKILL.md`.
- Rewrote the `description:`, subtitle line, and Overview lead-in to drop "complete test suite" / "all tests in the repository" wording (commit a39774b, in response to CodeRabbit's inline review). Added an explicit exclusion sentence listing what `check-and-test` does NOT cover: paid-LLM real-API tests, and scenario-probe skills from the `test-*` command family.
- Did NOT touch the embedded `reflexio/` checkout — that mirror updates when claude-smart re-syncs after the open-source reflexio rename PR merges.

## Note on cross-fork
The active `gh` user (`yilu331`) doesn't have direct push access to `ReflexioAI/claude-smart`, so the branch lives on the `yilu331/claude-smart` fork and this PR is a cross-fork PR.

Companion PRs: ReflexioAI/reflexio-enterprise#56 (bundles the enterprise rename + a separate nightly-CI fix) and ReflexioAI/reflexio#61 (open-source submodule rename). They land independently.