### PR TITLE
feat: credit/auth stall notification in SessionStart + dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ local-marketplace/
 # Scheduled tasks lock
 .claude/scheduled_tasks.lock
 .coverage
+
+# Local design docs / brainstorm specs (kept out of public repo)
+docs/superpowers/

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -427,3 +427,33 @@ Useful for debugging without a live Claude Code session:
 echo '{"session_id":"dev-1","source":"startup","cwd":"'"$PWD"'"}' \
   | uv run --project plugin python -m claude_smart.hook session-start
 ```
+
+## Manual smoke tests — credit-stall notification
+
+These exercise the credit-stall detection path end-to-end against real reflexio state.
+
+### 1. Force a stall via SQLite
+
+```bash
+sqlite3 ~/.reflexio/data/reflexio.db <<'SQL'
+UPDATE stall_state SET stalled=1, reason='billing_error',
+  stalled_at=datetime('now'), notified_in_cc=0,
+  error_message='manual smoke test';
+SQL
+```
+
+Open `http://localhost:3001` — the banner should appear. Start a new Claude Code session — the SessionStart banner should appear once. Start a second session immediately — no banner (notified_in_cc was flipped).
+
+Clear:
+
+```bash
+sqlite3 ~/.reflexio/data/reflexio.db "UPDATE stall_state SET stalled=0, reason=NULL, notified_in_cc=0 WHERE id=1;"
+```
+
+### 2. Real auth stall
+
+`claude /logout`, then trigger any reflexio extraction (e.g. `/learn`). Expect `reason='auth_error'`, then a `/login` banner on the next SessionStart.
+
+### 3. Real billing stall
+
+Reproducible only against an exhausted Agent SDK credit pool. Capture the stream-json output as a fixture under `reflexio/tests/server/llm/fixtures/` so the integration test stays current as Anthropic's error format evolves.

--- a/plugin/dashboard/app/layout.tsx
+++ b/plugin/dashboard/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Providers } from "./providers";
 import { Sidebar } from "@/components/layout/sidebar";
 import { TopBar } from "@/components/layout/top-bar";
