### PR TITLE
feat(cs-cite): install to ~/.local/bin so PATH works out of the box

### DIFF
--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -57,6 +57,10 @@ _SOURCE_SCRIPT = _PLUGIN_ROOT / "bin" / "cs-cite"
 # out of the box — no shell-init edits required.
 _INSTALL_DIR = Path.home() / ".local" / "bin"
 INSTALL_PATH = _INSTALL_DIR / "cs-cite"
+# Legacy install location from versions that wrote to ``~/.claude-smart/bin``.
+# Cleaned up on first successful install at the new path so a stale copy
+# earlier on PATH doesn't shadow the active script.
+_LEGACY_INSTALL_PATH = Path.home() / ".claude-smart" / "bin" / "cs-cite"
 
 _FINGERPRINT_LEN = 4
 
@@ -236,6 +240,25 @@ def ensure_installed() -> Path:
             shutil.copy2(_SOURCE_SCRIPT, INSTALL_PATH)
             mode = INSTALL_PATH.stat().st_mode
             INSTALL_PATH.chmod(mode | stat_.S_IXUSR | stat_.S_IXGRP | stat_.S_IXOTH)
+            _remove_legacy_install()
     except OSError as exc:
         _LOGGER.debug("cs-cite install failed: %s", exc)
     return INSTALL_PATH
+
+
+def _remove_legacy_install() -> None:
+    """Remove the legacy ``~/.claude-smart/bin/cs-cite`` script if present.
+
+    Called only after a successful install at the new ``~/.local/bin``
+    path so a user who had previously added the old directory to PATH
+    (ahead of ``~/.local/bin``) won't keep invoking the stale copy.
+    Failure is logged at DEBUG and otherwise ignored — citation injection
+    must never abort because of a stray legacy file.
+
+    Returns:
+        None
+    """
+    try:
+        _LEGACY_INSTALL_PATH.unlink(missing_ok=True)
+    except OSError as exc:
+        _LOGGER.debug("legacy cs-cite cleanup skipped: %s", exc)

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -29,7 +29,8 @@ This module holds:
   is available. ``p`` is preference, ``s`` is skill.
 - ``CITATION_CMD_RE``: regex matching a valid legacy ``cs-cite`` command line.
 - ``ensure_installed``: idempotent copy of ``plugin/bin/cs-cite`` to
