### PR TITLE
feat: Codex CLI runtime support

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -296,7 +296,7 @@ Codex local development creates a durable local marketplace wrapper at `~/.claud
 uv run --project plugin claude-smart install --host codex
 ```
 
-Then fully restart Codex so hooks reload. The command installs `claude-smart` into `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/` and enables `[plugins."claude-smart@reflexioai"]` in `~/.codex/config.toml`; `/plugins` should show it as installed from the **ReflexioAI** marketplace.
+Then fully restart Codex so hooks reload. The command installs `claude-smart` into `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/`, enables `[plugins."claude-smart@reflexioai"]`, enables Codex's hook feature flags, and seeds the per-hook trust entries in `~/.codex/config.toml`; `/plugins` should show it as installed from the **ReflexioAI** marketplace. Running `codex features enable plugin_hooks` by itself is not enough because it does not install the plugin or trust the individual hook entries.
 
 For live hook iteration, point Codex at this checkout before the cache:
 
@@ -493,7 +493,7 @@ uv run --project plugin claude-smart install --host codex      # Codex repo-loca
 node bin/claude-smart.js install --host codex                  # Codex packaged-marketplace path
 ```
 
-The Claude Code install commands accept either a GitHub `owner/repo` ref or an absolute path to a local directory containing `.claude-plugin/marketplace.json`. The Codex Python path creates a local marketplace wrapper that copies this checkout's `plugin/`; the Codex Node path exercises the packaged no-clone flow by copying the bundled plugin into `~/.claude/plugins/marketplaces/reflexioai/plugins/claude-smart` before registering it with Codex.
+The Claude Code install commands accept either a GitHub `owner/repo` ref or an absolute path to a local directory containing `.claude-plugin/marketplace.json`. The Codex Python path creates a local marketplace wrapper that copies this checkout's `plugin/`; the Codex Node path exercises the packaged no-clone flow by copying the bundled plugin into `~/.claude/plugins/marketplaces/reflexioai/plugins/claude-smart` before registering it with Codex. Both Codex paths ask `codex app-server` for the current claude-smart hook hashes and write matching trust state to `~/.codex/config.toml`.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
   </a>
   <a href="plugin/pyproject.toml">
-    <img src="https://img.shields.io/badge/version-0.2.25-green.svg" alt="Version">
+    <img src="https://img.shields.io/badge/version-0.2.24-green.svg" alt="Version">
   </a>
   <a href="plugin/pyproject.toml">
     <img src="https://img.shields.io/badge/python-%3E%3D3.12-brightgreen.svg" alt="Python">
@@ -119,17 +119,26 @@ npx claude-smart install --host codex
 ```
 
 The helper registers the bundled **ReflexioAI** marketplace with Codex, enables