+import { StallBanner } from "@/components/stall-banner";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -24,6 +25,7 @@ export default function RootLayout({
     <html lang="en" className={`${inter.variable} h-full`} suppressHydrationWarning>
       <body className="h-full flex flex-col antialiased font-sans">
         <Providers>
+          <StallBanner />
           <TopBar />
           <div className="flex flex-1 min-h-0">
             <aside className="hidden lg:block w-60 border-r border-border shrink-0">

--- a/plugin/dashboard/components/stall-banner.tsx
+++ b/plugin/dashboard/components/stall-banner.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useStallState } from "@/hooks/use-stall-state";
+
+/**
+ * Persistent top-of-page banner shown while reflexio learning is stalled.
+ * Renders nothing when state is null or clean.
+ */
+export function StallBanner() {
+  const state = useStallState();
+  if (!state || !state.stalled) return null;
+
+  const text = renderText(state.reason, state.reset_estimate);
+  if (!text) return null;
+
+  return (
+    <div
+      role="status"
+      className="w-full bg-amber-100 text-amber-900 border-b border-amber-300 px-4 py-2 text-sm dark:bg-amber-950 dark:text-amber-100 dark:border-amber-800"
+    >
+      {text}
+    </div>
+  );
+}
+
+function renderText(
+  reason: string | null,
+  resetEstimate: string | null,
+): string {
+  if (reason === "billing_error") {
+    if (resetEstimate) {
+      const formatted = formatReset(resetEstimate);
+      return `claude-smart: learning paused — Agent SDK credit exhausted (resets ~${formatted}).`;
+    }
+    return "claude-smart: learning paused — Agent SDK credit exhausted.";
+  }
+  if (reason === "auth_error") {
+    return "claude-smart: learning paused — please run /login in Claude Code.";
+  }
+  return "";
+}
+
+function formatReset(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/plugin/dashboard/components/stall-banner.tsx
+++ b/plugin/dashboard/components/stall-banner.tsx
@@ -16,6 +16,7 @@ export function StallBanner() {
   return (
     <div
       role="status"
+      aria-live="polite"
       className="w-full bg-amber-100 text-amber-900 border-b border-amber-300 px-4 py-2 text-sm dark:bg-amber-950 dark:text-amber-100 dark:border-amber-800"
     >
       {text}

--- a/plugin/dashboard/hooks/use-stall-state.ts
+++ b/plugin/dashboard/hooks/use-stall-state.ts
@@ -33,13 +33,17 @@ export function useStallState(): StallState | null {
     const base = reflexioUrl.replace(/\/$/, "");
 
     const tick = async () => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 10_000);
       try {
-        const resp = await fetch(`${base}/stall_state`);
+        const resp = await fetch(`${base}/stall_state`, { signal: controller.signal });
         if (!resp.ok) return;
         const body: StallState = await resp.json();
         if (!cancelled) setState(body);
       } catch {
-        // Reflexio offline — leave previous state in place.
+        // Reflexio offline / aborted — leave previous state in place.
+      } finally {
+        clearTimeout(timer);
       }
     };
 

--- a/plugin/dashboard/hooks/use-stall-state.ts
+++ b/plugin/dashboard/hooks/use-stall-state.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSettings } from "@/hooks/use-settings";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export type StallReason = "billing_error" | "auth_error";
+
+export interface StallState {
+  stalled: boolean;
+  reason: StallReason | null;
+  stalled_at: string | null;
+  reset_estimate: string | null;
+  notified_in_cc: boolean;
+  error_message: string | null;
+}
+
+/**
+ * Polls reflexio's GET /stall_state every minute. Returns the latest
+ * snapshot or `null` while still loading / when the server is unreachable.
+ *
+ * Reads the reflexio URL from the dashboard's settings context (the same
+ * URL the user can override in the top bar) so the banner follows whatever
+ * reflexio backend the rest of the dashboard is pointed at.
+ */
+export function useStallState(): StallState | null {
+  const { reflexioUrl } = useSettings();
+  const [state, setState] = useState<StallState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const base = reflexioUrl.replace(/\/$/, "");
+
+    const tick = async () => {
+      try {
+        const resp = await fetch(`${base}/stall_state`);
+        if (!resp.ok) return;
+        const body: StallState = await resp.json();
+        if (!cancelled) setState(body);
+      } catch {
+        // Reflexio offline — leave previous state in place.
+      }
+    };
+
+    tick();
+    const id = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [reflexioUrl]);
+
+  return state;
+}

--- a/plugin/src/claude_smart/events/session_start.py
+++ b/plugin/src/claude_smart/events/session_start.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import Any
 
 from claude_smart import hook
 from claude_smart.reflexio_adapter import Adapter
+from claude_smart.stall_banner import render_banner
 
 # Claude-smart's preferred extraction cadence — more frequent, smaller windows
 # than reflexio's out-of-box 10/5. Applied idempotently to the reflexio server
@@ -21,13 +23,64 @@ _DISABLE_OPTIMIZER_ENV = "CLAUDE_SMART_ENABLE_OPTIMIZER"
 _OPTIMIZER_TIMEOUT_SECONDS = 300
 
 
+def _adapter() -> Adapter:
+    """Construct the reflexio adapter for this hook invocation.
+
+    Indirected through a factory so tests can monkeypatch the adapter
+    construction without touching the ``Adapter`` class itself.
+
+    Returns:
+        Adapter: A fresh adapter bound to the current process env.
+    """
+    return Adapter()
+
+
+def _stall_banner(adapter: Any) -> str:
+    """Return the prepend-able stall banner, or "" if no banner should fire.
+
+    Reads ``adapter.fetch_stall_state()``; if it reports an active, not-yet-
+    notified stall, renders a one-line banner via ``stall_banner.render_banner``.
+    All exceptions are absorbed: this is defense-in-depth — even though the
+    hook dispatcher already wraps ``handle`` in try/except, a stall-path bug
+    must never block the existing playbook/profile rendering.
+
+    Args:
+        adapter (Any): The adapter to query. Duck-typed so tests can stub.
+
+    Returns:
+        str: The banner text, or ``""`` when there is nothing to show.
+    """
+    try:
+        state_obj = adapter.fetch_stall_state()
+    except Exception:  # noqa: BLE001 — stall path must never crash the hook.
+        return ""
+    if state_obj is None:
+        return ""
+    if not getattr(state_obj, "stalled", False):
+        return ""
+    if getattr(state_obj, "notified_in_cc", False):
+        return ""
+    try:
+        return render_banner(
+            reason=getattr(state_obj, "reason", None),
+            reset_estimate=getattr(state_obj, "reset_estimate", None),
+        )
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def handle(payload: dict[str, Any]) -> None:
     session_id = payload.get("session_id")
     if not session_id:
         hook.emit_continue()
         return
 
-    adapter = Adapter()
+    adapter = _adapter()
+
+    # Stall banner — prepended to additionalContext, fires at most once per
+    # stall event (controlled server-side via mark_stall_notified).
+    banner = _stall_banner(adapter)
+
     adapter.apply_extraction_defaults(
         window_size=_CLAUDE_SMART_WINDOW_SIZE,
         stride_size=_CLAUDE_SMART_STRIDE_SIZE,
@@ -37,7 +90,27 @@ def handle(payload: dict[str, Any]) -> None:
             script_path=_optimizer_assistant_path(),
             timeout_seconds=_OPTIMIZER_TIMEOUT_SECONDS,
         )
-    hook.emit_continue()
+
+    if not banner:
+        hook.emit_continue()
+        return
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": banner,
+                }
+            }
+        )
+    )
+    sys.stdout.write("\n")
+
+    try:
+        adapter.mark_stall_notified()
+    except Exception:  # noqa: BLE001 — telemetry must not break session.
+        pass
 
 
 def _optimizer_assistant_path() -> str:

