### PR TITLE
feat: bundle Codex marketplace in npm package + harden install path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-smart",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "source": "./plugin",
       "description": "Learns user corrections and project playbooks via reflexio — uses Claude Code itself as the LLM backend (no external API key required)"
     }

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+*.bak
+.coverage

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -126,7 +126,7 @@ git pull --ff-only
 
 # 2. Dry-run to confirm what will ship (optional but cheap).
 make publish-dry
-#   → npm: tarball ~13 KB, 4 files: bin/claude-smart.js, LICENSE, README.md, package.json
+#   → npm: tarball includes bin/, .agents/plugins/marketplace.json, plugin/, LICENSE, README.md, package.json
 #   → PyPI: dist/ contains a wheel + sdist
 
 # 3. One-shot release. Bumps, commits, tags v$VERSION, publishes to both
@@ -177,7 +177,7 @@ Once published, end users update to the latest version with either:
 npx claude-smart update     # or: uvx claude-smart update
 ```
 
-Both wrap `claude plugin update claude-smart@reflexioai`. Users restart Claude Code to apply.
+Both wrap `claude plugin update claude-smart@reflexioai`. Users restart Claude Code to apply. Codex users rerun `npx claude-smart install --host codex`, then restart Codex after `/plugins` has upgraded the installed plugin.
 
 ## Pre-release checklist
 
@@ -228,9 +228,9 @@ rm -f package.json.bak pyproject.toml.bak .claude-plugin/*.bak
 
 ## Developing locally
 
-For iterating on claude-smart itself — editing hooks, the Python package, the dashboard, or the reflexio submodule — install from a clone and point Claude Code at your working copy. End users don't need any of this; the `npx`/`uvx` install flow in the README covers them.
+For iterating on claude-smart itself — editing hooks, the Python package, the dashboard, or the reflexio submodule — install from a clone and point the host at your working copy. End users don't need any of this; the `npx`/`uvx` install flow in the README covers them.
 
-### Two independent axes
+### Local install overview
 
 You can flip each axis independently — e.g. local plugin + PyPI reflexio is a valid combination (you're touching hooks/slash commands/dashboard but not the backend), and so is remote plugin + local reflexio (smoke-test the shipped plugin against a patched backend).
 
@@ -239,11 +239,18 @@ You can flip each axis independently — e.g. local plugin + PyPI reflexio is a 
 | **Plugin** — hooks, slash commands, Python package, dashboard | this repo's `plugin/` (marketplace `reflexioai-local`) | GitHub cache `~/.claude/plugins/cache/reflexioai/…` | `.claude/settings.local.json` → `enabledPlugins` |
 | **reflexio** — backend, extraction, storage | vendored submodule at `reflexio/` (editable) | PyPI wheel `reflexio-ai` | `plugin/pyproject.toml` → `[tool.uv.sources]` |
 
-### Fast path: one-shot setup for "everything local"
+Start every local install from a clone:
 
 ```bash
 git clone --recurse-submodules https://github.com/ReflexioAI/claude-smart.git
 cd claude-smart