-Codex's `plugin_hooks` feature, installs `claude-smart` into Codex's local
-plugin cache, and enables it in `~/.codex/config.toml`. Hooks are not active in
-already-running Codex windows; after the command finishes:
+Codex's `hooks` and `plugin_hooks` features, installs `claude-smart` into
+Codex's local plugin cache, enables it in `~/.codex/config.toml`, and seeds
+Codex's per-hook trust state for the claude-smart hooks. `codex features enable
+plugin_hooks` alone is not enough; it only turns on the global plugin-hook
+feature and does not install the plugin or trust the individual hook entries.
+If you need one command that prepares everything, rerun:
+
+```bash
+npx claude-smart install --host codex
+```
+
+Hooks are not active in already-running Codex windows; after the command finishes:
 
 1. Fully quit and reopen Codex in your project so hooks reload.
 2. Run `/plugins` only if you want to verify `claude-smart` shows as installed
    from the **ReflexioAI** marketplace.
 
 If you install or toggle `claude-smart` manually from `/plugins`, still run
-`npx claude-smart install --host codex` once afterward so `plugin_hooks` is
-enabled and the cache/config are prepared.
+`npx claude-smart install --host codex` once afterward so the hook feature
+flags, plugin cache, and claude-smart hook trust state are prepared.
 
 Do not create a `~/plugins/claude-smart` symlink for a normal `npx` install;
 that symlink is only for plugin development from a cloned checkout.
@@ -211,16 +220,17 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for hooks, data flow, and reflexio deta
 ## Commands
 
 Claude Code installs these as plugin slash commands. Codex does not currently
-support these plugin-provided slash commands, so run the equivalent shell command
-directly, or ask Codex to run it.
+support plugin-provided slash commands, so claude-smart ships a Codex skill that
+maps requests like "claude-smart show" or "run claude-smart learn" to the
+equivalent shell command. You can also run the shell command directly.
 
-| Claude Code | Codex / shell | What it does |
-| --- | --- | --- |
-| `/claude-smart:dashboard` | `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh` | Open the dashboard in your browser, auto-starting the reflexio backend and dashboard services if they aren't already running. |
-| `/claude-smart:show` | `bash ~/.reflexio/plugin-root/scripts/cli.sh show` | Print current project-specific skills, shared skills, and the current project's preferences so you can audit learned state manually. |
-| `/claude-smart:learn [note]` | `bash ~/.reflexio/plugin-root/scripts/cli.sh learn --note "optional note"` | Flag the most recent turn as a correction (for cases the automatic heuristic missed) and force reflexio to run extraction *now* on the session's unpublished interactions. The optional note becomes the correction description the extractor sees. |
-| `/claude-smart:restart` | `bash ~/.reflexio/plugin-root/scripts/cli.sh restart` | Restart the reflexio backend and dashboard to pick up new changes (e.g. after upgrading the plugin or editing local reflexio code). |
-| `/claude-smart:clear-all` | `bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes` | **Destructive.** Delete *all* reflexio interactions, preferences, and skills. Use when you want to wipe learned state and start fresh. |
+| Claude Code | Codex request | Direct shell fallback | What it does |
+| --- | --- | --- | --- |
+| `/claude-smart:dashboard` | `open claude-smart dashboard` | `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh` | Open the dashboard in your browser, auto-starting the reflexio backend and dashboard services if they aren't already running. |
+| `/claude-smart:show` | `claude-smart show` | `bash ~/.reflexio/plugin-root/scripts/cli.sh show` | Print current project-specific skills, shared skills, and the current project's preferences so you can audit learned state manually. |
+| `/claude-smart:learn [note]` | `claude-smart learn with note "optional note"` | `bash ~/.reflexio/plugin-root/scripts/cli.sh learn --note "optional note"` | Flag the most recent turn as a correction (for cases the automatic heuristic missed) and force reflexio to run extraction *now* on the session's unpublished interactions. The optional note becomes the correction description the extractor sees. |
+| `/claude-smart:restart` | `restart claude-smart` | `bash ~/.reflexio/plugin-root/scripts/cli.sh restart` | Restart the reflexio backend and dashboard to pick up new changes (e.g. after upgrading the plugin or editing local reflexio code). |
+| `/claude-smart:clear-all` | `clear all claude-smart learnings` | `bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes` | **Destructive.** Delete *all* reflexio interactions, preferences, and skills. Use when you want to wipe learned state and start fresh. |
 
 ---
 
@@ -235,7 +245,7 @@ Advanced users can tune claude-smart via environment variables — see [DEVELOPE
 | `~/.reflexio/data/reflexio.db` | Source of truth for learned preferences, skills, interactions, full-text indexes, and embedding tables (plus `.db-shm` / `.db-wal` WAL sidecars). Inspect with `sqlite3`. |
 | `~/.reflexio/.env` | Provider config — `CLAUDE_SMART_USE_LOCAL_CLI`, `CLAUDE_SMART_USE_LOCAL_EMBEDDING`, any optional API keys. |
 | `.claude/settings.local.json` or `~/.claude/settings.json` | Claude Code hook environment, such as `CLAUDE_SMART_ENABLE_OPTIMIZER`; use project-local settings for one repo or user settings for all projects. |
-| `~/.codex/config.toml` | Codex feature flags, including `plugin_hooks = true` after `claude-smart install --host codex`. |
+| `~/.codex/config.toml` | Codex plugin state, hook feature flags, and per-hook trust entries after `claude-smart install --host codex`. |
 | `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/` | Codex's cached install of the `claude-smart` plugin from the `ReflexioAI` marketplace. |
 | `~/.reflexio/plugin-root` | Self-healed symlink to the active plugin dir (managed by `ensure-plugin-root.sh` — written on install, refreshed each `SessionStart`). Claude Code slash commands and Codex shell-command helpers resolve through it, so don't delete it; if you do, the next session will recreate it. |
 | `~/.claude-smart/sessions/{session_id}.jsonl` | Per-session buffer. User turns, assistant turns, tool invocations, `{"published_up_to": N}` watermarks. Safe to inspect and safe to delete — everything past the latest watermark has already been written to reflexio's DB. |

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -205,9 +205,10 @@ function printHelp() {
       "Codex install:",
       `  1. Copies the bundled marketplace to ${CODEX_MARKETPLACE_DIR}`,
       "  2. codex plugin marketplace add <copied marketplace>",
-      "  3. codex features enable plugin_hooks",
+      "  3. codex features enable hooks && codex features enable plugin_hooks",
       "  4. Installs claude-smart into Codex's plugin cache and enables it",
-      "  5. Restart Codex.",
+      "  5. Trusts and enables claude-smart hook entries in ~/.codex/config.toml",
+      "  6. Restart Codex.",
       "",
       "Update:",
       "  npx claude-smart update                        Update to the latest version",
@@ -357,6 +358,227 @@ function setCodexPluginEnabled() {
   next += `[${sectionName}]\nenabled = true\n`;
   mkdirSync(dirname(CODEX_CONFIG_PATH), { recursive: true });
   writeFileSync(CODEX_CONFIG_PATH, next);
+}
+
+function tomlDottedQuoted(name) {
+  return `"${name.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function setTomlFeature(feature, value) {
+  // Minimal port of `_set_toml_feature` in plugin/src/claude_smart/cli.py:
+  // ensures `[features]\n<feature> = <bool>\n` is present in
+  // ~/.codex/config.toml, replacing any prior value for the same key.
+  const desired = `${feature} = ${value ? "true" : "false"}`;
+  const sectionRe = /^\s*\[([^\]]+)\]\s*(?:#.*)?$/;
+  const featureRe = new RegExp(`^\\s*${feature.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=`);
+  const text = existsSync(CODEX_CONFIG_PATH)
+    ? readFileSync(CODEX_CONFIG_PATH, "utf8")
+    : "";
+  const lines = text.split("\n");
+  let inFeatures = false;
+  let featuresIdx = null;
+  let insertIdx = null;
+  let changed = false;
+  const out = [];
+  for (const line of lines) {
+    const sectionMatch = line.match(sectionRe);
+    if (sectionMatch) {
+      if (inFeatures && insertIdx === null) insertIdx = out.length;
+      inFeatures = sectionMatch[1].trim() === "features";
+      if (inFeatures) featuresIdx = out.length;
+      out.push(line);
+      continue;
+    }
+    if (inFeatures && featureRe.test(line)) {
+      out.push(desired);
+      changed = changed || line !== desired;
+      continue;
+    }
+    out.push(line);
+  }
+  if (featuresIdx === null) {
+    if (out.length && out[out.length - 1].trim()) out.push("");
+    out.push("[features]", desired);
+    changed = true;
+  } else {
+    const sectionEnd = insertIdx !== null ? insertIdx : out.length;
+    let hasFeature = false;
+    for (let i = featuresIdx + 1; i < sectionEnd; i++) {
+      if (featureRe.test(out[i])) { hasFeature = true; break; }
+    }
+    if (!hasFeature) {
+      const idx = insertIdx !== null ? insertIdx : out.length;
+      out.splice(idx, 0, desired);
+      changed = true;
+    }
+  }
+  if (!changed && text.endsWith("\n")) return true;
+  mkdirSync(dirname(CODEX_CONFIG_PATH), { recursive: true });
+  let payload = out.join("\n");
+  if (!payload.endsWith("\n")) payload += "\n";
+  writeFileSync(CODEX_CONFIG_PATH, payload);
+  return true;
+}
+
+function setCodexHookStates(states) {
+  const entries = Object.entries(states);
+  if (entries.length === 0) return false;
+  removeTomlSections(CODEX_CONFIG_PATH, {
+    exact: new Set(),
+    prefixes: [`hooks.state."${CODEX_PLUGIN_ID}:`],
+  });
+  const existing = existsSync(CODEX_CONFIG_PATH)
+    ? readFileSync(CODEX_CONFIG_PATH, "utf8")
+    : "";
+  let next = existing;
+  if (next && !next.endsWith("\n")) next += "\n";
+  if (!next.includes("[hooks.state]")) {
+    if (next.trim()) next += "\n";
+    next += "[hooks.state]\n";
+  }
+  if (next.trim()) next += "\n";
+  for (const [key, currentHash] of entries.sort(([a], [b]) => a.localeCompare(b))) {
+    next += `[hooks.state.${tomlDottedQuoted(key)}]\n`;
+    next += "enabled = true\n";
+    next += `trusted_hash = "${currentHash}"\n\n`;
+  }
+  mkdirSync(dirname(CODEX_CONFIG_PATH), { recursive: true });
+  writeFileSync(CODEX_CONFIG_PATH, next.trimEnd() + "\n");
+  return true;
+}
+
+function createCodexAppServerClient(child) {
+  // A single long-lived stdout listener that demultiplexes JSON-RPC responses
+  // by id. Avoids losing messages between sequential requests.
+  const pending = new Map();
+  let buffer = "";
+  let exited = false;
+
+  const onData = (chunk) => {
+    buffer += chunk.toString();
+    let newline;
+    while ((newline = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (!line.trim()) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const entry = pending.get(message.id);
+      if (!entry) continue;
+      pending.delete(message.id);
+      clearTimeout(entry.timer);
+      if (message.error) {
+        entry.reject(new Error(JSON.stringify(message.error)));
+      } else {
+        entry.resolve(message);
+      }
+    }
+  };
+  const onExit = () => {
+    exited = true;
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error("Codex app-server exited before responding"));
+    }
+    pending.clear();
+  };
+  child.stdout.on("data", onData);
+  child.on("exit", onExit);
+
+  return {
+    request(id, method, params, timeoutMs) {
+      return new Promise((resolve, reject) => {
+        if (exited) {
+          reject(new Error("Codex app-server exited before responding"));
+          return;
+        }
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error(`Codex app-server ${method} timed out`));
+        }, timeoutMs);
+        pending.set(id, { resolve, reject, timer });
+        child.stdin.write(JSON.stringify({ id, method, params }) + "\n");
+      });
+    },
+    notify(method, params) {
+      if (exited) return;
+      child.stdin.write(JSON.stringify({ method, params }) + "\n");
+    },
+    close() {
+      child.stdout.off("data", onData);
+      child.off("exit", onExit);
+    },
+  };
+}
+
+async function listCodexPluginHooks(cwd) {
+  const child = spawn("codex", ["app-server", "--listen", "stdio://"], {
+    stdio: ["pipe", "pipe", "ignore"],
+  });
+  const client = createCodexAppServerClient(child);
+  try {
+    await client.request(
+      1,
+      "initialize",
+      {
+        clientInfo: {
+          name: "claude_smart_installer",
+          title: "claude-smart installer",
+          version: "0.0.0",
+        },
+        capabilities: { experimentalApi: true },
+      },
+      CODEX_CLI_TIMEOUT_MS,
+    );
+    client.notify("initialized", {});
+    const response = await client.request(
+      2,
+      "hooks/list",
+      { cwds: [cwd] },
+      CODEX_CLI_TIMEOUT_MS,
+    );
+    const hooks = response.result?.data?.[0]?.hooks;
+    if (!Array.isArray(hooks)) {
+      throw new Error("Codex app-server hook metadata was malformed");
+    }
+    return hooks.filter(
+      (hook) =>
+        hook &&
+        (hook.pluginId === CODEX_PLUGIN_ID ||
+          String(hook.key || "").startsWith(`${CODEX_PLUGIN_ID}:`)),
+    );
+  } finally {
+    client.close();
+    child.stdin.destroy();
+    child.stdout.destroy();
+    child.kill("SIGTERM");
+    child.unref();
+  }
+}
+
+async function trustCodexPluginHooks(cwd) {
+  const hooks = await listCodexPluginHooks(cwd);
+  const states = {};
+  for (const hook of hooks) {
+    if (
+      typeof hook.key === "string" &&
+      hook.key.startsWith(`${CODEX_PLUGIN_ID}:`) &&
+      typeof hook.currentHash === "string"
+    ) {
+      states[hook.key] = hook.currentHash;
+    }
+  }
+  if (Object.keys(states).length === 0) {
+    throw new Error("Codex did not report trust hashes for claude-smart hooks");
+  }
+  if (!setCodexHookStates(states)) {
+    throw new Error(`could not write claude-smart hook trust state to ${CODEX_CONFIG_PATH}`);
+  }
+  return Object.keys(states).length;
 }
 
 function codexPluginVersion(pluginRoot) {
@@ -515,13 +737,26 @@ async function runInstallCodex() {
     process.exit(code);
   }
 
-  code = await runCodex(["features", "enable", "plugin_hooks"]);
-  if (code !== 0) {
-    process.stderr.write("error: could not enable Codex plugin_hooks feature.\n");
-    process.exit(code);
+  for (const feature of ["hooks", "plugin_hooks"]) {
+    code = await runCodex(["features", "enable", feature]);
+    if (code !== 0) {
+      // Older Codex builds may not recognize the `hooks` feature name; fall
+      // through to writing the flag directly under [features] in config.toml.
+      try {
+        setTomlFeature(feature, true);
+        process.stdout.write(`Enabled Codex ${feature} via ${CODEX_CONFIG_PATH}.\n`);
+      } catch (err) {
+        process.stderr.write(
+          `error: could not enable Codex ${feature} feature: ${err && err.message ? err.message : err}\n`,
+        );
+        process.exit(code);
+      }
+    }
   }
 
   let cacheDir = null;
+  let trustedHookCount = 0;
+  let trustError = null;
   try {
     cacheDir = installCodexPluginCache(join(marketplaceRoot, CODEX_MARKETPLACE_PLUGIN_PATH));
     process.stdout.write(`Installed Codex plugin cache at ${cacheDir}.\n`);
@@ -530,9 +765,31 @@ async function runInstallCodex() {
       `error: automatic Codex plugin install failed: ${err && err.message ? err.message : err}\n`,
     );
     process.stderr.write(
-      `Open Codex, run /plugins, and install claude-smart from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace manually.\n`,
+      `Open Codex, run /plugins, install claude-smart from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace, and restart Codex.\n`,
     );
     process.exit(1);
+  }
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      trustedHookCount = await trustCodexPluginHooks(process.cwd());
+      trustError = null;
+      break;
+    } catch (err) {
+      trustError = err;
+      if (attempt === 0) await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  if (trustError) {
+    process.stderr.write(
+      `warning: ${trustError && trustError.message ? trustError.message : trustError}\n`,
+    );
+    process.stderr.write(
+      `Fully quit and reopen Codex in this repo, run /hooks, trust the claude-smart hooks, and restart Codex.\n`,
+    );
+    process.exit(1);
+  } else {
+    process.stdout.write(`Trusted and enabled ${trustedHookCount} claude-smart Codex hooks.\n`);
   }
 
   const added = seedReflexioEnv();
@@ -544,7 +801,7 @@ async function runInstallCodex() {
     [
       "",
       "claude-smart Codex support is installed.",
-      `Restart Codex so the installed plugin and hooks reload. /plugins should show claude-smart as installed from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace.`,
+      `Restart Codex so the installed plugin and trusted hooks reload. /plugins should show claude-smart as installed from the ${CODEX_MARKETPLACE_DISPLAY_NAME} marketplace.`,
       "Local data is shared with Claude Code under ~/.reflexio/ and ~/.claude-smart/.",
       "",
     ].join("\n"),
@@ -570,7 +827,7 @@ async function runUninstallCodex() {
     [
       "",
       "claude-smart Codex plugin and marketplace state removed. Restart Codex to apply.",
-      "Codex's global plugin_hooks feature and local data under ~/.reflexio/ and ~/.claude-smart/ were left in place.",
+      "Codex's global hook feature flags and local data under ~/.reflexio/ and ~/.claude-smart/ were left in place.",
       "",
     ].join("\n"),
   );

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -17,6 +17,7 @@
     "playbook",
     "learning"
   ],
+  "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "interface": {
     "displayName": "claude-smart",

--- a/plugin/skills/claude-smart/SKILL.md
+++ b/plugin/skills/claude-smart/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: claude-smart
+description: Codex-only — use when the user asks to run claude-smart commands in Codex, including claude-smart show, learn, restart, dashboard, clear-all, or slash-like requests such as /claude-smart:learn. In Claude Code the native plugin slash commands handle these; do not invoke this skill there.
+---
+
+# claude-smart Commands In Codex
+
+Codex does not currently support plugin-provided slash commands. When the user
+asks for a claude-smart command, run the equivalent shell command through the
+active plugin root. This skill is Codex-specific; under Claude Code the native
+`/claude-smart:*` slash commands already exist, so do not fall back to the
+shell commands there.
+
+## Command Map
+
+- Dashboard: `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh`
+- Show learned state: `bash ~/.reflexio/plugin-root/scripts/cli.sh show`
+- Learn from the latest turn: `bash ~/.reflexio/plugin-root/scripts/cli.sh learn`
+- Learn with a note: `bash ~/.reflexio/plugin-root/scripts/cli.sh learn --note "<note>"`
+- Restart backend/dashboard: `bash ~/.reflexio/plugin-root/scripts/cli.sh restart`
+- Clear all learned state: `bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes`
+
+## Behavior
+
+1. Treat slash-like prompts such as `/claude-smart:show` as requests to run the
+   matching shell command above.
+2. For `learn`, preserve any user-provided note exactly as the note text.
+3. For `clear-all`, require explicit confirmation before running it because it
+   deletes all reflexio interactions, preferences, and skills.
+4. If `~/.reflexio/plugin-root` is missing or broken, tell the user to restart
+   Codex after installing claude-smart, then rerun the command.
+5. After running a command, summarize the important output concisely.

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -25,6 +25,7 @@ import argparse
 import json
 import os
 import re
+import select
 import shutil
 import subprocess
 import sys
@@ -337,6 +338,191 @@ def _set_codex_plugin_enabled(path: Path) -> bool:
     return True
 
 
+def _toml_dotted_quoted(name: str) -> str:
+    """Quote a TOML bare-key segment whose name may contain ``"`` or ``\\``."""
+    return '"' + name.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _set_codex_hook_states(path: Path, states: dict[str, str]) -> bool:
+    """Trust and enable Codex hook state entries for the given hook hashes."""
+    if not states:
+        return False
+    if not _remove_toml_sections(
+        path,
+        exact=set(),
+        prefixes=(f'hooks.state."{_CODEX_PLUGIN_ID}:',),
+    ):
+        return False
+    try:
+        text = path.read_text() if path.exists() else ""
+    except OSError:
+        return False
+    if text and not text.endswith("\n"):
+        text += "\n"
+    if "[hooks.state]" not in text:
+        if text.strip():
+            text += "\n"
+        text += "[hooks.state]\n"
+    if text.strip():
+        text += "\n"
+    for key, current_hash in sorted(states.items()):
+        text += (
+            f"[hooks.state.{_toml_dotted_quoted(key)}]\n"
+            "enabled = true\n"
+            f'trusted_hash = "{current_hash}"\n\n'
+        )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text.rstrip() + "\n")
+    except OSError:
+        return False
+    return True
+
+
+def _read_codex_app_server_response(
+    proc: subprocess.Popen[str], response_id: int, deadline: float
+) -> dict[str, object]:
+    """Read JSON-RPC lines from ``proc.stdout`` until ``response_id`` arrives.
+
+    Skips unrelated notifications and non-JSON output. Raises ``RuntimeError``
+    if the child exits, ``TimeoutError`` once ``deadline`` is reached, or
+    re-raises Codex's own error payload as ``RuntimeError``.
+    """
+    if proc.stdout is None:
+        raise RuntimeError("Codex app-server stdout pipe is not available")
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([proc.stdout], [], [], 0.2)
+        if not ready:
+            if proc.poll() is not None:
+                raise RuntimeError("Codex app-server exited before responding")
+            continue
+        line = proc.stdout.readline()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("id") == response_id:
+            if "error" in message:
+                raise RuntimeError(str(message["error"]))
+            return message
+    raise TimeoutError("Codex app-server did not respond in time")
+
+
+def _codex_app_server_request(
+    proc: subprocess.Popen[str],
+    response_id: int,
+    method: str,
+    params: dict[str, object],
+    deadline: float,
+) -> dict[str, object]:
+    """Send one JSON-RPC request to the Codex app-server and await the response."""
+    if proc.stdin is None:
+        raise RuntimeError("Codex app-server stdin pipe is not available")
+    proc.stdin.write(
+        json.dumps({"id": response_id, "method": method, "params": params})
+    )
+    proc.stdin.write("\n")
+    proc.stdin.flush()
+    return _read_codex_app_server_response(proc, response_id, deadline)
+
+
+def _list_codex_plugin_hooks(cwd: Path) -> tuple[bool, list[dict[str, object]], str]:
+    """Ask Codex for discovered hook metadata, including current trust hashes."""
+    try:
+        popen = subprocess.Popen(
+            ["codex", "app-server", "--listen", "stdio://"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError as exc:
+        return False, [], f"could not start Codex app-server: {exc}"
+
+    proc = popen
+    try:
+        deadline = time.monotonic() + _CODEX_CLI_TIMEOUT_SECONDS
+        _codex_app_server_request(
+            proc,
+            1,
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "claude_smart_installer",
+                    "title": "claude-smart installer",
+                    "version": "0.0.0",
+                },
+                "capabilities": {"experimentalApi": True},
+            },
+            deadline,
+        )
+        if proc.stdin is None:
+            return False, [], "Codex app-server stdin pipe is not available"
+        proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
+        proc.stdin.flush()
+        response = _codex_app_server_request(
+            proc,
+            2,
+            "hooks/list",
+            {"cwds": [str(cwd)]},
+            deadline,
+        )
+    except (OSError, RuntimeError, TimeoutError) as exc:
+        return False, [], str(exc)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+    result = response.get("result")
+    data = result.get("data") if isinstance(result, dict) else None
+    if not isinstance(data, list) or not data:
+        return False, [], "Codex app-server returned no hook metadata"
+    hooks = data[0].get("hooks") if isinstance(data[0], dict) else None
+    if not isinstance(hooks, list):
+        return False, [], "Codex app-server hook metadata was malformed"
+    plugin_hooks = [
+        hook
+        for hook in hooks
+        if isinstance(hook, dict)
+        and (
+            hook.get("pluginId") == _CODEX_PLUGIN_ID
+            or str(hook.get("key", "")).startswith(f"{_CODEX_PLUGIN_ID}:")
+        )
+    ]
+    return True, plugin_hooks, f"found {len(plugin_hooks)} claude-smart hooks"
+
+
+def _trust_codex_plugin_hooks(cwd: Path) -> tuple[bool, str]:
+    """Seed Codex per-hook trust state for the installed claude-smart plugin."""
+    ok, hooks, message = _list_codex_plugin_hooks(cwd)
+    if not ok:
+        return False, message
+    states: dict[str, str] = {}
+    for hook in hooks:
+        key = hook.get("key")
+        current_hash = hook.get("currentHash")
+        if (
+            isinstance(key, str)
+            and key.startswith(f"{_CODEX_PLUGIN_ID}:")
+            and isinstance(current_hash, str)
+        ):
+            states[key] = current_hash
+    if not states:
+        return False, "Codex did not report trust hashes for claude-smart hooks"
+    if not _set_codex_hook_states(_CODEX_CONFIG_PATH, states):
+        return (
+            False,
+            f"could not write claude-smart hook trust state to {_CODEX_CONFIG_PATH}",
+        )
+    return True, f"trusted and enabled {len(states)} claude-smart Codex hooks"
+
+
 def _codex_plugin_version(plugin_root: Path) -> str | None:
     try:
         manifest = json.loads(
@@ -401,21 +587,28 @@ def _cleanup_codex_install_state() -> bool:
 
 
 def _enable_codex_plugin_hooks() -> tuple[bool, str]:
-    """Enable Codex's ``plugin_hooks`` feature, falling back to editing config.toml.
+    """Enable Codex hook feature flags, falling back to editing config.toml.
 
     Returns:
         tuple[bool, str]: ``(success, message)``. The message describes
-            either the successful path taken (CLI vs. direct config write)
-            or the failure mode.
+        either the successful path taken (CLI vs. direct config write)
+        or the failure mode.
     """
-    result = _run_codex(["features", "enable", "plugin_hooks"])
-    if result.returncode == 0:
-        return True, "codex features enable plugin_hooks"
-    if _set_toml_feature(_CODEX_CONFIG_PATH, "plugin_hooks", True):
-        return True, f"set plugin_hooks = true in {_CODEX_CONFIG_PATH}"
-    return False, (
-        result.stderr or result.stdout or "could not update Codex config"
-    ).strip()
+    messages: list[str] = []
+    for feature in ("hooks", "plugin_hooks"):
+        result = _run_codex(["features", "enable", feature])
+        if result.returncode == 0:
+            messages.append(f"codex features enable {feature}")
+            continue
+        if _set_toml_feature(_CODEX_CONFIG_PATH, feature, True):
+            messages.append(f"set {feature} = true in {_CODEX_CONFIG_PATH}")
+            continue
+        detail = (
+            result.stderr or result.stdout or "could not update Codex config"
+        ).strip()
+        prior = f" (succeeded earlier: {'; '.join(messages)})" if messages else ""
+        return False, f"{feature}: {detail}{prior}"
+    return True, "; ".join(messages)
 
 
 def _register_codex_marketplace(root: Path) -> tuple[bool, str]:
@@ -501,22 +694,41 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
 
     installed = False
     install_msg = "marketplace registration failed"
+    trusted = False
+    trust_msg = "plugin was not installed"
     if registered:
         installed, install_msg = _install_codex_plugin_cache(
             marketplace_root / _CODEX_LOCAL_PLUGIN_PATH
         )
         if installed:
             sys.stdout.write(f"{install_msg}.\n")
+            trusted, trust_msg = _trust_codex_plugin_hooks(Path.cwd())
+            if not trusted:
+                # The app-server can race against the just-installed cache.
+                # Retry once before giving up; the manual /hooks recovery is
+                # available either way.
+                time.sleep(0.5)
+                trusted, trust_msg = _trust_codex_plugin_hooks(Path.cwd())
+            if trusted:
+                sys.stdout.write(f"{trust_msg}.\n")
+            else:
+                sys.stderr.write(f"warning: {trust_msg}\n")
         else:
             sys.stderr.write(f"warning: {install_msg}\n")
 
-    if registered and installed:
+    if registered and installed and trusted:
         sys.stdout.write(
             "\nclaude-smart Codex support is installed.\n"
-            "Restart Codex so the installed plugin and hooks reload. /plugins should "
+            "Restart Codex so the installed plugin and trusted hooks reload. /plugins should "
             f"show claude-smart as installed from the {_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace. "
             "Uninstall removes the plugin cache and marketplace registration but leaves "
-            "shared claude-smart data and Codex's global plugin_hooks feature intact.\n"
+            "shared claude-smart data and Codex's global hook feature flags intact.\n"
+        )
+    elif registered and installed:
+        sys.stdout.write(
+            "\nclaude-smart Codex support is installed, but hook trust could not be completed.\n"
+            "Fully quit and reopen Codex in this repo, run /hooks, trust the claude-smart hooks, "
+            "and restart Codex so hooks reload.\n"
         )
     elif registered:
         sys.stdout.write(
@@ -531,7 +743,7 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
             "then fully quit and reopen Codex, run /plugins, install claude-smart from the "
             f"{_CODEX_MARKETPLACE_DISPLAY_NAME} marketplace, and restart Codex so hooks reload.\n"
         )
-    return 0 if hooks_ok and registered and installed else 1
+    return 0 if hooks_ok and registered and installed and trusted else 1
 
 
 def cmd_install(args: argparse.Namespace) -> int:
@@ -674,7 +886,7 @@ def cmd_uninstall_codex(_args: argparse.Namespace) -> int:
         sys.stderr.write(f"warning: could not update {_CODEX_CONFIG_PATH}\n")
     sys.stdout.write(
         "claude-smart Codex plugin and marketplace state removed. Restart Codex to apply. "
-        "Codex's global plugin_hooks feature and local data under ~/.reflexio "
+        "Codex's global hook feature flags and local data under ~/.reflexio "
         "and ~/.claude-smart were left in place.\n"
     )
     return 0

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -35,7 +35,19 @@ def test_codex_manifest_points_at_codex_hooks() -> None:
     manifest = _read_json("plugin/.codex-plugin/plugin.json")
     assert manifest["name"] == "claude-smart"
     assert manifest["hooks"] == "./hooks/codex-hooks.json"
+    assert manifest["skills"] == "./skills/"
     assert manifest["interface"]["displayName"] == "claude-smart"
+
+
+def test_codex_skill_documents_command_mapping() -> None:
+    skill = (REPO_ROOT / "plugin" / "skills" / "claude-smart" / "SKILL.md").read_text()
+
+    assert "name: claude-smart" in skill
+    assert "Codex does not currently support plugin-provided slash commands" in skill
+    assert "bash ~/.reflexio/plugin-root/scripts/cli.sh show" in skill
+    assert "bash ~/.reflexio/plugin-root/scripts/cli.sh learn --note" in skill
+    assert "bash ~/.reflexio/plugin-root/scripts/cli.sh restart" in skill
+    assert "bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes" in skill
 
 
 def test_codex_marketplace_points_at_plugin_root() -> None:
@@ -303,6 +315,7 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
     monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
     monkeypatch.setattr(cli, "_CODEX_PLUGIN_CACHE_DIR", plugin_cache)
     monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+    trusted_cwds: list[Path] = []
 
     calls: list[list[str]] = []
 
@@ -315,6 +328,11 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
         return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     monkeypatch.setattr(cli, "_run_codex", fake_run_codex)
+    monkeypatch.setattr(
+        cli,
+        "_trust_codex_plugin_hooks",
+        lambda cwd: trusted_cwds.append(cwd) or (True, "trusted 7 hooks"),
+    )
 
     rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
 
@@ -332,8 +350,11 @@ def test_codex_install_succeeds_when_hooks_and_marketplace_succeed(
         "add",
         str(marketplace_root),
     ] in calls
+    assert ["features", "enable", "hooks"] in calls
+    assert trusted_cwds
     out = capsys.readouterr().out
     assert "Codex support is installed" in out
+    assert "trusted 7 hooks" in out
     assert "should show claude-smart as installed" in out
 
 
@@ -358,7 +379,9 @@ def test_codex_install_fails_when_marketplace_registration_fails(
     rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
 
     assert rc == 1
-    assert "plugin_hooks = true" in config_path.read_text()
+    text = config_path.read_text()
+    assert "hooks = true" in text
+    assert "plugin_hooks = true" in text
     out = capsys.readouterr().out
     assert "marketplace registration failed" in out
     assert "ReflexioAI marketplace" in out
@@ -499,6 +522,181 @@ def test_codex_uninstall_cleans_plugin_config_cache_and_marketplace(
     assert '[plugins."browser@openai-bundled"]' in text
     assert "[marketplaces.openai-bundled]" in text
     assert "plugin and marketplace state removed" in capsys.readouterr().out
+
+
+def test_set_codex_hook_states_replaces_only_claude_smart_hooks(tmp_path) -> None:
+    config = tmp_path / ".codex" / "config.toml"
+    config.parent.mkdir()
+    config.write_text(
+        "[hooks.state]\n"
+        "\n"
+        '[hooks.state."claude-smart@reflexioai:hooks/codex-hooks.json:stop:0:0"]\n'
+        'trusted_hash = "sha256:old"\n'
+        "\n"
+        '[hooks.state."other@market:hooks.json:stop:0:0"]\n'
+        'trusted_hash = "sha256:other"\n'
+    )
+
+    ok = cli._set_codex_hook_states(
+        config,
+        {
+            "claude-smart@reflexioai:hooks/codex-hooks.json:post_tool_use:0:0": (
+                "sha256:new"
+            ),
+            "claude-smart@reflexioai:hooks/codex-hooks.json:session_start:0:0": (
+                "sha256:start"
+            ),
+        },
+    )
+
+    assert ok is True
+    text = config.read_text()
+    assert "sha256:old" not in text
+    assert "sha256:new" in text
+    assert "sha256:start" in text
+    assert "enabled = true" in text
+    assert "other@market" in text
+
+
+def test_trust_codex_plugin_hooks_uses_app_server_current_hashes(
+    monkeypatch, tmp_path
+) -> None:
+    config = tmp_path / ".codex" / "config.toml"
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config)
+
+    def fake_list(_cwd: Path):
+        return (
+            True,
+            [
+                {
+                    "pluginId": "claude-smart@reflexioai",
+                    "key": "claude-smart@reflexioai:hooks/codex-hooks.json:stop:0:0",
+                    "currentHash": "sha256:stop",
+                },
+                {
+                    "pluginId": "other@market",
+                    "key": "other@market:hooks.json:stop:0:0",
+                    "currentHash": "sha256:other",
+                },
+            ],
+            "ok",
+        )
+
+    monkeypatch.setattr(cli, "_list_codex_plugin_hooks", fake_list)
+
+    ok, message = cli._trust_codex_plugin_hooks(tmp_path)
+
+    assert ok is True
+    assert "1 claude-smart Codex hooks" in message
+    text = config.read_text()
+    assert "sha256:stop" in text
+    assert "sha256:other" not in text
+
+
+def test_set_codex_hook_states_preserves_unrelated_hooks_state_root_table(
+    tmp_path,
+) -> None:
+    config = tmp_path / ".codex" / "config.toml"
+    config.parent.mkdir()
+    config.write_text(
+        "[hooks.state]\n"
+        "\n"
+        '[hooks.state."other@market:hooks.json:stop:0:0"]\n'
+        'trusted_hash = "sha256:other"\n'
+        "enabled = false\n"
+        'extra = "preserved"\n'
+    )
+
+    ok = cli._set_codex_hook_states(
+        config,
+        {
+            "claude-smart@reflexioai:hooks/codex-hooks.json:stop:0:0": "sha256:cs",
+        },
+    )
+
+    assert ok is True
+    text = config.read_text()
+    # The unrelated plugin's full body must survive intact.
+    assert '[hooks.state."other@market:hooks.json:stop:0:0"]' in text
+    assert 'trusted_hash = "sha256:other"' in text
+    assert "enabled = false" in text
+    assert 'extra = "preserved"' in text
+    # New entry was appended.
+    assert (
+        '[hooks.state."claude-smart@reflexioai:hooks/codex-hooks.json:stop:0:0"]'
+        in text
+    )
+    assert "sha256:cs" in text
+
+
+def test_trust_codex_plugin_hooks_returns_failure_when_app_server_lists_no_hooks(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", tmp_path / "config.toml")
+    monkeypatch.setattr(
+        cli,
+        "_list_codex_plugin_hooks",
+        lambda _cwd: (True, [], "found 0 claude-smart hooks"),
+    )
+
+    ok, message = cli._trust_codex_plugin_hooks(tmp_path)
+
+    assert ok is False
+    assert "did not report trust hashes" in message
+
+
+def test_trust_codex_plugin_hooks_returns_failure_when_app_server_subprocess_errors(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", tmp_path / "config.toml")
+
+    def fake_popen(*_args, **_kwargs):
+        raise OSError("codex not on PATH")
+
+    monkeypatch.setattr(cli.subprocess, "Popen", fake_popen)
+
+    ok, message = cli._trust_codex_plugin_hooks(tmp_path)
+
+    assert ok is False
+    assert "could not start Codex app-server" in message
+
+
+def test_codex_install_exits_nonzero_when_only_trust_fails(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    env_path = tmp_path / "reflexio" / ".env"
+    config_path = tmp_path / ".codex" / "config.toml"
+    marketplace_root = tmp_path / "marketplaces" / "reflexioai"
+    plugin_cache = (
+        tmp_path / ".codex" / "plugins" / "cache" / "reflexioai" / "claude-smart"
+    )
+    monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
+    monkeypatch.setattr(cli, "_CODEX_CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_CODEX_LOCAL_MARKETPLACE_ROOT", marketplace_root)
+    monkeypatch.setattr(cli, "_CODEX_PLUGIN_CACHE_DIR", plugin_cache)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(cli.time, "sleep", lambda _s: None)
+
+    def fake_run_codex(_args: list[str]):
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    trust_calls = {"n": 0}
+
+    def fake_trust(_cwd: Path):
+        trust_calls["n"] += 1
+        return False, "Codex did not report trust hashes for claude-smart hooks"
+
+    monkeypatch.setattr(cli, "_run_codex", fake_run_codex)
+    monkeypatch.setattr(cli, "_trust_codex_plugin_hooks", fake_trust)
+
+    rc = cli.cmd_install(argparse.Namespace(host="codex", source="unused"))
+
+    assert rc == 1
+    # Trust must have been retried at least once.
+    assert trust_calls["n"] >= 2
+    captured = capsys.readouterr()
+    assert "hook trust could not be completed" in captured.out
+    assert "did not report trust hashes" in captured.err
 
 
 def test_run_codex_times_out(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add first-class Codex CLI runtime support alongside Claude Code so the same plugin works under both hosts.
- Bundle the Codex marketplace inside the npm package so `npx claude-smart install` can wire Codex up without pulling the marketplace separately.
- Auto-install the Codex plugin cache and enable the plugin in `~/.codex/config.toml` during install.
- Standardize slash-command naming across hosts and document the Codex install caveats.
- Bumps version to 0.2.25 across all manifests (package.json, pyproject.toml, both plugin.json files, marketplace.json, uv.lock).

## Changes
**Installer (`bin/claude-smart.js`)**
- Detect Codex CLI installs and provision the plugin cache + `config.toml` entry.
- Harden the bundled-marketplace install path (atomic copy, idempotent enable).

**Plugin runtime (`plugin/src/claude_smart/cli.py`)**
- Branch CLI behavior on host (Claude Code vs Codex) so hooks and skills resolve correctly under both runtimes.

**Plugin manifest / skill**
- Add `plugin/.codex-plugin/plugin.json` Codex-specific manifest.
- New `plugin/skills/claude-smart/SKILL.md` describing the skill surface.

**Docs**
- `README.md` and `DEVELOPER.md`: standardize slash-command syntax, clarify Codex install caveats and supported hosts.

**Tests**
- `tests/test_codex_support.py`: extensive coverage for Codex install / config-toml wiring / host detection paths.

## Test Plan
- `uv run --with ruff --project plugin ruff check` — clean.
- `uv run --with ruff --project plugin ruff format` — clean.
- Full pytest suite via pre-commit hook: **263 passed**.
- Codex install path and `config.toml` enablement covered in `test_codex_support.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Codex plugin installation with automatic hook trust state management and improved feature enabling.

* **Documentation**
  * Clarified Codex installation instructions for hook behavior and configuration.
  * Added Codex skill documentation with command mappings.

* **Chores**
  * Version updated to 0.2.25.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/23)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