--- a/plugin/src/claude_smart/events/session_start.py
+++ b/plugin/src/claude_smart/events/session_start.py
@@ -65,7 +65,7 @@ def _stall_banner(adapter: Any) -> str:
             reason=getattr(state_obj, "reason", None),
             reset_estimate=getattr(state_obj, "reset_estimate", None),
         )
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001 — render_banner bug must not block playbook injection.
         return ""
 
 

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -176,6 +176,41 @@ class Adapter:
             return False
 
     # -----------------------------------------------------------------
+    # Stall-state reads/writes (used by SessionStart banner)
+    # -----------------------------------------------------------------
+
+    def fetch_stall_state(self) -> Any | None:
+        """Fetch the current learning-stall snapshot from reflexio.
+
+        Returns:
+            Any | None: ``StallStateResponse``-shaped object (attribute access
+                for stalled/reason/etc), or None when the reflexio server is
+                unreachable. The caller must tolerate either case.
+        """
+        client = self._get_client()
+        if client is None:
+            return None
+        try:
+            return client.get_stall_state()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("get_stall_state failed: %s", exc)
+            return None
+
+    def mark_stall_notified(self) -> None:
+        """Idempotently flip ``notified_in_cc`` on the active stall row.
+
+        Returns:
+            None
+        """
+        client = self._get_client()
+        if client is None:
+            return
+        try:
+            client.mark_stall_notified()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("mark_stall_notified failed: %s", exc)
+
+    # -----------------------------------------------------------------
     # Broad reads (used by /show)
     # -----------------------------------------------------------------
 

--- a/plugin/src/claude_smart/stall_banner.py
+++ b/plugin/src/claude_smart/stall_banner.py
@@ -14,12 +14,13 @@ StallReason = Literal["billing_error", "auth_error"]
 _DASHBOARD = "localhost:3001"
 
 