-  ``~/.claude-smart/bin/cs-cite`` with the executable bit set.
+  ``~/.local/bin/cs-cite`` (a standard XDG user bin dir on PATH) with
+  the executable bit set.
 - ``CITATION_INSTRUCTION``: the trailer text appended to injected context
   so the assistant knows when and how to emit the citation marker.
 """
@@ -48,7 +49,13 @@ _LOGGER = logging.getLogger(__name__)
 _THIS_DIR = Path(__file__).resolve().parent
 _PLUGIN_ROOT = _THIS_DIR.parents[1]  # plugin/src/claude_smart/ -> plugin/
 _SOURCE_SCRIPT = _PLUGIN_ROOT / "bin" / "cs-cite"
-_INSTALL_DIR = Path.home() / ".claude-smart" / "bin"
+# Install into ``~/.local/bin`` (a standard XDG user bin dir already on
+# PATH for any setup that runs pip/uv/cargo-style user installs). The
+# previous location ``~/.claude-smart/bin`` was self-contained but not
+# on PATH by default, which forced users to add it to their shell rc
+# file. Switching to ``~/.local/bin`` makes ``cs-cite`` discoverable
+# out of the box — no shell-init edits required.
+_INSTALL_DIR = Path.home() / ".local" / "bin"
 INSTALL_PATH = _INSTALL_DIR / "cs-cite"
 
 _FINGERPRINT_LEN = 4
@@ -200,7 +207,7 @@ def _parse_id_tokens(raw_ids: str) -> list[str]:
 
 
 def ensure_installed() -> Path:
-    """Idempotently install ``cs-cite`` into ``~/.claude-smart/bin/``.
+    """Idempotently install ``cs-cite`` into ``~/.local/bin/``.
 
     Called from every PreToolUse / UserPromptSubmit inject, so we
     short-circuit when the target file already exists with

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -196,6 +196,36 @@ def test_ensure_installed_refreshes_stale_executable(tmp_path, monkeypatch) -> N
     assert target.stat().st_mode & stat.S_IXUSR
 
 
+def test_ensure_installed_removes_legacy_copy(tmp_path, monkeypatch) -> None:
+    """A successful install removes the legacy ``~/.claude-smart/bin`` copy."""
+    monkeypatch.setattr(cs_cite, "_INSTALL_DIR", tmp_path / "bin")
+    monkeypatch.setattr(cs_cite, "INSTALL_PATH", tmp_path / "bin" / "cs-cite")
+    legacy = tmp_path / "legacy" / "cs-cite"
+    legacy.parent.mkdir()
+    legacy.write_text("#!/bin/sh\nexit 0\n")
+    legacy.chmod(0o755)
+    monkeypatch.setattr(cs_cite, "_LEGACY_INSTALL_PATH", legacy)
+
+    cs_cite.ensure_installed()
+
+    assert (tmp_path / "bin" / "cs-cite").is_file()
+    assert not legacy.exists()
+
+
+def test_ensure_installed_tolerates_missing_legacy_copy(tmp_path, monkeypatch) -> None:
+    """Legacy cleanup is best-effort: no legacy file means a silent no-op."""
+    monkeypatch.setattr(cs_cite, "_INSTALL_DIR", tmp_path / "bin")
+    monkeypatch.setattr(cs_cite, "INSTALL_PATH", tmp_path / "bin" / "cs-cite")
+    monkeypatch.setattr(
+        cs_cite, "_LEGACY_INSTALL_PATH", tmp_path / "nonexistent" / "cs-cite"
+    )
+
+    # Must not raise even though the legacy path does not exist.
+    cs_cite.ensure_installed()
+
+    assert (tmp_path / "bin" / "cs-cite").is_file()
+
+
 def test_ensure_installed_tolerates_readonly_target_parent(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

`ensure_installed()` copies `cs-cite` to `~/.claude-smart/bin/` — but that directory is not on PATH by default. Users had to manually add the path to `~/.zshrc` / `~/.bashrc` for Claude's Bash citation calls to resolve. Easy to miss; the symptom (citation silently failing) is hard to debug.

This change installs to `~/.local/bin/` instead — the standard XDG user-bin dir already on PATH for any setup that runs `pip --user`, `uv tool install`, `cargo install`, etc.

## What changed

`plugin/src/claude_smart/cs_cite.py`:
- `_INSTALL_DIR = Path.home() / ".claude-smart" / "bin"` → `Path.home() / ".local" / "bin"`
- Two docstring references updated to match
- Added a comment explaining why we chose this path

## Migration

`ensure_installed()` runs on every PreToolUse / UserPromptSubmit hook, so existing users get the new install on their next session automatically — no re-install required. The legacy `~/.claude-smart/bin/cs-cite` is harmless and can be removed manually:

```bash
rm ~/.claude-smart/bin/cs-cite
```

## Tests

`tests/test_cs_cite.py` — 32 passed. The tests already use `monkeypatch.setattr(cs_cite, "_INSTALL_DIR", tmp_path / "bin")` so they're path-agnostic and don't pin to the legacy location.

## Verification

```
$ python -c "from claude_smart.cs_cite import ensure_installed, INSTALL_PATH; ensure_installed(); print(INSTALL_PATH)"
/home/openclaw/.local/bin/cs-cite

$ which cs-cite
/home/openclaw/.local/bin/cs-cite

$ cs-cite r1-ab12
(works — no PATH hacks needed)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation documentation and inline comments for the `cs-cite` tool to reflect a new installation directory aligned with XDG standards.

* **Configuration**
  * Changed the default installation destination for `cs-cite` to a standard user binary directory, improving system compatibility and reducing the need for additional shell configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/24)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->