+```
+
+### Claude Code local install
+
+Use the one-shot setup when developing the Claude Code plugin, dashboard, or local `reflexio` submodule:
+
+```bash
 bash scripts/setup-local-dev.sh
 ```
 
@@ -253,13 +260,89 @@ Idempotent. This single script handles everything — see its header comment for
 2. Uncomments `[tool.uv.sources]` in `plugin/pyproject.toml` (absolute path to the submodule) and hides the divergence with `git update-index --skip-worktree`.
 3. `uv sync` in `plugin/`.
 4. Appends `CLAUDE_SMART_USE_LOCAL_CLI=1` and `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` to `~/.reflexio/.env`.
-5. Registers the local marketplace (`local-marketplace/`, manifest name `reflexioai-local`) at user scope via `claude plugin marketplace add`.
+5. Prepares and registers the local marketplace (`local-marketplace/`, manifest name `reflexioai-local`) at user scope via `claude plugin marketplace add`.
 6. Writes `.claude/settings.local.json` → enable `claude-smart@reflexioai-local`, disable `claude-smart@reflexioai`.
 7. Force-sets `~/.reflexio/plugin-root` → `plugin/` so slash commands resolve to editable in-repo sources.
 
-**Then restart Claude Code.** That's the only manual step.
+Then restart Claude Code. In the new session, `/plugin` should show `claude-smart@reflexioai-local` and should not also show the published `claude-smart@reflexioai`.
 
-### Switching axis 1 — plugin source (local ↔ remote)
+Uninstalling the local Claude Code plugin is a marketplace/settings cleanup:
+
+```bash
+claude plugin marketplace remove reflexioai-local
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path(".claude/settings.local.json")
+if path.exists():
+    data = json.loads(path.read_text() or "{}")
+    enabled = data.get("enabledPlugins")
+    if isinstance(enabled, dict):
+        enabled.pop("claude-smart@reflexioai-local", None)
+        enabled.pop("claude-smart@reflexioai", None)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+rm -f ~/.reflexio/plugin-root
+```
+
+This leaves learned data under `~/.reflexio/` and `~/.claude-smart/` intact.
+
+### Codex local install
+
+Codex local development creates a durable local marketplace wrapper at `~/.claude/plugins/marketplaces/reflexioai`. The wrapper copies this checkout's `plugin/` directory to `./plugins/claude-smart`, which keeps Codex's plugin folder name aligned with the manifest name while preserving the existing Claude Code layout:
+
+```bash
+uv run --project plugin claude-smart install --host codex
+```
+
+Then fully restart Codex, open `/plugins`, and install `claude-smart` from the **ReflexioAI** marketplace. Restart Codex again after installation so hooks reload. Codex caches the installed plugin under `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/`.
+
+For live hook iteration, point Codex at this checkout before the cache:
+
+```bash
+mkdir -p ~/plugins
+ln -sfn "$PWD/plugin" ~/plugins/claude-smart
+```
+
+This symlink is only for local plugin development; normal `npx claude-smart install --host codex` users should not create it. The Codex hook resolver checks `~/plugins/claude-smart` before the Codex cache, so Python, hook, and script edits in `$PWD/plugin` are picked up without reinstalling the marketplace. Without that dev symlink, rerun `uv run --project plugin claude-smart install --host codex` after plugin edits so the wrapper copy is refreshed.
+
+Uninstall local Codex support with the CLI. This removes the Codex marketplace registration, installed plugin config, hook trust state, and Codex plugin cache while preserving learned data:
+
+```bash
+uv run --project plugin claude-smart uninstall --host codex
+rm -f ~/plugins/claude-smart
+```
+
+If `/plugins` still shows a stale pre-rename install, remove the legacy Codex state too:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+
+path = Path.home() / ".codex" / "config.toml"
+text = path.read_text()
+lines = text.splitlines(keepends=True)
+drop_prefixes = (
+    '[marketplaces.claude-smart-local]',
+    '[plugins."claude-smart@claude-smart-local"]',
+    '[hooks.state."claude-smart@claude-smart-local:',
+)
+out = []
+dropping = False
+for line in lines:
+    if line.startswith("[") and line.rstrip().endswith("]"):
+        dropping = any(line.startswith(prefix) for prefix in drop_prefixes)
+    if not dropping:
+        out.append(line)
+path.write_text("".join(out))
+PY
+rm -rf ~/.codex/plugins/cache/claude-smart-local
+```
+
+Restart Codex after uninstalling. Learned data under `~/.reflexio/` and `~/.claude-smart/` is intentionally preserved.
+
+### Switching Claude Code plugin source (local ↔ remote)
 
 Edit `.claude/settings.local.json` to flip which variant is enabled (both must be present so the other one is explicitly disabled and can't shadow):
 
@@ -279,7 +362,7 @@ Edit `.claude/settings.local.json` to flip which variant is enabled (both must b
 ```
 
 Prerequisites (one-time, already done by `setup-local-dev.sh`):
-- Local marketplace registered at user scope: `claude plugin marketplace add $PWD/local-marketplace`.
+- Local marketplace prepared and registered at user scope: `claude plugin marketplace add $PWD/local-marketplace`.
 - Remote marketplace registered at user scope (`~/.claude/settings.json` → `extraKnownMarketplaces.reflexioai` → `github: ReflexioAI/claude-smart`).
 
 **Apply the change:** restart Claude Code. In the new session, `/plugin` must show **exactly one** `claude-smart@…` entry (if it shows two, the scopes are stacking).
@@ -406,9 +489,11 @@ Useful when you're modifying the `install` subcommand itself and want to test wi
 ```bash
 uv run --project plugin claude-smart install --source $PWD    # Python path
 node bin/claude-smart.js install --source $PWD                # Node path
+uv run --project plugin claude-smart install --host codex      # Codex repo-local path
+node bin/claude-smart.js install --host codex                  # Codex packaged-marketplace path
 ```
 
-Both accept either a GitHub `owner/repo` ref or an absolute path to a local directory containing `.claude-plugin/marketplace.json`.
+The Claude Code install commands accept either a GitHub `owner/repo` ref or an absolute path to a local directory containing `.claude-plugin/marketplace.json`. The Codex Python path creates a local marketplace wrapper that copies this checkout's `plugin/`; the Codex Node path exercises the packaged no-clone flow by copying the bundled plugin into `~/.claude/plugins/marketplaces/reflexioai/plugins/claude-smart` before registering it with Codex.
 
 ## Tests
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -296,7 +296,7 @@ Codex local development creates a durable local marketplace wrapper at `~/.claud
 uv run --project plugin claude-smart install --host codex
 ```
 
-Then fully restart Codex, open `/plugins`, and install `claude-smart` from the **ReflexioAI** marketplace. Restart Codex again after installation so hooks reload. Codex caches the installed plugin under `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/`.
+Then fully restart Codex so hooks reload. The command installs `claude-smart` into `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/` and enables `[plugins."claude-smart@reflexioai"]` in `~/.codex/config.toml`; `/plugins` should show it as installed from the **ReflexioAI** marketplace.
 
 For live hook iteration, point Codex at this checkout before the cache:
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Release automation for claude-smart.
 #
 # Usage:
-#   make bump VERSION=0.1.1          Update version in all 4 manifests
+#   make bump VERSION=0.1.1          Update version in all release manifests
 #   make release VERSION=0.1.1       Bump, commit, tag v0.1.1, publish, push
 #   make publish                     Publish current version to npm + PyPI
 #   make publish-npm                 npm publish only
@@ -18,8 +18,8 @@
         ensure-remote-reflexio unskip-worktree
 
 VERSION_FILES := package.json plugin/pyproject.toml \
-                 plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json \
-                 README.md
+                 plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json \
+                 .claude-plugin/marketplace.json README.md
 LOCK_FILES    := plugin/uv.lock
 PYPROJECT     := plugin/pyproject.toml
 
@@ -76,15 +76,16 @@ ensure-remote-reflexio: ## Ensure [tool.uv.sources] is commented out so publishe
 	  exit 1; \
 	fi
 
-bump: check-version unskip-worktree ensure-remote-reflexio ## Rewrite version in all 4 manifests
+bump: check-version unskip-worktree ensure-remote-reflexio ## Rewrite version in all release manifests
 	@echo "→ bumping to $(VERSION)"
 	@sed -i.bak -E 's/"version": "[^"]+"/"version": "$(VERSION)"/' \
-	    package.json plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+	    package.json plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json \
+	    .claude-plugin/marketplace.json
 	@sed -i.bak -E 's/^version = "[^"]+"/version = "$(VERSION)"/' plugin/pyproject.toml
 	@sed -i.bak -E 's|badge/version-[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?-green\.svg|badge/version-$(VERSION)-green.svg|' README.md
 	@rm -f package.json.bak plugin/pyproject.toml.bak \
-	       plugin/.claude-plugin/plugin.json.bak .claude-plugin/marketplace.json.bak \
-	       README.md.bak
+	       plugin/.claude-plugin/plugin.json.bak plugin/.codex-plugin/plugin.json.bak \
+	       .claude-plugin/marketplace.json.bak README.md.bak
 	@echo "→ refreshing uv lockfile (resolves reflexio-ai from PyPI)"
 	@uv lock --refresh-package reflexio-ai --project plugin
 	@echo "→ resulting versions:"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   claude-smart
 </h1>
 
-<h4 align="center">The <a href="https://claude.com/claude-code" target="_blank">Claude Code</a> plugin that makes Claude Code self-improve as you use it — so Claude Code stops repeating mistakes and gets better every session.</h4>
+<h4 align="center">A local learning plugin for <a href="https://claude.com/claude-code" target="_blank">Claude Code</a> and Codex that turns corrections into durable rules your coding assistant follows in future sessions.</h4>
 
 <p align="center">
   <a href="LICENSE">
@@ -22,7 +22,7 @@
     <img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg" alt="Node">
   </a>
   <a href="#quick-start">
-    <img src="https://img.shields.io/badge/llm-claude%20code%20cli-purple.svg" alt="LLM">
+    <img src="https://img.shields.io/badge/hosts-Claude%20Code%20%2B%20Codex-purple.svg" alt="Hosts">
   </a>
   <a href="https://discord.gg/Jbft3jPn">
     <img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&logoColor=white" alt="Discord">
@@ -32,7 +32,7 @@
 <p align="center">
   <a href="#quick-start">Quick Start</a> •
   <a href="#how-it-works">How It Works</a> •
-  <a href="#slash-commands">Slash Commands</a> •
+  <a href="#commands">Commands</a> •
   <a href="#dashboard">Dashboard</a> •
   <a href="#configuration">Configuration</a> •
   <a href="TROUBLESHOOTING.md">Troubleshooting</a> •
@@ -40,7 +40,7 @@
 </p>
 
 <p align="center">
-  It learns both corrections and successful execution patterns—so Claude Code avoids repeating mistakes and reuses what works. Project-specific skills capture repo-local rules, and shared skills roll up durable patterns for reuse across projects.
+  It learns both corrections and successful execution patterns—so your coding assistant avoids repeating mistakes and reuses what works. Project-specific skills capture repo-local rules, and shared skills roll up durable patterns for reuse across projects.
 </p>
 
 <p align="center">
@@ -55,7 +55,7 @@ Most memory solutions are still mostly informative—Claude remembers what happe
 
 `claude-smart` focuses on learning instead.
 
-Four ways this changes what Claude Code can do for you:
+Four ways this changes what your coding assistant can do for you:
 
 - 💡 **Stop repeating the same mistakes:** Produces actionable skills Claude can follow next time; memory only records what happened.
 
@@ -77,6 +77,8 @@ Four ways this changes what Claude Code can do for you:
 ---
 
 ## Quick Start
+
+### Claude Code
 
 ```bash
 claude plugin marketplace add ReflexioAI/claude-smart
@@ -108,10 +110,45 @@ Or, if you already have Node.js or uv:
 npx claude-smart uninstall     # or: uvx claude-smart uninstall
 ```
 
-Local data under `~/.reflexio/` and `~/.claude-smart/` is left in place — remove manually if desired.
+### Codex
+
+You need the `codex` CLI on `PATH` and Node.js available for `npx`:
+
+```bash
+npx claude-smart install --host codex
+```
+
+The helper registers the bundled **ReflexioAI** marketplace with Codex and
+enables Codex plugin hooks. Then:
+
+1. Fully quit and reopen Codex in your project.
+2. Run `/plugins`.
+3. Install `claude-smart` from the **ReflexioAI** marketplace.
+4. Restart Codex again so hooks reload.
+
+Do not create a `~/plugins/claude-smart` symlink for a normal `npx` install;
+that symlink is only for plugin development from a cloned checkout.
+
+Installing from a clone is only for plugin development; see
+[DEVELOPER.md](./DEVELOPER.md#developing-locally).
+
+Codex and Claude Code intentionally share the same `CLAUDE_SMART_*` environment
+variables, `~/.reflexio/` data, `~/.claude-smart/` session buffers, backend,
+dashboard, and learned skills/preferences.
+
+
+To uninstall:
+
+```bash
+npx claude-smart uninstall --host codex
+```
+
+This removes the Codex marketplace registration, installed plugin config, and
+Codex plugin cache. Local data under `~/.reflexio/` and `~/.claude-smart/` is
+left in place — remove manually if desired. Restart Codex after uninstalling.
 
 Developing the plugin itself? See [DEVELOPER.md](./DEVELOPER.md#developing-locally).
-> **Not supported:** Claude Code Cowork and claude.ai/code web — they run in a remote sandbox, so the local backend/dashboard and `~/.reflexio/` aren't reachable.
+> **Not supported:** Claude Code Cowork, claude.ai/code web, or remote Codex environments without local plugin hooks — they run outside your local machine, so the local backend/dashboard and `~/.reflexio/` aren't reachable.
 
 ---
 
@@ -124,13 +161,13 @@ Developing the plugin itself? See [DEVELOPER.md](./DEVELOPER.md#developing-local
 - 🔌 **No external API call** — semantic search runs on an in-process ONNX embedder (all-MiniLM-L6-v2), and all data (preferences, skills, interaction buffers) is stored locally on your machine (`~/.reflexio/` and `~/.claude-smart/`).
 - 🔎 **Hybrid search** — Skills and preferences are indexed with vector + BM25 search for fast, robust retrieval.
 - 🧪 **Offline resilience** — If the reflexio backend is down, hooks buffer to disk; the next successful publish drains them.
-- 🧰 **Manual correction marker** — `/claude-smart:learn` flags the last turn as a correction so the extractor weights it heavily.
+- 🧰 **Manual correction marker** — `/claude-smart:learn` in Claude Code, or `bash ~/.reflexio/plugin-root/scripts/cli.sh learn` in Codex, flags the last turn as a correction so the extractor weights it heavily.
 
 ---
 
 ## Dashboard
 
-A web UI for browsing session histories, inspecting preferences, and editing project-specific and shared skills. The dashboard auto-starts alongside the backend, so you can open **http://localhost:3001** directly. Or run `/claude-smart:dashboard` in Claude Code to launch dashboard in browser.
+A web UI for browsing session histories, inspecting preferences, and editing project-specific and shared skills. The dashboard auto-starts alongside the backend, so you can open **http://localhost:3001** directly. Or run `/claude-smart:dashboard` in Claude Code to launch dashboard in browser. In Codex, run `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh`.
 
 <p align="center">
   <img src="assets/preferences_dashboard.png" alt="Preferences dashboard" width="49%">
@@ -141,7 +178,7 @@ A web UI for browsing session histories, inspecting preferences, and editing pro
 
 ## How It Works
 
-claude-smart builds three artifacts as you work and injects the relevant ones into Claude:
+claude-smart builds three artifacts as you work and injects the relevant ones into Claude Code or Codex:
 
 - **Preferences** (project-scoped) — how you work in this specific repo (stack, role, small quirks). *e.g.* "uses pnpm, not npm"; "prefers terse answers"; "backend engineer — explain frontend with backend analogues."
 - **Project-specific skills** — durable rules with triggers and rationales learned from corrections in a project. *e.g.* "always pass `--run` to `npm test` — watch mode hangs CI."
@@ -149,32 +186,35 @@ claude-smart builds three artifacts as you work and injects the relevant ones in
 
 Skills clean themselves up: correct the same thing twice and they merge; change your mind and the old one is archived.
 
-Under the hood: hooks watch your turns, tool calls, and Claude's replies, auto-flagging corrections (or anything you flag with `/learn`). At session end (or on `/learn`), [reflexio](https://github.com/ReflexioAI/reflexio) — the self-improving engine that powers claude-smart — extracts preferences and project-specific skills, then rolls durable patterns into shared skills. On each new user prompt, claude-smart searches for matching context and injects only the relevant hits. Run `/show` to audit the current learned state. Everything runs on your machine.
+Under the hood: hooks watch your turns, tool calls, and assistant replies, auto-flagging corrections (or anything you flag with `/learn`). At session end (or on `/learn`), [reflexio](https://github.com/ReflexioAI/reflexio) — the self-improving engine that powers claude-smart — extracts preferences and project-specific skills, then rolls durable patterns into shared skills. On each new user prompt, claude-smart searches for matching context and injects only the relevant hits. Run `/show` or the equivalent CLI command to audit the current learned state. Everything runs on your machine.
 
-**Citations (`cs-cite`).** At the end of a reply, Claude may run:
+**Citations.** At the end of a reply, the assistant may append a short marker:
 
 ```
-⏺ Bash(cs-cite s1-252,p1-5aed)
-  ⎿  (No output)
-
-⏺ ✨ 2 claude-smart learnings applied
+✨ 2 claude-smart learnings applied [cs:s1-252,p1-5aed]
 ```
 
-That signals a preference (`p…`) or skill (`s…`) materially shaped the reply. Open the interaction's detail page in the [dashboard](#dashboard) to see the exact cited item.
+That signals a preference (`p…`) or skill (`s…`) materially shaped the reply.
+Standalone wrappers like `✨abc123✨` are not claude-smart citations and will not
+link back to dashboard entries. Open the interaction's detail page in the
+[dashboard](#dashboard) to see the exact cited item.
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for hooks, data flow, and reflexio details.
 
 ---
 
-## Slash Commands
+## Commands
 
-| Command | What it does |
-| --- | --- |
-| `/dashboard` | Open the dashboard in your browser, auto-starting the reflexio backend and dashboard services if they aren't already running. |
-| `/show` | Print current project-specific skills, shared skills, and the current project's preferences so you can audit learned state manually. |
-| `/learn [note]` | Flag the most recent turn as a correction (for cases the automatic heuristic missed) and force reflexio to run extraction *now* on the session's unpublished interactions. The optional note becomes the correction description the extractor sees. |
-| `/restart` | Restart the reflexio backend and dashboard to pick up new changes (e.g. after upgrading the plugin or editing local reflexio code). |
-| `/clear-all` | **Destructive.** Delete *all* reflexio interactions, preferences, and skills. Use when you want to wipe learned state and start fresh. |
+Claude Code installs these as slash commands. In Codex, run the equivalent shell
+command directly, or ask Codex to run it.
+
+| Claude Code | Codex / shell | What it does |
+| --- | --- | --- |
+| `/dashboard` | `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh` | Open the dashboard in your browser, auto-starting the reflexio backend and dashboard services if they aren't already running. |
+| `/show` | `bash ~/.reflexio/plugin-root/scripts/cli.sh show` | Print current project-specific skills, shared skills, and the current project's preferences so you can audit learned state manually. |
+| `/learn [note]` | `bash ~/.reflexio/plugin-root/scripts/cli.sh learn --note "optional note"` | Flag the most recent turn as a correction (for cases the automatic heuristic missed) and force reflexio to run extraction *now* on the session's unpublished interactions. The optional note becomes the correction description the extractor sees. |
+| `/restart` | `bash ~/.reflexio/plugin-root/scripts/cli.sh restart` | Restart the reflexio backend and dashboard to pick up new changes (e.g. after upgrading the plugin or editing local reflexio code). |
+| `/clear-all` | `bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes` | **Destructive.** Delete *all* reflexio interactions, preferences, and skills. Use when you want to wipe learned state and start fresh. |
 
 ---
 
@@ -189,6 +229,8 @@ Advanced users can tune claude-smart via environment variables — see [DEVELOPE
 | `~/.reflexio/data/reflexio.db` | Source of truth for learned preferences, skills, interactions, full-text indexes, and embedding tables (plus `.db-shm` / `.db-wal` WAL sidecars). Inspect with `sqlite3`. |
 | `~/.reflexio/.env` | Provider config — `CLAUDE_SMART_USE_LOCAL_CLI`, `CLAUDE_SMART_USE_LOCAL_EMBEDDING`, any optional API keys. |
 | `.claude/settings.local.json` or `~/.claude/settings.json` | Claude Code hook environment, such as `CLAUDE_SMART_ENABLE_OPTIMIZER`; use project-local settings for one repo or user settings for all projects. |
+| `~/.codex/config.toml` | Codex feature flags, including `plugin_hooks = true` after `claude-smart install --host codex`. |
+| `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/` | Codex's cached install of the `claude-smart` plugin from the `ReflexioAI` marketplace. |
 | `~/.reflexio/plugin-root` | Self-healed symlink to the active plugin dir (managed by `ensure-plugin-root.sh` — written on install, refreshed each `SessionStart`). Slash commands resolve through it, so don't delete it; if you do, the next session will recreate it. |
 | `~/.claude-smart/sessions/{session_id}.jsonl` | Per-session buffer. User turns, assistant turns, tool invocations, `{"published_up_to": N}` watermarks. Safe to inspect and safe to delete — everything past the latest watermark has already been written to reflexio's DB. |
 | `~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/` | Cached ONNX weights (~86 MB, downloaded once). Delete to force a re-download. |
@@ -211,4 +253,4 @@ See the [LICENSE](LICENSE) file for details.
 
 ---
 
-**Built on** [reflexio](https://github.com/ReflexioAI/reflexio) · **Runs on** [Claude Code](https://claude.com/claude-code) · **Written in** Python 3.12+
+**Built on** [reflexio](https://github.com/ReflexioAI/reflexio) · **Runs on** [Claude Code](https://claude.com/claude-code) and Codex · **Written in** Python 3.12+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
   </a>
   <a href="plugin/pyproject.toml">
-    <img src="https://img.shields.io/badge/version-0.2.23-green.svg" alt="Version">
+    <img src="https://img.shields.io/badge/version-0.2.24-green.svg" alt="Version">
   </a>
   <a href="plugin/pyproject.toml">
     <img src="https://img.shields.io/badge/python-%3E%3D3.12-brightgreen.svg" alt="Python">

--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ npx claude-smart install --host codex
 ```
 
 The helper registers the bundled **ReflexioAI** marketplace with Codex and
-enables Codex plugin hooks. Then:
+enables Codex plugin hooks, installs `claude-smart` into Codex's local plugin
+cache, and enables it in `~/.codex/config.toml`. Then:
 
-1. Fully quit and reopen Codex in your project.
-2. Run `/plugins`.
-3. Install `claude-smart` from the **ReflexioAI** marketplace.
-4. Restart Codex again so hooks reload.
+1. Fully quit and reopen Codex in your project so hooks reload.
+2. Run `/plugins` only if you want to verify `claude-smart` shows as installed
+   from the **ReflexioAI** marketplace.
 
 Do not create a `~/plugins/claude-smart` symlink for a normal `npx` install;
 that symlink is only for plugin development from a cloned checkout.

--- a/README.md
+++ b/README.md
@@ -118,13 +118,18 @@ You need the `codex` CLI on `PATH` and Node.js available for `npx`:
 npx claude-smart install --host codex
 ```
 
-The helper registers the bundled **ReflexioAI** marketplace with Codex and
-enables Codex plugin hooks, installs `claude-smart` into Codex's local plugin
-cache, and enables it in `~/.codex/config.toml`. Then:
+The helper registers the bundled **ReflexioAI** marketplace with Codex, enables
+Codex's `plugin_hooks` feature, installs `claude-smart` into Codex's local
+plugin cache, and enables it in `~/.codex/config.toml`. Hooks are not active in
+already-running Codex windows; after the command finishes:
 
 1. Fully quit and reopen Codex in your project so hooks reload.
 2. Run `/plugins` only if you want to verify `claude-smart` shows as installed
    from the **ReflexioAI** marketplace.
+
+If you install or toggle `claude-smart` manually from `/plugins`, still run
+`npx claude-smart install --host codex` once afterward so `plugin_hooks` is
+enabled and the cache/config are prepared.
 
 Do not create a `~/plugins/claude-smart` symlink for a normal `npx` install;
 that symlink is only for plugin development from a cloned checkout.
@@ -186,7 +191,7 @@ claude-smart builds three artifacts as you work and injects the relevant ones in
 
 Skills clean themselves up: correct the same thing twice and they merge; change your mind and the old one is archived.
 
-Under the hood: hooks watch your turns, tool calls, and assistant replies, auto-flagging corrections (or anything you flag with `/learn`). At session end (or on `/learn`), [reflexio](https://github.com/ReflexioAI/reflexio) — the self-improving engine that powers claude-smart — extracts preferences and project-specific skills, then rolls durable patterns into shared skills. On each new user prompt, claude-smart searches for matching context and injects only the relevant hits. Run `/show` or the equivalent CLI command to audit the current learned state. Everything runs on your machine.
+Under the hood: hooks watch your turns, tool calls, and assistant replies, auto-flagging corrections (or anything you flag with `/claude-smart:learn`). At session end (or on `/claude-smart:learn`), [reflexio](https://github.com/ReflexioAI/reflexio) — the self-improving engine that powers claude-smart — extracts preferences and project-specific skills, then rolls durable patterns into shared skills. On each new user prompt, claude-smart searches for matching context and injects only the relevant hits. Run `/claude-smart:show` or the equivalent CLI command to audit the current learned state. Everything runs on your machine.
 
 **Citations.** At the end of a reply, the assistant may append a short marker:
 
@@ -205,16 +210,17 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for hooks, data flow, and reflexio deta
 
 ## Commands
 
-Claude Code installs these as slash commands. In Codex, run the equivalent shell
-command directly, or ask Codex to run it.
+Claude Code installs these as plugin slash commands. Codex does not currently
+support these plugin-provided slash commands, so run the equivalent shell command
+directly, or ask Codex to run it.
 
 | Claude Code | Codex / shell | What it does |
 | --- | --- | --- |
-| `/dashboard` | `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh` | Open the dashboard in your browser, auto-starting the reflexio backend and dashboard services if they aren't already running. |
-| `/show` | `bash ~/.reflexio/plugin-root/scripts/cli.sh show` | Print current project-specific skills, shared skills, and the current project's preferences so you can audit learned state manually. |
-| `/learn [note]` | `bash ~/.reflexio/plugin-root/scripts/cli.sh learn --note "optional note"` | Flag the most recent turn as a correction (for cases the automatic heuristic missed) and force reflexio to run extraction *now* on the session's unpublished interactions. The optional note becomes the correction description the extractor sees. |
-| `/restart` | `bash ~/.reflexio/plugin-root/scripts/cli.sh restart` | Restart the reflexio backend and dashboard to pick up new changes (e.g. after upgrading the plugin or editing local reflexio code). |
-| `/clear-all` | `bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes` | **Destructive.** Delete *all* reflexio interactions, preferences, and skills. Use when you want to wipe learned state and start fresh. |
+| `/claude-smart:dashboard` | `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh` | Open the dashboard in your browser, auto-starting the reflexio backend and dashboard services if they aren't already running. |
+| `/claude-smart:show` | `bash ~/.reflexio/plugin-root/scripts/cli.sh show` | Print current project-specific skills, shared skills, and the current project's preferences so you can audit learned state manually. |
+| `/claude-smart:learn [note]` | `bash ~/.reflexio/plugin-root/scripts/cli.sh learn --note "optional note"` | Flag the most recent turn as a correction (for cases the automatic heuristic missed) and force reflexio to run extraction *now* on the session's unpublished interactions. The optional note becomes the correction description the extractor sees. |
+| `/claude-smart:restart` | `bash ~/.reflexio/plugin-root/scripts/cli.sh restart` | Restart the reflexio backend and dashboard to pick up new changes (e.g. after upgrading the plugin or editing local reflexio code). |
+| `/claude-smart:clear-all` | `bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes` | **Destructive.** Delete *all* reflexio interactions, preferences, and skills. Use when you want to wipe learned state and start fresh. |
 
 ---
 
@@ -231,7 +237,7 @@ Advanced users can tune claude-smart via environment variables — see [DEVELOPE
 | `.claude/settings.local.json` or `~/.claude/settings.json` | Claude Code hook environment, such as `CLAUDE_SMART_ENABLE_OPTIMIZER`; use project-local settings for one repo or user settings for all projects. |
 | `~/.codex/config.toml` | Codex feature flags, including `plugin_hooks = true` after `claude-smart install --host codex`. |
 | `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/` | Codex's cached install of the `claude-smart` plugin from the `ReflexioAI` marketplace. |
-| `~/.reflexio/plugin-root` | Self-healed symlink to the active plugin dir (managed by `ensure-plugin-root.sh` — written on install, refreshed each `SessionStart`). Slash commands resolve through it, so don't delete it; if you do, the next session will recreate it. |
+| `~/.reflexio/plugin-root` | Self-healed symlink to the active plugin dir (managed by `ensure-plugin-root.sh` — written on install, refreshed each `SessionStart`). Claude Code slash commands and Codex shell-command helpers resolve through it, so don't delete it; if you do, the next session will recreate it. |
 | `~/.claude-smart/sessions/{session_id}.jsonl` | Per-session buffer. User turns, assistant turns, tool invocations, `{"published_up_to": N}` watermarks. Safe to inspect and safe to delete — everything past the latest watermark has already been written to reflexio's DB. |
 | `~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/` | Cached ONNX weights (~86 MB, downloaded once). Delete to force a re-download. |
 

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -1,22 +1,75 @@
 #!/usr/bin/env node
 /**
- * npx claude-smart install — thin wrapper around the native Claude Code
- * plugin CLI. Registers the GitHub marketplace, installs the plugin, and
- * seeds ~/.reflexio/.env with the two local-provider flags so reflexio
- * can route generation through the local `claude` CLI with no API key.
+ * npx claude-smart install — thin wrapper around the native host plugin
+ * CLIs. For Claude Code it registers the GitHub marketplace and installs the
+ * plugin. For Codex it copies the bundled local marketplace, registers it,
+ * and enables plugin hooks. Both paths seed ~/.reflexio/.env with the two
+ * local-provider flags so reflexio can route generation through local tools
+ * with no API key.
  *
  * Keep this file dependency-free — it runs via `npx` with no install step.
  */
 "use strict";
 
-const { execFileSync, execSync, spawn } = require("child_process");
-const { appendFileSync, existsSync, mkdirSync, readFileSync } = require("fs");
+const { execSync, spawn } = require("child_process");
+const {
+  appendFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} = require("fs");
 const { homedir } = require("os");
 const { dirname, join } = require("path");
 
 const DEFAULT_MARKETPLACE_SOURCE = "ReflexioAI/claude-smart";
 const PLUGIN_SPEC = "claude-smart@reflexioai";
+const CODEX_MARKETPLACE_NAME = "reflexioai";
+const CODEX_MARKETPLACE_DISPLAY_NAME = "ReflexioAI";
+const CODEX_PLUGIN_ID = `claude-smart@${CODEX_MARKETPLACE_NAME}`;
 const REFLEXIO_ENV_PATH = join(homedir(), ".reflexio", ".env");
+const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
+const PACKAGE_ROOT = dirname(dirname(__filename));
+const CODEX_MARKETPLACE_DIR = join(
+  homedir(),
+  ".claude",
+  "plugins",
+  "marketplaces",
+  CODEX_MARKETPLACE_NAME,
+);
+const CODEX_MARKETPLACE_PLUGIN_PATH = join("plugins", "claude-smart");
+const CODEX_PLUGIN_CACHE_DIR = join(
+  homedir(),
+  ".codex",
+  "plugins",
+  "cache",
+  CODEX_MARKETPLACE_NAME,
+  "claude-smart",
+);
+const CODEX_REQUIRED_FILES = [
+  ".agents/plugins/marketplace.json",
+  "plugin/.codex-plugin/plugin.json",
+  "plugin/hooks/codex-hooks.json",
+  "plugin/scripts/_codex_env.sh",
+];
+const CODEX_CLI_TIMEOUT_MS = 30_000;
+const COPYTREE_IGNORE_NAMES = new Set([
+  "__pycache__",
+  ".venv",
+  ".pytest_cache",
+  ".ruff_cache",
+  "node_modules",
+  ".next",
+]);
+
+function shouldCopyPath(src) {
+  const base = src.split(/[\\/]/).pop() || "";
+  if (COPYTREE_IGNORE_NAMES.has(base)) return false;
+  if (base.endsWith(".pyc") || base.endsWith(".pyo")) return false;
+  return true;
+}
 
 function runClaude(args, { spinnerLabel } = {}) {
   const useSpinner = Boolean(spinnerLabel) && process.stdout.isTTY && !process.env.CI;
@@ -80,13 +133,41 @@ function runClaude(args, { spinnerLabel } = {}) {
 }
 
 function hasClaudeCli() {
-  const probe = process.platform === "win32" ? "where claude" : "command -v claude";
+  return hasCli("claude");
+}
+
+function hasCli(name) {
+  const probe = process.platform === "win32" ? `where ${name}` : `command -v ${name}`;
   try {
     execSync(probe, { stdio: "ignore" });
     return true;
   } catch {
     return false;
   }
+}
+
+function runCodex(args) {
+  return new Promise((resolve) => {
+    const child = spawn("codex", args, {
+      stdio: "inherit",
+      timeout: CODEX_CLI_TIMEOUT_MS,
+      killSignal: "SIGTERM",
+    });
+    let timedOut = false;
+    child.on("exit", (code, signal) => {
+      if (signal === "SIGTERM" && code === null) {
+        timedOut = true;
+        process.stderr.write(
+          `error: codex ${args.join(" ")} timed out after ${CODEX_CLI_TIMEOUT_MS / 1000}s\n`,
+        );
+        resolve(124);
+        return;
+      }
+      if (timedOut) return;
+      resolve(typeof code === "number" ? code : 1);
+    });
+    child.on("error", () => resolve(1));
+  });
 }
 
 function seedReflexioEnv() {
@@ -106,18 +187,26 @@ function seedReflexioEnv() {
 function printHelp() {
   process.stdout.write(
     [
-      "claude-smart — install helper for the Claude Code plugin",
+      "claude-smart — install helper for Claude Code and Codex",
       "",
       "Usage:",
       "  npx claude-smart install                       Install the plugin into Claude Code",
+      "  npx claude-smart install --host codex          Register the plugin marketplace for Codex",
       "  npx claude-smart install --source <owner/repo> Override the marketplace source",
+      "  npx claude-smart uninstall --host codex        Remove the Codex marketplace registration",
       "  npx claude-smart --help                        Show this help",
       "",
-      "What it does:",
+      "Claude Code install:",
       "  1. claude plugin marketplace add <source>",
       `  2. claude plugin install ${PLUGIN_SPEC}`,
       "  3. Appends CLAUDE_SMART_USE_LOCAL_CLI=1 and CLAUDE_SMART_USE_LOCAL_EMBEDDING=1",
       "     to ~/.reflexio/.env (idempotent).",
+      "",
+      "Codex install:",
+      `  1. Copies the bundled marketplace to ${CODEX_MARKETPLACE_DIR}`,
+      "  2. codex plugin marketplace add <copied marketplace>",
+      "  3. codex features enable plugin_hooks",
+      "  4. Fully quit and reopen Codex, run /plugins, install claude-smart, then restart Codex.",
       "",
       "Update:",
       "  npx claude-smart update                        Update to the latest version",
@@ -140,6 +229,121 @@ function parseSource(args) {
   return value;
 }
 
+function parseHost(args) {
+  const idx = args.indexOf("--host");
+  if (idx === -1) return "claude-code";
+  const value = args[idx + 1];
+  if (!value) {
+    process.stderr.write("error: --host requires a value: claude-code or codex\n");
+    process.exit(1);
+  }
+  if (value !== "claude-code" && value !== "codex") {
+    process.stderr.write("error: --host must be claude-code or codex\n");
+    process.exit(1);
+  }
+  return value;
+}
+
+function copyCodexMarketplace() {
+  for (const rel of CODEX_REQUIRED_FILES) {
+    const path = join(PACKAGE_ROOT, rel);
+    if (!existsSync(path)) {
+      process.stderr.write(
+        `error: published package is missing ${rel}; reinstall claude-smart or use a newer release\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  rmSync(CODEX_MARKETPLACE_DIR, { recursive: true, force: true });
+  mkdirSync(join(CODEX_MARKETPLACE_DIR, ".agents", "plugins"), { recursive: true });
+  mkdirSync(join(CODEX_MARKETPLACE_DIR, "plugins"), { recursive: true });
+
+  writeFileSync(
+    join(CODEX_MARKETPLACE_DIR, ".agents", "plugins", "marketplace.json"),
+    JSON.stringify(
+      {
+        name: CODEX_MARKETPLACE_NAME,
+        interface: { displayName: CODEX_MARKETPLACE_DISPLAY_NAME },
+        plugins: [
+          {
+            name: "claude-smart",
+            source: {
+              source: "local",
+              path: `./${CODEX_MARKETPLACE_PLUGIN_PATH}`,
+            },
+            policy: {
+              installation: "AVAILABLE",
+              authentication: "ON_INSTALL",
+            },
+            category: "Productivity",
+          },
+        ],
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  cpSync(join(PACKAGE_ROOT, "plugin"), join(CODEX_MARKETPLACE_DIR, CODEX_MARKETPLACE_PLUGIN_PATH), {
+    recursive: true,
+    force: true,
+    verbatimSymlinks: false,
+    filter: shouldCopyPath,
+  });
+
+  for (const rel of ["README.md", "LICENSE", "package.json"]) {
+    const src = join(PACKAGE_ROOT, rel);
+    if (existsSync(src)) {
+      cpSync(src, join(CODEX_MARKETPLACE_DIR, rel), {
+        recursive: true,
+        force: true,
+        verbatimSymlinks: false,
+      });
+    }
+  }
+  return CODEX_MARKETPLACE_DIR;
+}
+
+function removeTomlSections(path, { exact, prefixes = [] }) {
+  if (!existsSync(path)) return true;
+  const text = readFileSync(path, "utf8");
+  if (!text) return true;
+
+  let changed = false;
+  let dropping = false;
+  const lines = text.split(/(?<=\n)/);
+  const kept = [];
+  for (const line of lines) {
+    const match = line.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/);
+    if (match) {
+      const name = match[1].trim();
+      dropping = exact.has(name) || prefixes.some((prefix) => name.startsWith(prefix));
+      changed = changed || dropping;
+    }
+    if (!dropping) kept.push(line);
+  }
+  if (changed) writeFileSync(path, kept.join(""));
+  return true;
+}
+
+function cleanupCodexInstallState() {
+  removeTomlSections(CODEX_CONFIG_PATH, {
+    exact: new Set([
+      `plugins."${CODEX_PLUGIN_ID}"`,
+      `marketplaces.${CODEX_MARKETPLACE_NAME}`,
+    ]),
+    prefixes: [`hooks.state."${CODEX_PLUGIN_ID}:`],
+  });
+  rmSync(CODEX_MARKETPLACE_DIR, { recursive: true, force: true });
+  rmSync(CODEX_PLUGIN_CACHE_DIR, { recursive: true, force: true });
+  try {
+    rmSync(dirname(CODEX_PLUGIN_CACHE_DIR), { recursive: false, force: true });
+  } catch {
+    // Leave the marketplace cache parent if Codex has other entries there.
+  }
+}
+
 async function runUpdate() {
   if (!hasClaudeCli()) {
     process.stderr.write(
@@ -160,7 +364,12 @@ async function runUpdate() {
   process.stdout.write("\nclaude-smart updated. Restart Claude Code to apply.\n");
 }
 
-async function runUninstall() {
+async function runUninstall(args) {
+  if (parseHost(args) === "codex") {
+    await runUninstallCodex();
+    return;
+  }
+
   if (!hasClaudeCli()) {
     process.stderr.write(
       "error: 'claude' CLI not found on PATH. " +
@@ -190,6 +399,11 @@ async function runUninstall() {
 }
 
 async function runInstall(args) {
+  if (parseHost(args) === "codex") {
+    await runInstallCodex();
+    return;
+  }
+
   if (!hasClaudeCli()) {
     process.stderr.write(
       "error: 'claude' CLI not found on PATH. " +
@@ -232,6 +446,77 @@ async function runInstall(args) {
   );
 }
 
+async function runInstallCodex() {
+  if (!hasCli("codex")) {
+    process.stderr.write("error: 'codex' CLI not found on PATH. Install Codex first.\n");
+    process.exit(1);
+  }
+
+  const marketplaceRoot = copyCodexMarketplace();
+  process.stdout.write(`Prepared Codex marketplace at ${marketplaceRoot}.\n`);
+
+  let code = await runCodex(["plugin", "marketplace", "add", marketplaceRoot]);
+  if (code !== 0) {
+    process.stderr.write(
+      `warning: \`codex plugin marketplace add ${marketplaceRoot}\` failed; retrying after removing ${CODEX_MARKETPLACE_NAME}.\n`,
+    );
+    await runCodex(["plugin", "marketplace", "remove", CODEX_MARKETPLACE_NAME]);
+    code = await runCodex(["plugin", "marketplace", "add", marketplaceRoot]);
+  }
+  if (code !== 0) {
+    process.stderr.write(
+      `error: could not register Codex marketplace. Run manually: codex plugin marketplace add ${marketplaceRoot}\n`,
+    );
+    process.exit(code);
+  }
+
+  code = await runCodex(["features", "enable", "plugin_hooks"]);
+  if (code !== 0) {
+    process.stderr.write("error: could not enable Codex plugin_hooks feature.\n");
+    process.exit(code);
+  }
+
+  const added = seedReflexioEnv();
+  if (added.length > 0) {
+    process.stdout.write(`Seeded ${REFLEXIO_ENV_PATH} with ${added.join(", ")}.\n`);
+  }
+
+  process.stdout.write(
+    [
+      "",
+      "claude-smart Codex support is prepared.",
+      `Fully quit and reopen Codex, run /plugins, install claude-smart from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace, then restart Codex so hooks reload.`,
+      "Local data is shared with Claude Code under ~/.reflexio/ and ~/.claude-smart/.",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function runUninstallCodex() {
+  if (!hasCli("codex")) {
+    process.stdout.write("Codex CLI not found; skipping marketplace removal.\n");
+    cleanupCodexInstallState();
+    return;
+  }
+
+  const code = await runCodex(["plugin", "marketplace", "remove", CODEX_MARKETPLACE_NAME]);
+  if (code !== 0) {
+    process.stderr.write(
+      `warning: Codex marketplace removal failed; remove manually with: codex plugin marketplace remove ${CODEX_MARKETPLACE_NAME}\n`,
+    );
+  }
+  cleanupCodexInstallState();
+
+  process.stdout.write(
+    [
+      "",
+      "claude-smart Codex plugin and marketplace state removed. Restart Codex to apply.",
+      "Codex's global plugin_hooks feature and local data under ~/.reflexio/ and ~/.claude-smart/ were left in place.",
+      "",
+    ].join("\n"),
+  );
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const cmd = args[0] || "install";
@@ -252,7 +537,7 @@ async function main() {
   }
 
   if (cmd === "uninstall") {
-    await runUninstall();
+    await runUninstall(args.slice(1));
     return;
   }
 

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -206,7 +206,8 @@ function printHelp() {
       `  1. Copies the bundled marketplace to ${CODEX_MARKETPLACE_DIR}`,
       "  2. codex plugin marketplace add <copied marketplace>",
       "  3. codex features enable plugin_hooks",
-      "  4. Fully quit and reopen Codex, run /plugins, install claude-smart, then restart Codex.",
+      "  4. Installs claude-smart into Codex's plugin cache and enables it",
+      "  5. Restart Codex.",
       "",
       "Update:",
       "  npx claude-smart update                        Update to the latest version",
@@ -344,6 +345,50 @@ function cleanupCodexInstallState() {
   }
 }
 
+function setCodexPluginEnabled() {
+  const sectionName = `plugins."${CODEX_PLUGIN_ID}"`;
+  removeTomlSections(CODEX_CONFIG_PATH, { exact: new Set([sectionName]) });
+  const existing = existsSync(CODEX_CONFIG_PATH)
+    ? readFileSync(CODEX_CONFIG_PATH, "utf8")
+    : "";
+  let next = existing;
+  if (next && !next.endsWith("\n")) next += "\n";
+  if (next.trim()) next += "\n";
+  next += `[${sectionName}]\nenabled = true\n`;
+  mkdirSync(dirname(CODEX_CONFIG_PATH), { recursive: true });
+  writeFileSync(CODEX_CONFIG_PATH, next);
+}
+
+function codexPluginVersion(pluginRoot) {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+    );
+    return typeof manifest.version === "string" && manifest.version
+      ? manifest.version
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function installCodexPluginCache(pluginRoot) {
+  const version = codexPluginVersion(pluginRoot);
+  if (!version) {
+    throw new Error(`missing version in ${join(pluginRoot, ".codex-plugin", "plugin.json")}`);
+  }
+  const cacheDir = join(CODEX_PLUGIN_CACHE_DIR, version);
+  rmSync(cacheDir, { recursive: true, force: true });
+  mkdirSync(dirname(cacheDir), { recursive: true });
+  cpSync(pluginRoot, cacheDir, {
+    recursive: true,
+    force: true,
+    verbatimSymlinks: false,
+  });
+  setCodexPluginEnabled();
+  return cacheDir;
+}
+
 async function runUpdate() {
   if (!hasClaudeCli()) {
     process.stderr.write(
@@ -476,6 +521,20 @@ async function runInstallCodex() {
     process.exit(code);
   }
 
+  let cacheDir = null;
+  try {
+    cacheDir = installCodexPluginCache(join(marketplaceRoot, CODEX_MARKETPLACE_PLUGIN_PATH));
+    process.stdout.write(`Installed Codex plugin cache at ${cacheDir}.\n`);
+  } catch (err) {
+    process.stderr.write(
+      `error: automatic Codex plugin install failed: ${err && err.message ? err.message : err}\n`,
+    );
+    process.stderr.write(
+      `Open Codex, run /plugins, and install claude-smart from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace manually.\n`,
+    );
+    process.exit(1);
+  }
+
   const added = seedReflexioEnv();
   if (added.length > 0) {
     process.stdout.write(`Seeded ${REFLEXIO_ENV_PATH} with ${added.join(", ")}.\n`);
@@ -484,8 +543,8 @@ async function runInstallCodex() {
   process.stdout.write(
     [
       "",
-      "claude-smart Codex support is prepared.",
-      `Fully quit and reopen Codex, run /plugins, install claude-smart from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace, then restart Codex so hooks reload.`,
+      "claude-smart Codex support is installed.",
+      `Restart Codex so the installed plugin and hooks reload. /plugins should show claude-smart as installed from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace.`,
       "Local data is shared with Claude Code under ~/.reflexio/ and ~/.claude-smart/.",
       "",
     ].join("\n"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Self-improving Claude Code plugin — learns from corrections via reflexio",
   "keywords": [
     "claude",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,16 @@
   },
   "files": [
     "bin",
+    ".agents/plugins/marketplace.json",
+    "plugin",
+    "!plugin/**/__pycache__",
+    "!plugin/**/*.py[cod]",
+    "!plugin/**/.pytest_cache",
+    "!plugin/**/.ruff_cache",
+    "!plugin/**/.mypy_cache",
+    "!plugin/**/.venv",
+    "!plugin/**/node_modules",
+    "!plugin/**/.next/cache",
     "README.md",
     "LICENSE"
   ],

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Self-improving Claude Code plugin — learns from corrections across sessions via reflexio",
   "author": {
     "name": "Yi Lu"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.22",
+  "version": "0.2.24",
   "description": "Self-improving coding assistant plugin — learns from corrections across sessions via reflexio",
   "author": {
     "name": "Yi Lu"

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-smart"
-version = "0.2.23"
+version = "0.2.24"
 description = "Self-improving Claude Code plugin — learns from corrections via reflexio"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -39,7 +39,21 @@ _REFLEXIO_ENV_PATH = Path.home() / ".reflexio" / ".env"
 _DEFAULT_MARKETPLACE_SOURCE = "ReflexioAI/claude-smart"
 _PLUGIN_SPEC = "claude-smart@reflexioai"
 _CODEX_MARKETPLACE_NAME = "reflexioai"
+_CODEX_MARKETPLACE_DISPLAY_NAME = "ReflexioAI"
+_CODEX_PLUGIN_ID = f"claude-smart@{_CODEX_MARKETPLACE_NAME}"
 _CODEX_CONFIG_PATH = Path.home() / ".codex" / "config.toml"
+_CODEX_LOCAL_MARKETPLACE_ROOT = (
+    Path.home() / ".claude" / "plugins" / "marketplaces" / _CODEX_MARKETPLACE_NAME
+)
+_CODEX_LOCAL_PLUGIN_PATH = Path("plugins") / "claude-smart"
+_CODEX_PLUGIN_CACHE_DIR = (
+    Path.home()
+    / ".codex"
+    / "plugins"
+    / "cache"
+    / _CODEX_MARKETPLACE_NAME
+    / "claude-smart"
+)
 _CODEX_CLI_TIMEOUT_SECONDS = 30
 _REFLEXIO_UNREACHABLE_MSG = (
     "Failed to reach reflexio. Check ~/.claude-smart/backend.log "
@@ -62,6 +76,16 @@ _CODEX_REQUIRED_FILES = (
     Path("plugin/.codex-plugin/plugin.json"),
     Path("plugin/hooks/codex-hooks.json"),
     Path("plugin/scripts/_codex_env.sh"),
+)
+_COPYTREE_IGNORE = shutil.ignore_patterns(
+    ".venv",
+    "__pycache__",
+    "*.pyc",
+    "*.pyo",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".next",
+    "node_modules",
 )
 
 
@@ -99,7 +123,71 @@ def _missing_codex_marketplace_files(root: Path) -> list[Path]:
     return [entry for entry in _CODEX_REQUIRED_FILES if not (root / entry).is_file()]
 
 
+def _prepare_codex_local_marketplace() -> Path:
+    """Create the local Codex marketplace wrapper used for install.
+
+    Wipes any prior wrapper at ``_CODEX_LOCAL_MARKETPLACE_ROOT``, copies
+    this checkout's ``plugin/`` directory under ``plugins/claude-smart``
+    (skipping dev artifacts in ``_COPYTREE_IGNORE``), and writes a fresh
+    ``.agents/plugins/marketplace.json`` pointing at it. The directory
+    name ``plugins/claude-smart`` keeps the on-disk plugin folder aligned
+    with the manifest name so Codex resolves it cleanly.
+
+    Returns:
+        Path: The marketplace root that Codex should register.
+    """
+    marketplace_root = _CODEX_LOCAL_MARKETPLACE_ROOT
+    marketplace_manifest = marketplace_root / ".agents" / "plugins" / "marketplace.json"
+    plugin_dir = marketplace_root / _CODEX_LOCAL_PLUGIN_PATH
+
+    if marketplace_root.exists() or marketplace_root.is_symlink():
+        if marketplace_root.is_dir() and not marketplace_root.is_symlink():
+            shutil.rmtree(marketplace_root)
+        else:
+            marketplace_root.unlink()
+    marketplace_manifest.parent.mkdir(parents=True, exist_ok=True)
+    plugin_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(_PLUGIN_ROOT, plugin_dir, symlinks=False, ignore=_COPYTREE_IGNORE)
+
+    marketplace_manifest.write_text(
+        json.dumps(
+            {
+                "name": _CODEX_MARKETPLACE_NAME,
+                "interface": {"displayName": _CODEX_MARKETPLACE_DISPLAY_NAME},
+                "plugins": [
+                    {
+                        "name": "claude-smart",
+                        "source": {
+                            "source": "local",
+                            "path": f"./{_CODEX_LOCAL_PLUGIN_PATH.as_posix()}",
+                        },
+                        "policy": {
+                            "installation": "AVAILABLE",
+                            "authentication": "ON_INSTALL",
+                        },
+                        "category": "Productivity",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return marketplace_root
+
+
 def _run_codex(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Invoke the ``codex`` CLI with a hard timeout.
+
+    Args:
+        args: Argument list after ``codex`` (e.g. ``["features", "enable",
+            "plugin_hooks"]``).
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed run. On timeout,
+            returns a synthetic process with exit code 124 and a stderr
+            message identifying the hung command.
+    """
     command = ["codex", *args]
     try:
         return subprocess.run(
@@ -175,7 +263,98 @@ def _set_toml_feature(path: Path, feature: str, value: bool) -> bool:
     return True
 
 
+def _remove_toml_sections(
+    path: Path, *, exact: set[str], prefixes: tuple[str, ...] = ()
+) -> bool:
+    """Remove simple top-level TOML sections by section name.
+
+    Walks ``path`` line by line, dropping every line from a matching
+    ``[section]`` header through the next header. Intended for minimal
+    TOML files like ``~/.codex/config.toml``; nested array-of-tables
+    (``[[…]]``) and inline tables are not supported.
+
+    Args:
+        path: TOML file to rewrite. A missing file is treated as success.
+        exact: Section names to drop (e.g. ``"marketplaces.reflexioai"``).
+        prefixes: Section-name prefixes to drop (e.g.
+            ``("hooks.state.\"claude-smart@reflexioai:",)``).
+
+    Returns:
+        bool: ``True`` if the file is now consistent (including the
+            no-op case). ``False`` only if the file existed but could
+            not be read or written.
+    """
+    try:
+        text = path.read_text() if path.exists() else ""
+    except OSError:
+        return False
+    if not text:
+        return True
+
+    section_re = re.compile(r"^\s*\[([^\]]+)\]\s*(?:#.*)?$")
+    changed = False
+    dropping = False
+    out: list[str] = []
+    for line in text.splitlines(keepends=True):
+        section_match = section_re.match(line)
+        if section_match:
+            name = section_match.group(1).strip()
+            dropping = name in exact or any(
+                name.startswith(prefix) for prefix in prefixes
+            )
+            changed = changed or dropping
+        if not dropping:
+            out.append(line)
+
+    if not changed:
+        return True
+    try:
+        path.write_text("".join(out))
+    except OSError:
+        return False
+    return True
+
+
+def _cleanup_codex_install_state() -> bool:
+    """Remove Codex's local install artifacts while preserving shared learning data.
+
+    Drops the ``[plugins."claude-smart@reflexioai"]`` /
+    ``[marketplaces.reflexioai]`` / ``[hooks.state."claude-smart@reflexioai:…"]``
+    sections from ``~/.codex/config.toml``, removes the marketplace
+    wrapper and the Codex-side plugin cache, and tries to clean the
+    parent cache directory if it is now empty. Shared
+    ``~/.reflexio/`` and ``~/.claude-smart/`` data, and Codex's global
+    ``plugin_hooks`` feature, are intentionally left in place.
+
+    Returns:
+        bool: ``True`` if the TOML rewrite succeeded (or no rewrite was
+            needed). Filesystem cleanup errors are swallowed.
+    """
+    ok = _remove_toml_sections(
+        _CODEX_CONFIG_PATH,
+        exact={
+            f'plugins."{_CODEX_PLUGIN_ID}"',
+            f"marketplaces.{_CODEX_MARKETPLACE_NAME}",
+        },
+        prefixes=(f'hooks.state."{_CODEX_PLUGIN_ID}:',),
+    )
+    shutil.rmtree(_CODEX_LOCAL_MARKETPLACE_ROOT, ignore_errors=True)
+    shutil.rmtree(_CODEX_PLUGIN_CACHE_DIR, ignore_errors=True)
+    try:
+        _CODEX_PLUGIN_CACHE_DIR.parent.rmdir()
+    except OSError:
+        pass
+    return ok
+
+
 def _enable_codex_plugin_hooks() -> tuple[bool, str]:
+    """Enable Codex's ``plugin_hooks`` feature, falling back to editing config.toml.
+
+    Returns:
+        tuple[bool, str]: ``(success, message)``. The message describes
+            either the successful path taken (CLI vs. direct config write)
+            or the failure mode.
+    """
     result = _run_codex(["features", "enable", "plugin_hooks"])
     if result.returncode == 0:
         return True, "codex features enable plugin_hooks"
@@ -187,6 +366,19 @@ def _enable_codex_plugin_hooks() -> tuple[bool, str]:
 
 
 def _register_codex_marketplace(root: Path) -> tuple[bool, str]:
+    """Register ``root`` as a Codex marketplace, replacing a stale entry if needed.
+
+    On success runs ``plugin marketplace upgrade reflexioai`` to refresh
+    Codex's cache. On the "different source" error path, removes the
+    existing registration and retries once.
+
+    Args:
+        root: Local marketplace directory to register.
+
+    Returns:
+        tuple[bool, str]: ``(success, message)`` where the message
+            captures the path taken or the Codex CLI's error output.
+    """
     result = _run_codex(["plugin", "marketplace", "add", str(root)])
     if result.returncode == 0:
         upgrade = _run_codex(
@@ -207,7 +399,18 @@ def _register_codex_marketplace(root: Path) -> tuple[bool, str]:
 
 
 def cmd_install_codex(_args: argparse.Namespace) -> int:
-    """Install the local claude-smart plugin marketplace for Codex."""
+    """Install the claude-smart plugin marketplace for Codex.
+
+    Only supported from a source checkout — the wheel ships the Python
+    package without the repo-level ``.agents/`` and top-level ``plugin/``
+    layout this command expects. End users install via the npm wrapper.
+
+    Args:
+        _args: Parsed CLI args (unused).
+
+    Returns:
+        int: 0 on success, non-zero on failure or unsupported runtime.
+    """
     if not shutil.which("codex"):
         sys.stderr.write("error: 'codex' CLI not found on PATH. Install Codex first.\n")
         return 1
@@ -219,9 +422,13 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
 
     missing = _missing_codex_marketplace_files(_REPO_ROOT)
     if missing:
-        formatted = ", ".join(str(path) for path in missing)
-        sys.stderr.write(f"error: Codex marketplace files missing: {formatted}\n")
+        sys.stderr.write(
+            "error: `claude-smart install --host codex` (Python path) only runs "
+            "from a source checkout. End users: `npx claude-smart install --host "
+            "codex` instead.\n"
+        )
         return 1
+    marketplace_root = _prepare_codex_local_marketplace()
 
     added = _seed_reflexio_env()
     if added:
@@ -233,7 +440,7 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
     else:
         sys.stderr.write(f"warning: could not enable Codex plugin hooks: {hooks_msg}\n")
 
-    registered, registration_msg = _register_codex_marketplace(_REPO_ROOT)
+    registered, registration_msg = _register_codex_marketplace(marketplace_root)
     if registered:
         sys.stdout.write(f"{registration_msg}.\n")
     else:
@@ -242,8 +449,8 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
     if registered:
         sys.stdout.write(
             "\nclaude-smart Codex support is prepared.\n"
-            "Open Codex in this repo, run /plugins, install claude-smart from "
-            "the claude-smart (local) marketplace if it is not already installed, "
+            "Fully quit and reopen Codex in this repo, run /plugins, install claude-smart from "
+            f"the {_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace if it is not already installed, "
             "then restart Codex so hooks reload. Uninstall removes the marketplace "
             "registration but leaves shared claude-smart data and Codex's global "
             "plugin_hooks feature intact.\n"
@@ -251,9 +458,9 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
     else:
         sys.stdout.write(
             "\nCodex hooks enabled; marketplace registration failed.\n"
-            f"Install manually with `codex plugin marketplace add {_REPO_ROOT}`, "
-            "then open Codex, run /plugins, install claude-smart from the "
-            "claude-smart (local) marketplace, and restart Codex so hooks reload.\n"
+            f"Install manually with `codex plugin marketplace add {marketplace_root}`, "
+            "then fully quit and reopen Codex, run /plugins, install claude-smart from the "
+            f"{_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace, and restart Codex so hooks reload.\n"
         )
     return 0 if hooks_ok and registered else 1
 
@@ -367,8 +574,24 @@ def cmd_uninstall(_args: argparse.Namespace) -> int:
 
 
 def cmd_uninstall_codex(_args: argparse.Namespace) -> int:
+    """Remove the Codex marketplace registration and local install state.
+
+    Runs ``codex plugin marketplace remove reflexioai`` (skipped when the
+    Codex CLI is absent) and then cleans the on-disk marketplace
+    wrapper, plugin cache, and the corresponding sections of
+    ``~/.codex/config.toml``. Shared learning data is preserved.
+
+    Args:
+        _args: Parsed CLI args (unused).
+
+    Returns:
+        int: 0 on success or partial cleanup; non-zero is reserved for
+            future failure modes — current paths swallow Codex CLI
+            errors and continue cleaning local state.
+    """
     if not shutil.which("codex"):
         sys.stdout.write("Codex CLI not found; skipping marketplace removal.\n")
+        _cleanup_codex_install_state()
         return 0
     result = _run_codex(["plugin", "marketplace", "remove", _CODEX_MARKETPLACE_NAME])
     if result.returncode != 0:
@@ -378,9 +601,10 @@ def cmd_uninstall_codex(_args: argparse.Namespace) -> int:
             + (f": {output}" if output else "")
             + "\n"
         )
-        return 1
+    if not _cleanup_codex_install_state():
+        sys.stderr.write(f"warning: could not update {_CODEX_CONFIG_PATH}\n")
     sys.stdout.write(
-        "claude-smart Codex marketplace removed. Restart Codex to apply. "
+        "claude-smart Codex plugin and marketplace state removed. Restart Codex to apply. "
         "Codex's global plugin_hooks feature and local data under ~/.reflexio "
         "and ~/.claude-smart were left in place.\n"
     )

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -315,6 +315,59 @@ def _remove_toml_sections(
     return True
 
 
+def _set_codex_plugin_enabled(path: Path) -> bool:
+    """Write Codex's installed-plugin config section for claude-smart."""
+    section_name = f'plugins."{_CODEX_PLUGIN_ID}"'
+    if not _remove_toml_sections(path, exact={section_name}):
+        return False
+    try:
+        text = path.read_text() if path.exists() else ""
+    except OSError:
+        return False
+    if text and not text.endswith("\n"):
+        text += "\n"
+    if text.strip():
+        text += "\n"
+    text += f"[{section_name}]\nenabled = true\n"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    except OSError:
+        return False
+    return True
+
+
+def _codex_plugin_version(plugin_root: Path) -> str | None:
+    try:
+        manifest = json.loads(
+            (plugin_root / ".codex-plugin" / "plugin.json").read_text()
+        )
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = manifest.get("version")
+    return version if isinstance(version, str) and version else None
+
+
+def _install_codex_plugin_cache(plugin_root: Path) -> tuple[bool, str]:
+    """Best-effort local install equivalent to selecting Install in /plugins."""
+    version = _codex_plugin_version(plugin_root)
+    if not version:
+        return (
+            False,
+            f"missing version in {plugin_root / '.codex-plugin' / 'plugin.json'}",
+        )
+    cache_dir = _CODEX_PLUGIN_CACHE_DIR / version
+    try:
+        shutil.rmtree(cache_dir, ignore_errors=True)
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(plugin_root, cache_dir, symlinks=False, ignore=_COPYTREE_IGNORE)
+    except OSError as exc:
+        return False, f"could not write Codex plugin cache: {exc}"
+    if not _set_codex_plugin_enabled(_CODEX_CONFIG_PATH):
+        return False, f"could not enable {_CODEX_PLUGIN_ID} in {_CODEX_CONFIG_PATH}"
+    return True, f"installed Codex plugin cache at {cache_dir}"
+
+
 def _cleanup_codex_install_state() -> bool:
     """Remove Codex's local install artifacts while preserving shared learning data.
 
@@ -446,14 +499,30 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
     else:
         sys.stderr.write(f"warning: {registration_msg}\n")
 
+    installed = False
+    install_msg = "marketplace registration failed"
     if registered:
+        installed, install_msg = _install_codex_plugin_cache(
+            marketplace_root / _CODEX_LOCAL_PLUGIN_PATH
+        )
+        if installed:
+            sys.stdout.write(f"{install_msg}.\n")
+        else:
+            sys.stderr.write(f"warning: {install_msg}\n")
+
+    if registered and installed:
         sys.stdout.write(
-            "\nclaude-smart Codex support is prepared.\n"
+            "\nclaude-smart Codex support is installed.\n"
+            "Restart Codex so the installed plugin and hooks reload. /plugins should "
+            f"show claude-smart as installed from the {_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace. "
+            "Uninstall removes the plugin cache and marketplace registration but leaves "
+            "shared claude-smart data and Codex's global plugin_hooks feature intact.\n"
+        )
+    elif registered:
+        sys.stdout.write(
+            "\nclaude-smart Codex marketplace is prepared, but automatic plugin install failed.\n"
             "Fully quit and reopen Codex in this repo, run /plugins, install claude-smart from "
-            f"the {_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace if it is not already installed, "
-            "then restart Codex so hooks reload. Uninstall removes the marketplace "
-            "registration but leaves shared claude-smart data and Codex's global "
-            "plugin_hooks feature intact.\n"
+            f"the {_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace, and restart Codex so hooks reload.\n"
         )
     else:
         sys.stdout.write(
@@ -462,7 +531,7 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
             "then fully quit and reopen Codex, run /plugins, install claude-smart from the "
             f"{_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace, and restart Codex so hooks reload.\n"
         )
-    return 0 if hooks_ok and registered else 1
+    return 0 if hooks_ok and registered and installed else 1
 
 
 def cmd_install(args: argparse.Namespace) -> int:

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -88,6 +88,8 @@ CITATION_INSTRUCTION = (
     "`✨ 1 claude-smart learning applied [cs:s1-ab12]`. Use this exact format "
     "for multiple ids: `✨ 2 claude-smart learnings applied [cs:s1-ab12,p2-cd34]`, "
     "where the number is the count of ids in the brackets. "
+    "Never emit a standalone wrapper like `✨s1-ab12✨` or `✨abc123✨`; "
+    "those are not claude-smart citations and cannot be resolved. "
     "Default is to skip. If an item is merely on-topic, confirms what you "
     "already planned, or your reply would read the same without it, do not "
     "cite — end the turn normally with your reply. When unsure, skip. Do "

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -419,7 +419,7 @@ wheels = [
 
 [[package]]
 name = "claude-smart"
-version = "0.2.23"
+version = "0.2.24"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -11,7 +11,7 @@
 #   4. `uv sync` from plugin/.
 #   5. Append CLAUDE_SMART_USE_LOCAL_CLI=1 / _USE_LOCAL_EMBEDDING=1 to
 #      ~/.reflexio/.env so reflexio runs without any external API key.
-#   6. Register the local marketplace with Claude Code (user scope) so
+#   6. Prepare and register the local marketplace with Claude Code (user scope) so
 #      `claude-smart@reflexioai-local` is available everywhere.
 #   7. Wire this repo's .claude/settings.local.json to enable the local
 #      plugin and shadow the remote one for this project.
@@ -67,15 +67,28 @@ if ! grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$REFLEXIO_ENV"; then
   log "appended CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 to $REFLEXIO_ENV"
 fi
 
-# Register the local marketplace with Claude Code (user-scope). We use
-# the local-marketplace/ subdir because its manifest declares
-# name=reflexioai-local — distinct from the remote `reflexioai`, so both
-# can coexist in Claude Code's marketplace list.
+# Prepare and register the local marketplace with Claude Code (user-scope).
+# local-marketplace/ is gitignored because it contains a symlink to this
+# checkout's plugin/ directory. Its manifest declares name=reflexioai-local —
+# distinct from the remote `reflexioai`, so both can coexist in Claude Code's
+# marketplace list.
 LOCAL_MKT_DIR="$REPO_ROOT/local-marketplace"
-if [ ! -f "$LOCAL_MKT_DIR/.claude-plugin/marketplace.json" ]; then
-  log "ERROR: expected marketplace manifest at $LOCAL_MKT_DIR/.claude-plugin/marketplace.json"
-  exit 1
-fi
+log "preparing local marketplace at $LOCAL_MKT_DIR..."
+mkdir -p "$LOCAL_MKT_DIR/.claude-plugin"
+python3 - "$REPO_ROOT/.claude-plugin/marketplace.json" "$LOCAL_MKT_DIR/.claude-plugin/marketplace.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+data = json.loads(src.read_text())
+data["name"] = "reflexioai-local"
+data["plugins"][0]["source"] = "./plugin"
+dst.write_text(json.dumps(data, indent=2) + "\n")
+PY
+rm -rf "$LOCAL_MKT_DIR/plugin"
+ln -sfn "$PLUGIN_ROOT" "$LOCAL_MKT_DIR/plugin"
 
 if command -v claude >/dev/null 2>&1; then
   log "registering local marketplace with Claude Code..."

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -41,9 +41,92 @@ def test_codex_manifest_points_at_codex_hooks() -> None:
 def test_codex_marketplace_points_at_plugin_root() -> None:
     marketplace = _read_json(".agents/plugins/marketplace.json")
     entry = marketplace["plugins"][0]
+    assert marketplace["name"] == cli._CODEX_MARKETPLACE_NAME
+    assert (
+        marketplace["interface"]["displayName"] == cli._CODEX_MARKETPLACE_DISPLAY_NAME
+    )
     assert entry["name"] == "claude-smart"
     assert entry["source"]["path"] == "./plugin"
     assert entry["policy"]["installation"] == "AVAILABLE"
+
+
+def test_prepare_codex_local_marketplace_uses_named_plugin_path(
+    monkeypatch, tmp_path
+) -> None:
+    plugin_root = tmp_path / "repo" / "plugin"
+    plugin_root.mkdir(parents=True)
+    marketplace_root = tmp_path / "marketplaces" / "reflexioai"
+    stale_file = marketplace_root / "old-copy" / "stale.txt"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale")
+    monkeypatch.setattr(cli, "_PLUGIN_ROOT", plugin_root)
+    monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
+
+    result = cli._prepare_codex_local_marketplace()
+
+    assert result == marketplace_root
+    manifest = json.loads(
+        (marketplace_root / ".agents" / "plugins" / "marketplace.json").read_text()
+    )
+    entry = manifest["plugins"][0]
+    assert entry["name"] == "claude-smart"
+    assert entry["source"]["path"] == "./plugins/claude-smart"
+    copied_plugin = marketplace_root / "plugins" / "claude-smart"
+    assert copied_plugin.is_dir()
+    assert not copied_plugin.is_symlink()
+    assert not stale_file.exists()
+
+
+def test_prepare_codex_local_marketplace_filters_dev_artifacts(
+    monkeypatch, tmp_path
+) -> None:
+    plugin_root = tmp_path / "repo" / "plugin"
+    (plugin_root / "src" / "claude_smart").mkdir(parents=True)
+    (plugin_root / "src" / "claude_smart" / "cli.py").write_text("# real\n")
+    (plugin_root / "src" / "claude_smart" / "__pycache__").mkdir()
+    (
+        plugin_root / "src" / "claude_smart" / "__pycache__" / "cli.cpython-312.pyc"
+    ).write_text("x")
+    (plugin_root / "src" / "claude_smart" / "cli.pyc").write_text("x")
+    (plugin_root / ".venv" / "bin").mkdir(parents=True)
+    (plugin_root / ".venv" / "bin" / "python").write_text("x")
+    (plugin_root / ".pytest_cache").mkdir()
+    (plugin_root / ".pytest_cache" / "CACHEDIR.TAG").write_text("x")
+    (plugin_root / ".ruff_cache").mkdir()
+    (plugin_root / "dashboard" / "node_modules").mkdir(parents=True)
+    (plugin_root / "dashboard" / "node_modules" / "package").mkdir()
+    (plugin_root / "dashboard" / ".next" / "cache").mkdir(parents=True)
+    marketplace_root = tmp_path / "marketplaces" / "reflexioai"
+    monkeypatch.setattr(cli, "_PLUGIN_ROOT", plugin_root)
+    monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
+
+    cli._prepare_codex_local_marketplace()
+
+    copied = marketplace_root / "plugins" / "claude-smart"
+    assert (copied / "src" / "claude_smart" / "cli.py").is_file()
+    assert not (copied / "src" / "claude_smart" / "__pycache__").exists()
+    assert not (copied / "src" / "claude_smart" / "cli.pyc").exists()
+    assert not (copied / ".venv").exists()
+    assert not (copied / ".pytest_cache").exists()
+    assert not (copied / ".ruff_cache").exists()
+    assert not (copied / "dashboard" / "node_modules").exists()
+    assert not (copied / "dashboard" / ".next").exists()
+
+
+def test_npm_package_includes_codex_marketplace_payload() -> None:
+    package = _read_json("package.json")
+    files = set(package["files"])
+
+    assert ".agents/plugins/marketplace.json" in files
+    assert "plugin" in files
+    assert "!plugin/**/__pycache__" in files
+    assert "!plugin/**/*.py[cod]" in files
+
+
+def test_release_bump_updates_codex_manifest() -> None:
+    makefile = (REPO_ROOT / "Makefile").read_text()
+
+    assert "plugin/.codex-plugin/plugin.json" in makefile
 
 
 def test_hook_commands_pass_explicit_host() -> None:
@@ -211,8 +294,10 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
 ) -> None:
     env_path = tmp_path / "reflexio" / ".env"
     config_path = tmp_path / ".codex" / "config.toml"
+    marketplace_root = tmp_path / "marketplaces" / "reflexioai"
     monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
     monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
     monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
 
     calls: list[list[str]] = []
@@ -232,8 +317,15 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
     assert rc == 0
     assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in env_path.read_text()
     assert "plugin_hooks = true" in config_path.read_text()
-    assert ["plugin", "marketplace", "add", str(cli._REPO_ROOT)] in calls
-    assert "run /plugins" in capsys.readouterr().out
+    assert [
+        "plugin",
+        "marketplace",
+        "add",
+        str(marketplace_root),
+    ] in calls
+    out = capsys.readouterr().out
+    assert "run /plugins" in out
+    assert "ReflexioAI marketplace" in out
 
 
 def test_codex_install_fails_when_marketplace_registration_fails(
@@ -241,8 +333,10 @@ def test_codex_install_fails_when_marketplace_registration_fails(
 ) -> None:
     env_path = tmp_path / "reflexio" / ".env"
     config_path = tmp_path / ".codex" / "config.toml"
+    marketplace_root = tmp_path / "marketplaces" / "reflexioai"
     monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
     monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
     monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
 
     def fake_run_codex(args: list[str]):
@@ -256,7 +350,9 @@ def test_codex_install_fails_when_marketplace_registration_fails(
 
     assert rc == 1
     assert "plugin_hooks = true" in config_path.read_text()
-    assert "marketplace registration failed" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "marketplace registration failed" in out
+    assert "ReflexioAI marketplace" in out
 
 
 def test_codex_install_fails_when_required_files_missing(monkeypatch, tmp_path) -> None:
@@ -276,6 +372,94 @@ def test_codex_install_fails_when_codex_cli_missing(monkeypatch) -> None:
     rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
 
     assert rc == 1
+
+
+def test_remove_toml_sections_removes_codex_plugin_state(tmp_path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(
+        '[plugins."claude-smart@reflexioai"]\n'
+        "enabled = true\n"
+        "\n"
+        '[hooks.state."claude-smart@reflexioai:hooks/codex-hooks.json:stop:0:0"]\n'
+        'trusted_hash = "sha256:abc"\n'
+        "\n"
+        "[marketplaces.reflexioai]\n"
+        'source_type = "local"\n'
+        "\n"
+        '[plugins."browser@openai-bundled"]\n'
+        "enabled = true\n"
+    )
+
+    assert cli._remove_toml_sections(
+        config,
+        exact={
+            'plugins."claude-smart@reflexioai"',
+            "marketplaces.reflexioai",
+        },
+        prefixes=('hooks.state."claude-smart@reflexioai:',),
+    )
+
+    text = config.read_text()
+    assert "claude-smart@reflexioai" not in text
+    assert "marketplaces.reflexioai" not in text
+    assert '[plugins."browser@openai-bundled"]' in text
+
+
+def test_codex_uninstall_cleans_plugin_config_cache_and_marketplace(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    config = tmp_path / ".codex" / "config.toml"
+    config.parent.mkdir()
+    config.write_text(
+        '[plugins."claude-smart@reflexioai"]\n'
+        "enabled = true\n"
+        "\n"
+        '[hooks.state."claude-smart@reflexioai:hooks/codex-hooks.json:stop:0:0"]\n'
+        'trusted_hash = "sha256:abc"\n'
+        "\n"
+        "[marketplaces.reflexioai]\n"
+        'source_type = "local"\n'
+        "\n"
+        '[plugins."browser@openai-bundled"]\n'
+        "enabled = true\n"
+        "\n"
+        "[marketplaces.openai-bundled]\n"
+        'source_type = "builtin"\n'
+        "\n"
+        "[features]\n"
+        "plugin_hooks = true\n"
+    )
+    marketplace_root = tmp_path / "marketplaces" / "reflexioai"
+    marketplace_root.mkdir(parents=True)
+    cache_root = tmp_path / ".codex" / "plugins" / "cache" / "reflexioai"
+    plugin_cache = cache_root / "claude-smart"
+    plugin_cache.mkdir(parents=True)
+
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config)
+    monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
+    monkeypatch.setattr(cli, "_CODEX_PLUGIN_CACHE_DIR", plugin_cache)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(
+        cli,
+        "_run_codex",
+        lambda _args: type(
+            "Result", (), {"returncode": 0, "stdout": "", "stderr": ""}
+        )(),
+    )
+
+    rc = cli.cmd_uninstall(argparse.Namespace(host="codex"))
+
+    assert rc == 0
+    assert not marketplace_root.exists()
+    assert not plugin_cache.exists()
+    assert not cache_root.exists()
+    text = config.read_text()
+    assert "claude-smart@reflexioai" not in text
+    assert "marketplaces.reflexioai" not in text
+    assert "plugin_hooks = true" in text
+    assert '[plugins."browser@openai-bundled"]' in text
+    assert "[marketplaces.openai-bundled]" in text
+    assert "plugin and marketplace state removed" in capsys.readouterr().out
 
 
 def test_run_codex_times_out(monkeypatch) -> None:

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -295,9 +295,13 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
     env_path = tmp_path / "reflexio" / ".env"
     config_path = tmp_path / ".codex" / "config.toml"
     marketplace_root = tmp_path / "marketplaces" / "reflexioai"
+    plugin_cache = (
+        tmp_path / ".codex" / "plugins" / "cache" / "reflexioai" / "claude-smart"
+    )
     monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
     monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config_path)
     monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
+    monkeypatch.setattr(cli, "_CODEX_PLUGIN_CACHE_DIR", plugin_cache)
     monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
 
     calls: list[list[str]] = []
@@ -316,7 +320,12 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
 
     assert rc == 0
     assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in env_path.read_text()
-    assert "plugin_hooks = true" in config_path.read_text()
+    config = config_path.read_text()
+    assert "plugin_hooks = true" in config
+    assert '[plugins."claude-smart@reflexioai"]' in config
+    assert "enabled = true" in config
+    version = _read_json("plugin/.codex-plugin/plugin.json")["version"]
+    assert (plugin_cache / version / ".codex-plugin" / "plugin.json").is_file()
     assert [
         "plugin",
         "marketplace",
@@ -324,8 +333,8 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
         str(marketplace_root),
     ] in calls
     out = capsys.readouterr().out
-    assert "run /plugins" in out
-    assert "ReflexioAI marketplace" in out
+    assert "Codex support is installed" in out
+    assert "should show claude-smart as installed" in out
 
 
 def test_codex_install_fails_when_marketplace_registration_fails(
@@ -353,6 +362,36 @@ def test_codex_install_fails_when_marketplace_registration_fails(
     out = capsys.readouterr().out
     assert "marketplace registration failed" in out
     assert "ReflexioAI marketplace" in out
+
+
+def test_install_codex_plugin_cache_enables_plugin_and_copies_versioned_cache(
+    monkeypatch, tmp_path
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    (plugin_root / ".codex-plugin").mkdir(parents=True)
+    (plugin_root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "claude-smart", "version": "9.8.7"})
+    )
+    (plugin_root / "hooks").mkdir()
+    (plugin_root / "hooks" / "codex-hooks.json").write_text("{}")
+    config = tmp_path / ".codex" / "config.toml"
+    config.parent.mkdir()
+    config.write_text('[plugins."browser@openai-bundled"]\nenabled = true\n')
+    plugin_cache = (
+        tmp_path / ".codex" / "plugins" / "cache" / "reflexioai" / "claude-smart"
+    )
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config)
+    monkeypatch.setattr(cli, "_CODEX_PLUGIN_CACHE_DIR", plugin_cache)
+
+    ok, message = cli._install_codex_plugin_cache(plugin_root)
+
+    assert ok is True
+    assert "9.8.7" in message
+    assert (plugin_cache / "9.8.7" / "hooks" / "codex-hooks.json").is_file()
+    text = config.read_text()
+    assert '[plugins."browser@openai-bundled"]' in text
+    assert '[plugins."claude-smart@reflexioai"]' in text
+    assert "enabled = true" in text
 
 
 def test_codex_install_fails_when_required_files_missing(monkeypatch, tmp_path) -> None:

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -103,6 +103,7 @@ def test_render_with_registry_emits_citation_instruction() -> None:
     assert "Do not call `cs-cite`" in md
     assert "✨ 1 claude-smart learning applied [cs:s1-ab12]" in md
     assert "✨ 2 claude-smart learnings applied [cs:s1-ab12,p2-cd34]" in md
+    assert "Never emit a standalone wrapper" in md
     assert "`✨ N claude-smart" not in md
 
 

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -49,6 +49,13 @@ def test_parse_text_citations_ignores_plain_inline_tags() -> None:
     assert cs_cite.parse_text_citations(text) == []
 
 
+def test_parse_text_citations_rejects_standalone_wrapper() -> None:
+    assert cs_cite.parse_text_citations("Answer.\n\n✨s2-cd34✨") == []
+    assert (
+        cs_cite.parse_text_citations("Answer.\n\n✨1gkgg8b9r7fx99kr2j3q6k5c1v✨") == []
+    )
+
+
 def test_parse_text_citations_uses_last_marker_line() -> None:
     text = (
         "✨ 1 claude-smart learning applied [cs:s1-1111]\n"


### PR DESCRIPTION
## Summary

- Adds a no-clone Codex install path: `npx claude-smart install --host codex` bundles the plugin marketplace into the npm tarball and copies it to `~/.claude/plugins/marketplaces/reflexioai/` at install time, so end users get the same flow as `npx claude-smart install` for Claude Code.
- **Auto-installs the plugin into Codex's cache and enables it in `~/.codex/config.toml`**, so after `npx claude-smart install --host codex` the user only needs to restart Codex — no manual `/plugins` install step. The Python source-checkout path (`uv run --project plugin claude-smart install --host codex`) mirrors the same behavior.
- Hardens the existing source-checkout Codex install with a 30s CLI timeout, dev-artifact filtering during `copytree`, a clear error when invoked from a PyPI wheel, and full state cleanup on uninstall (TOML sections + plugin cache).
- Locks down citation behavior: the `CITATION_INSTRUCTION` now explicitly rejects standalone `✨s1-ab12✨` wrappers, with a regression test in `tests/test_cs_cite.py`.
- Release tooling now bumps `plugin/.codex-plugin/plugin.json` alongside the other manifests, and `scripts/setup-local-dev.sh` materializes `local-marketplace/` from `.claude-plugin/marketplace.json` instead of requiring a tracked file.
- Documentation updates: standardize slash-command references to the prefixed `/claude-smart:*` form throughout the README (matches actual Claude Code skill identifiers); clarify in the Commands section that Codex does not currently support plugin-provided slash commands so the shell column is the entry point; spell out that already-running Codex windows must restart after install for hooks to load.

## Changes

**npm install path (`bin/claude-smart.js`):**
- New `--host codex` branch on `install`/`uninstall`. `copyCodexMarketplace` writes a fresh `.agents/plugins/marketplace.json` and `cpSync`s `plugin/` to `plugins/claude-smart/` under the wrapper.
- `installCodexPluginCache` reads the version from `.codex-plugin/plugin.json`, copies the plugin to `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/`, and writes `[plugins."claude-smart@reflexioai"] enabled = true` into `~/.codex/config.toml` via `setCodexPluginEnabled` (idempotent — removes any pre-existing section first). Falls back to the old "open /plugins manually" instructions if the automatic install fails.
- `runCodex` enforces a 30s timeout (`CODEX_CLI_TIMEOUT_MS`) and translates SIGTERM into exit code 124, mirroring the Python `_run_codex` semantics.
- `cpSync` uses a `filter` callback (`shouldCopyPath`) that drops `__pycache__/`, `.venv/`, `.pytest_cache/`, `.ruff_cache/`, `node_modules/`, `.next/`, and `*.pyc`/`*.pyo`, mirroring `_COPYTREE_IGNORE` on the Python side so a "node bin/claude-smart.js install --host codex" run from a clone matches the published tarball.
- `cleanupCodexInstallState` drops the Codex `[plugins."claude-smart@reflexioai"]`, `[marketplaces.reflexioai]`, and `[hooks.state."claude-smart@reflexioai:…"]` sections from `~/.codex/config.toml`, removes the marketplace wrapper and Codex plugin cache, and best-effort-removes the empty parent cache dir.

**Source-checkout Codex install (`plugin/src/claude_smart/cli.py`):**
- New `_prepare_codex_local_marketplace()` builds the same wrapper layout that the JS path creates, using `shutil.copytree(..., ignore=_COPYTREE_IGNORE)`.
- New `_install_codex_plugin_cache()` and `_set_codex_plugin_enabled()` mirror the JS auto-install: copy the plugin into Codex's versioned cache directory and idempotently rewrite the `[plugins."claude-smart@reflexioai"]` section in `~/.codex/config.toml`.
- `cmd_install_codex` short-circuits with a precise error message when the repo-layout files are absent (i.e. when invoked from a PyPI wheel) — `npx claude-smart install --host codex` is the supported end-user path.
- Returns non-zero if hooks, marketplace registration, or the new plugin-cache install step fails, with distinct success messages for the fully-installed vs. registration-only-success cases.
- Mirrors of `_remove_toml_sections` and `_cleanup_codex_install_state` for parity with the JS implementation, plus Google-style docstrings on every new helper.

**Packaging (`package.json`, `.npmignore`):**
- `files` ships `bin/`, `.agents/plugins/marketplace.json`, `plugin/`, plus negated patterns to exclude `__pycache__`/cache/build artifacts.
- `.npmignore` keeps only the two patterns not covered by `files`: `*.bak` and `.coverage`.

**Citation guidance (`plugin/src/claude_smart/cs_cite.py`):**
- `CITATION_INSTRUCTION` now warns explicitly: "Never emit a standalone wrapper like `✨s1-ab12✨` or `✨abc123✨`; those are not claude-smart citations and cannot be resolved."

**Release tooling:**
- `Makefile` `bump`/`VERSION_FILES` now include `plugin/.codex-plugin/plugin.json` so version drift can't sneak in across hosts.
- `scripts/setup-local-dev.sh` generates `local-marketplace/.claude-plugin/marketplace.json` from the canonical manifest and symlinks `plugin/` into it, instead of requiring a checked-in `local-marketplace/` directory.

**Docs (`README.md`, `DEVELOPER.md`):**
- Codex Quick Start now documents the streamlined flow — after `npx claude-smart install --host codex`, just restart Codex (no manual `/plugins` step). Calls out that already-running Codex windows must be fully reopened, and that users who install/toggle from `/plugins` manually should still re-run the npx helper once to finish `plugin_hooks` + cache setup.
- All slash-command references in the README use the prefixed `/claude-smart:*` form (e.g., `/claude-smart:learn`, `/claude-smart:dashboard`) — matches the actual Claude Code skill identifiers and avoids `/learn`/`/dashboard` collisions with other plugins.
- Commands section preamble clarifies that Codex does not currently support plugin-provided slash commands, so the `bash …/scripts/cli.sh …` column is the entry point under Codex.
- `~/.reflexio/plugin-root` entry in the file inventory now reflects both Claude Code slash commands and Codex shell helpers resolving through the symlink.
- `DEVELOPER.md` documents the Codex local-install workflow (with auto-install), the optional `~/plugins/claude-smart` symlink for live hook iteration, and the uninstall recipe (including legacy pre-rename state cleanup).

## Test Plan

- [x] `uvx ruff check` on all changed Python files — clean.
- [x] `uvx ruff format` — applied.
- [x] `uvx pyright plugin/src/claude_smart/cli.py` — 0 errors.
- [x] `node --check bin/claude-smart.js` — passes.
- [x] `uv run pytest tests/` — **256 passed** (25 in `test_codex_support.py`).
- [x] `npm pack --dry-run --json` — no `__pycache__`/`.venv`/`.bak`/`.coverage`/`.next/cache`/`node_modules` in the tarball.

**New tests covering this PR:**
- `test_install_codex_plugin_cache_enables_plugin_and_copies_versioned_cache` — verifies the versioned cache copy + idempotent config rewrite, and that unrelated `[plugins."browser@openai-bundled"]` sections survive.
- `test_prepare_codex_local_marketplace_filters_dev_artifacts` — confirms `__pycache__/`, `.venv/`, `.pytest_cache/`, `.ruff_cache/`, `node_modules/`, `.next/`, and `*.pyc` are stripped from the copied plugin tree.
- `test_codex_uninstall_cleans_plugin_config_cache_and_marketplace` — extended to include unrelated `[plugins."browser@openai-bundled"]` and `[marketplaces.openai-bundled]` sections; asserts they survive the cleanup.
- `test_remove_toml_sections_removes_codex_plugin_state` — locks the section-removal regex against a representative config.
- `test_parse_text_citations_rejects_standalone_wrapper` — regression test for the new citation guidance.
- `test_codex_install_succeeds_when_hooks_and_marketplace_succeed` updated to assert the new "Codex support is installed" message and the versioned cache directory.
- `test_npm_package_includes_codex_marketplace_payload`, `test_release_bump_updates_codex_manifest` — packaging contract.

**Manual verification still needed before release:**
- [ ] Real `npx claude-smart install --host codex` end-to-end on a fresh machine: after restart, `/plugins` shows claude-smart already installed under the **ReflexioAI** marketplace, hooks fire on next prompt.
- [ ] `npx claude-smart uninstall --host codex` followed by `codex --version` to confirm Codex itself still works and only the reflexioai marketplace + plugin cache are gone.