-def render_banner(*, reason: str, reset_estimate: datetime | None) -> str:
+def render_banner(*, reason: str | None, reset_estimate: datetime | None) -> str:
     """Format the SessionStart banner for the given stall reason.
 
     Args:
-        reason (str): ``"billing_error"`` or ``"auth_error"``. Other values
-            yield an empty string so callers can pass raw DB values safely.
+        reason (str | None): ``"billing_error"`` or ``"auth_error"``. Other values
+            (including ``None``) yield an empty string so callers can pass raw DB
+            values safely.
         reset_estimate (datetime | None): Best-effort credit reset time;
             included in the billing-error banner when present.
 

--- a/plugin/src/claude_smart/stall_banner.py
+++ b/plugin/src/claude_smart/stall_banner.py
@@ -48,5 +48,13 @@ def render_banner(*, reason: str, reset_estimate: datetime | None) -> str:
 
 
 def _format_reset(value: datetime) -> str:
-    """Format a reset datetime as e.g. ``Jun 12 09:00`` for the banner."""
-    return value.strftime("%b %d %H:%M").lstrip("0")
+    """Format a reset datetime as e.g. ``Jun 12 9:00`` for the banner.
+
+    Args:
+        value (datetime): The reset time to format.
+
+    Returns:
+        str: The banner-friendly representation, with the hour shown
+            without a leading zero (e.g. ``Jun 12 9:00``).
+    """
+    return f"{value.strftime('%b %d')} {value.hour}:{value.minute:02d}"

--- a/plugin/src/claude_smart/stall_banner.py
+++ b/plugin/src/claude_smart/stall_banner.py
@@ -1,0 +1,52 @@
+"""Render the 1-line SessionStart banner for a credit/auth stall.
+
+The template branches on the stall reason; output goes through Claude Code's
+``additionalContext`` so the model sees it once per stall event.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+StallReason = Literal["billing_error", "auth_error"]
+
+_DASHBOARD = "localhost:3001"
+
+
+def render_banner(*, reason: str, reset_estimate: datetime | None) -> str:
+    """Format the SessionStart banner for the given stall reason.
+
+    Args:
+        reason (str): ``"billing_error"`` or ``"auth_error"``. Other values
+            yield an empty string so callers can pass raw DB values safely.
+        reset_estimate (datetime | None): Best-effort credit reset time;
+            included in the billing-error banner when present.
+
+    Returns:
+        str: A single-line banner, or ``""`` for unknown reasons.
+    """
+    match reason:
+        case "billing_error":
+            if reset_estimate is None:
+                return (
+                    f"claude-smart: learning paused — Agent SDK credit "
+                    f"exhausted. Details: {_DASHBOARD}"
+                )
+            return (
+                f"claude-smart: learning paused — Agent SDK credit "
+                f"exhausted (resets ~{_format_reset(reset_estimate)}). "
+                f"Details: {_DASHBOARD}"
+            )
+        case "auth_error":
+            return (
+                f"claude-smart: learning paused — please run /login. "
+                f"Details: {_DASHBOARD}"
+            )
+        case _:
+            return ""
+
+
+def _format_reset(value: datetime) -> str:
+    """Format a reset datetime as e.g. ``Jun 12 09:00`` for the banner."""
+    return value.strftime("%b %d %H:%M").lstrip("0")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -528,3 +528,47 @@ def test_apply_optimizer_defaults_absorbs_get_config_errors() -> None:
     a = _adapter_with(_OptimizerConfigClient(get_raises=RuntimeError("down")))
 
     assert a.apply_optimizer_defaults(script_path="/venv/bin/assistant") is False
+
+
+# -----------------------------------------------------------------------------
+# fetch_stall_state / mark_stall_notified
+# -----------------------------------------------------------------------------
+
+
+class _StubClientWithStallState:
+    def __init__(self, response):
+        self._response = response
+        self.notified_called = False
+
+    def get_stall_state(self):
+        return self._response
+
+    def mark_stall_notified(self):
+        self.notified_called = True
+
+
+def test_fetch_stall_state_returns_none_when_client_unavailable():
+    adapter = reflexio_adapter.Adapter(url="http://nope/")
+    adapter._client = None  # type: ignore[attr-defined]
+    # _get_client returns None when reflexio unimportable / unreachable
+    assert adapter.fetch_stall_state() is None
+
+
+def test_fetch_stall_state_passes_through_when_clean(monkeypatch):
+    stub = _StubClientWithStallState(SimpleNamespace(
+        stalled=False, reason=None, stalled_at=None,
+        reset_estimate=None, notified_in_cc=False, error_message=None,
+    ))
+    adapter = reflexio_adapter.Adapter(url="http://x/")
+    monkeypatch.setattr(adapter, "_get_client", lambda: stub)
+    state = adapter.fetch_stall_state()
+    assert state is not None
+    assert state.stalled is False
+
+
+def test_mark_stall_notified_calls_through(monkeypatch):
+    stub = _StubClientWithStallState(None)
+    adapter = reflexio_adapter.Adapter(url="http://x/")
+    monkeypatch.setattr(adapter, "_get_client", lambda: stub)
+    adapter.mark_stall_notified()
+    assert stub.notified_called is True

--- a/tests/test_stall_banner.py
+++ b/tests/test_stall_banner.py
@@ -17,6 +17,7 @@ def test_billing_error_with_reset_estimate():
     assert "learning paused" in text
     assert "credit exhausted" in text
     assert "Jun 12" in text
+    assert "Jun 12 9:00" in text
     assert "localhost:3001" in text
 
 

--- a/tests/test_stall_banner.py
+++ b/tests/test_stall_banner.py
@@ -1,0 +1,37 @@
+"""Banner-text rendering for credit-stall notifications."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from claude_smart.stall_banner import render_banner
+
+
+def test_billing_error_with_reset_estimate():
+    text = render_banner(
+        reason="billing_error",
+        reset_estimate=datetime(2026, 6, 12, 9, 0, tzinfo=timezone.utc),
+    )
+    assert "learning paused" in text
+    assert "credit exhausted" in text
+    assert "Jun 12" in text
+    assert "localhost:3001" in text
+
+
+def test_billing_error_without_reset_estimate_drops_parenthetical():
+    text = render_banner(reason="billing_error", reset_estimate=None)
+    assert "learning paused" in text
+    assert "credit exhausted" in text
+    assert "resets" not in text
+
+
+def test_auth_error_mentions_login():
+    text = render_banner(reason="auth_error", reset_estimate=None)
+    assert "/login" in text
+    assert "credit" not in text
+
+
+def test_unknown_reason_returns_empty():
+    assert render_banner(reason="something_else", reset_estimate=None) == ""

--- a/tests/test_stall_in_session_start.py
+++ b/tests/test_stall_in_session_start.py
@@ -86,13 +86,42 @@ def test_clean_state_no_banner(clean_state, monkeypatch, session_dir):
     assert "learning paused" not in text
 
 
-def test_adapter_unreachable_does_not_crash(monkeypatch, session_dir):
+def test_state_none_does_not_crash(monkeypatch, session_dir):
     monkeypatch.setattr(
         "claude_smart.events.session_start._adapter",
         lambda: _AdapterStub(None),
     )
     text = _capture_output({"session_id": "s1", "cwd": "/tmp"})
     assert "learning paused" not in text  # silent skip
+
+
+def test_fetch_stall_state_raises_does_not_crash(monkeypatch, session_dir):
+    """When fetch_stall_state raises (e.g., reflexio server unreachable),
+    session_start must still emit normally with no banner."""
+
+    class _RaisingAdapter(_AdapterStub):
+        def fetch_stall_state(self):  # noqa: D102
+            raise ConnectionRefusedError("reflexio down")
+
+    monkeypatch.setattr(
+        "claude_smart.events.session_start._adapter",
+        lambda: _RaisingAdapter(None),
+    )
+    text = _capture_output({"session_id": "s1", "cwd": "/tmp"})
+    assert "learning paused" not in text
+
+
+def test_banner_only_emits_just_banner(stalled_state, monkeypatch, session_dir):
+    """Banner-only path: when there's no playbook/profile markdown, the
+    additionalContext is exactly the banner — no leading/trailing whitespace."""
+    monkeypatch.setattr(
+        "claude_smart.events.session_start._adapter",
+        lambda: _AdapterStub(stalled_state),
+    )
+    text = _capture_output({"session_id": "s1", "cwd": "/tmp"})
+    assert text.startswith("claude-smart: learning paused")
+    # No double-newline trailing — banner is the only content
+    assert "\n\n" not in text or text.split("\n\n")[1:] == [""]  # tolerate trailing newline
 
 
 class _AdapterStub:

--- a/tests/test_stall_in_session_start.py
+++ b/tests/test_stall_in_session_start.py
@@ -139,5 +139,8 @@ class _AdapterStub:
     def fetch_both(self, **kw):
         return [], []
 
-    def apply_batch_defaults(self, **kw):
+    def apply_extraction_defaults(self, **kw):
+        return True
+
+    def apply_optimizer_defaults(self, **kw):
         return True

--- a/tests/test_stall_in_session_start.py
+++ b/tests/test_stall_in_session_start.py
@@ -1,0 +1,114 @@
+"""SessionStart should prepend the stall banner exactly once per stall event."""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from claude_smart.events import session_start
+
+
+@pytest.fixture
+def stalled_state():
+    return SimpleNamespace(
+        stalled=True,
+        reason="billing_error",
+        stalled_at=datetime.now(timezone.utc),
+        reset_estimate=datetime(2026, 6, 12, 9, 0, tzinfo=timezone.utc),
+        notified_in_cc=False,
+        error_message="x",
+    )
+
+
+@pytest.fixture
+def clean_state():
+    return SimpleNamespace(
+        stalled=False,
+        reason=None,
+        stalled_at=None,
+        reset_estimate=None,
+        notified_in_cc=False,
+        error_message=None,
+    )
+
+
+def _capture_output(payload):
+    """Run session_start.handle with stdout captured. Returns the additionalContext."""
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        session_start.handle(payload)
+    out = buf.getvalue().strip()
+    if not out:
+        return ""
+    return json.loads(out).get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def test_stalled_unnotified_prepends_banner(stalled_state, monkeypatch, session_dir):
+    monkeypatch.setattr(
+        "claude_smart.events.session_start._adapter",
+        lambda: _AdapterStub(stalled_state),
+    )
+    text = _capture_output({"session_id": "s1", "cwd": "/tmp"})
+    assert "learning paused" in text
+    assert text.startswith("claude-smart: learning paused")
+
+
+def test_stalled_unnotified_calls_mark_notified(stalled_state, monkeypatch, session_dir):
+    stub = _AdapterStub(stalled_state)
+    monkeypatch.setattr("claude_smart.events.session_start._adapter", lambda: stub)
+    _capture_output({"session_id": "s1", "cwd": "/tmp"})
+    assert stub.notified_calls == 1
+
+
+def test_stalled_already_notified_does_not_prepend(
+    stalled_state, monkeypatch, session_dir
+):
+    stalled_state.notified_in_cc = True
+    monkeypatch.setattr(
+        "claude_smart.events.session_start._adapter",
+        lambda: _AdapterStub(stalled_state),
+    )
+    text = _capture_output({"session_id": "s1", "cwd": "/tmp"})
+    assert "learning paused" not in text
+
+
+def test_clean_state_no_banner(clean_state, monkeypatch, session_dir):
+    monkeypatch.setattr(
+        "claude_smart.events.session_start._adapter",
+        lambda: _AdapterStub(clean_state),
+    )
+    text = _capture_output({"session_id": "s1", "cwd": "/tmp"})
+    assert "learning paused" not in text
+
+
+def test_adapter_unreachable_does_not_crash(monkeypatch, session_dir):
+    monkeypatch.setattr(
+        "claude_smart.events.session_start._adapter",
+        lambda: _AdapterStub(None),
+    )
+    text = _capture_output({"session_id": "s1", "cwd": "/tmp"})
+    assert "learning paused" not in text  # silent skip
+
+
+class _AdapterStub:
+    def __init__(self, state):
+        self._state = state
+        self.notified_calls = 0
+
+    def fetch_stall_state(self):
+        return self._state
+
+    def mark_stall_notified(self):
+        self.notified_calls += 1
+
+    # Mirror the rest of Adapter's API as needed — return [] / no-op.
+    def fetch_both(self, **kw):
+        return [], []
+
+    def apply_batch_defaults(self, **kw):
+        return True


### PR DESCRIPTION
## Summary

- Surfaces a 1-line credit/auth stall notification in Claude Code's `SessionStart` and a persistent banner in the dashboard — sourced from reflexio's new `/stall_state` endpoint (server side: ReflexioAI/reflexio#63).
- Banner fires exactly once per stall event (server-side `notified_in_cc` gate); silent in all other states.
- Two stall reasons share one notification path via a discriminator: `billing_error` → "credit exhausted (resets ~...)", `auth_error` → "please run /login".
- Adapter and SessionStart code are written so a reflexio outage never crashes a CC session — every stall-path call is wrapped in try/except.

## Changes

### Plugin (Python)
- `plugin/src/claude_smart/stall_banner.py` — pure-function template renderer; `render_banner(reason, reset_estimate)` returns the 1-line banner or `""` for unknown reasons. `_format_reset` strips the leading zero from the hour (`Jun 12 9:00`, not `09:00`).
- `plugin/src/claude_smart/reflexio_adapter.py` — `Adapter.fetch_stall_state()` (returns `StallStateResponse`-shaped object or `None`) and `Adapter.mark_stall_notified()` (idempotent flip). Both swallow exceptions at `debug` level for parity with the other read methods.
- `plugin/src/claude_smart/events/session_start.py` — introduces a module-level `_adapter()` factory so tests can monkeypatch adapter construction. Inserts a `_stall_banner(adapter)` helper before the existing `apply_extraction_defaults` / `apply_optimizer_defaults` calls; when a banner fires, emits it as `additionalContext` and calls `mark_stall_notified` *after* the stdout write (so a SIGPIPE doesn't strand the notified flag).

### Dashboard (Next.js / React / TS)
- `plugin/dashboard/hooks/use-stall-state.ts` — `useStallState()` polls `GET /stall_state` on mount and every 60s, returns `StallState | null`. Uses `useSettings().reflexioUrl` so the banner follows the dashboard's runtime URL toggle. Has a 10s `AbortController` timeout so a hung server doesn't accumulate in-flight requests.
- `plugin/dashboard/components/stall-banner.tsx` — `<StallBanner />` client component. Returns `null` when state is null or clean. Renders amber + dark-mode variant with `role="status"` and `aria-live="polite"`.
- `plugin/dashboard/app/layout.tsx` — mounts `<StallBanner />` as the first child inside `<Providers>` so it sits at the very top of every page.

### Submodule + docs
- `reflexio` submodule pointer bumped to ReflexioAI/reflexio#63's HEAD (`0ec9e26`).
- `DEVELOPER.md` — appended a "Manual smoke tests — credit-stall notification" section with the SQL one-liners that force a stall and clear it.

## Diagrams

```mermaid
flowchart LR
    A[reflexio claude -p extraction fails<br/>billing/auth] --> B[server writes stall_state row]
    B --> C{Polling sources}
    C --> D[Claude Code SessionStart hook<br/>plugin adapter]
    C --> E[Dashboard useStallState<br/>60s poll]
    D -->|stalled and not notified_in_cc| F[Prepend banner to additionalContext]
    F --> G[POST stall_state/notified<br/>flip flag]
    E -->|stalled| H[Render top-of-page banner]
    A2[Next successful extraction] --> B2[server calls clear_stall_state]
    B2 --> C
```

## Test Plan

Automated (run via `uv run --project plugin pytest tests/`):
- `tests/test_stall_banner.py` — 4 cases: billing with/without reset, auth, unknown reason.
- `tests/test_adapter.py` — 3 added cases: client-unavailable returns None, passes through clean state, mark calls through.
- `tests/test_stall_in_session_start.py` — 7 integration cases: stalled+unnotified prepends banner, stalled+unnotified flips notified once, stalled+notified silent, clean state silent, state-None silent, `fetch_stall_state` raises silent, banner-only emits exactly the banner.
- All 42 feature tests pass; full plugin suite of 146 tests passes (one pre-existing unrelated CLI test failure flagged separately).

Dashboard:
- `npm run build` is clean (TypeScript + Next.js 16 build, no errors).

Manual / live smoke (verified end-to-end against the user's real `~/.reflexio/data/reflexio.db`):
- Seed `billing_error` via `UPDATE stall_state SET stalled=1, reason='billing_error', ...` → SessionStart hook emits the expected banner; second SessionStart goes silent; `notified_in_cc=true` confirmed via `GET /stall_state`.
- Switch to `reason='auth_error'` → banner says "/login", no "credit" mention.
- Clear → banner gone, both at SessionStart and in the dashboard polling cycle.
- Dashboard banner verified live via agent-browser screenshots in three states (billing, auth, clean) — amber bar at top of page in dark mode, copy matches spec.

```bash
# Manual one-liner to force a billing stall:
sqlite3 ~/.reflexio/data/reflexio.db <<'SQL'
UPDATE stall_state SET stalled=1, reason='billing_error',
  stalled_at=datetime('now'), reset_estimate=datetime('now','+1 day'),
  notified_in_cc=0, error_message='manual smoke test';
SQL

# Clear:
sqlite3 ~/.reflexio/data/reflexio.db \
  "UPDATE stall_state SET stalled=0, reason=NULL, notified_in_cc=0 WHERE id=1;"
```

## Notes for reviewers

- Depends on ReflexioAI/reflexio#63. The submodule pointer in this PR (`0ec9e26`) is the HEAD of that branch's `feat/stall-state`; both PRs should land together.
- Branch was rebased onto current `origin/main` after #18/#19 landed; one substantive conflict in `events/session_start.py` (which `main` simplified by dropping memory retrieval) was resolved to keep the new lean shape while inserting the stall path inline.
- The 60s dashboard poll interval is the right tradeoff for "noticeable within a minute, no thundering herd" — easy to tighten if reviewers prefer.
- Banner copy is intentionally terse and one-line per `[cs:p3-f3e7]` preference for minimal non-intrusive UX. Open to copy changes if the framing reads differently in context.
