### PR TITLE
[codex] Fix claude-smart Codex host publishing

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -25,10 +25,10 @@ Tunables read by the plugin at runtime. Most users don't need to touch these —
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `CLAUDE_SMART_USE_LOCAL_CLI` | `0` (installer sets `1`) | Route generation through the local `claude` CLI. Written to `~/.reflexio/.env` by `claude-smart install`. |
+| `CLAUDE_SMART_USE_LOCAL_CLI` | `0` (installer sets `1`) | Route generation through the active host CLI (`claude` for Claude Code, `codex` for Codex). Written to `~/.reflexio/.env` by `claude-smart install`. |
 | `CLAUDE_SMART_USE_LOCAL_EMBEDDING` | `0` (installer sets `1`) | Use the in-process ONNX embedder (requires `chromadb`). Written to `~/.reflexio/.env` by `claude-smart install`. |
 | `CLAUDE_SMART_ENABLE_OPTIMIZER` | enabled unless set to `0` | Hook-side env var that controls shared skill optimization and rollups during `SessionStart`. Set it in Claude Code settings, not `~/.reflexio/.env`. |
-| `CLAUDE_SMART_CLI_PATH` | `shutil.which("claude")` | Override the path to the `claude` binary. |
+| `CLAUDE_SMART_CLI_PATH` | `claude` on Claude Code; Codex compatibility wrapper on Codex | Override the executable Reflexio calls for local generation. |
 | `CLAUDE_SMART_STATE_DIR` | `~/.claude-smart/sessions/` | Where the per-session JSONL buffer lives. |
 | `CLAUDE_SMART_BACKEND_AUTOSTART` | `1` | Set to `0` to stop the SessionStart hook from spawning the reflexio backend on `localhost:8071`. |
 | `CLAUDE_SMART_DASHBOARD_AUTOSTART` | `1` | Set to `0` to stop the SessionStart hook from spawning the Next.js dashboard on `localhost:3001`. |

--- a/plugin/scripts/_codex_env.sh
+++ b/plugin/scripts/_codex_env.sh
@@ -25,3 +25,4 @@ _R="${_R%/}"
 export _R
 export PLUGIN_ROOT="$_R"
 export CLAUDE_PLUGIN_ROOT="$_R"
+export CLAUDE_SMART_HOST="codex"

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -29,24 +29,29 @@ PORT=8071
 # binds to PORT instead of reflexio's library default (8081).
 export BACKEND_PORT="$PORT"
 
-# Default: route extraction through the local claude CLI + ONNX embedder
+# Default: route extraction through the active host CLI + ONNX embedder
 # so claude-smart works without any LLM API key. Users can opt out by
 # pre-exporting these to 0.
 export CLAUDE_SMART_USE_LOCAL_CLI="${CLAUDE_SMART_USE_LOCAL_CLI:-1}"
 export CLAUDE_SMART_USE_LOCAL_EMBEDDING="${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}"
-# The backend can be spawned from contexts whose PATH lacks the claude
+# The backend can be spawned from contexts whose PATH lacks the host
 # CLI dir (commonly ~/.local/bin or /opt/homebrew/bin). Pin the CLI
 # explicitly if we can resolve it from our own (post-login-path) PATH.
+PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+
 if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
-  if _cs_claude_path=$(command -v claude 2>/dev/null) && [ -n "$_cs_claude_path" ]; then
-    export CLAUDE_SMART_CLI_PATH="$_cs_claude_path"
+  if [ "${CLAUDE_SMART_HOST:-claude-code}" = "codex" ]; then
+    # Reflexio's provider still calls CLAUDE_SMART_CLI_PATH with Claude CLI
+    # flags. Use a small compatibility executable that translates that narrow
+    # contract to `codex exec`.
+    export CLAUDE_SMART_CLI_PATH="$PLUGIN_ROOT/scripts/codex-claude-compat.py"
+  elif _cs_cli_path=$(command -v claude 2>/dev/null) && [ -n "$_cs_cli_path" ]; then
+    export CLAUDE_SMART_CLI_PATH="$_cs_cli_path"
   elif [ -x "$HOME/.local/bin/claude" ]; then
     export CLAUDE_SMART_CLI_PATH="$HOME/.local/bin/claude"
   fi
-  unset _cs_claude_path
+  unset _cs_cli_path
 fi
-
-PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 
 STATE_DIR="$HOME/.claude-smart"
 PID_FILE="$STATE_DIR/backend.pid"

--- a/plugin/scripts/codex-claude-compat.py
+++ b/plugin/scripts/codex-claude-compat.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Translate Reflexio's Claude CLI provider contract to ``codex exec``.
+
+Reflexio's local provider currently shells out to ``CLAUDE_SMART_CLI_PATH`` as
+if it were the Claude Code CLI:
+
+    <path> -p --output-format json --model <model> [--append-system-prompt ...]
+
+When claude-smart runs under Codex, this executable preserves that narrow
+contract while routing the actual model call through ``codex exec``. The
+stdout shape intentionally matches Claude Code's JSON output enough for
+Reflexio's provider to read ``result``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+_TIMEOUT_SECONDS = 120
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    try:
+        system_prompt = _parse_supported_args(argv)
+        content = _run_codex(
+            prompt=sys.stdin.read(),
+            system_prompt=system_prompt,
+        )
+    except Exception as exc:  # noqa: BLE001 - CLI bridge errors go to stderr.
+        print(f"codex-claude-compat: {exc}", file=sys.stderr)
+        return 1
+
+    json.dump({"result": content}, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _parse_supported_args(argv: list[str]) -> str:
+    system_prompt = ""
+    idx = 0
+    while idx < len(argv):
+        arg = argv[idx]
+        if arg == "-p":
+            idx += 1
+        elif arg == "--output-format":
+            idx += 2
+        elif arg == "--model":
+            idx += 2
+        elif arg == "--append-system-prompt":
+            if idx + 1 >= len(argv):
+                raise ValueError("--append-system-prompt requires a value")
+            system_prompt = argv[idx + 1]
+            idx += 2
+        else:
+            raise ValueError(f"unsupported Claude CLI argument: {arg}")
+    return system_prompt
+
+
+def _run_codex(*, prompt: str, system_prompt: str) -> str:
+    codex_path = os.environ.get("CLAUDE_SMART_CODEX_PATH") or shutil.which("codex")
+    if not codex_path:
+        raise FileNotFoundError("codex CLI not found on PATH")
+
+    output_path = _temporary_output_path()
+    cmd = [
+        codex_path,
+        "exec",
+        "--sandbox",
+        "read-only",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "--ignore-rules",
+        "--output-last-message",
+        str(output_path),
+        "-",
+    ]
+
+    env = os.environ.copy()
+    env["CLAUDE_SMART_HOST"] = "codex"
+    env["CLAUDE_SMART_INTERNAL"] = "1"
+    env["CLAUDE_CODE_ENTRYPOINT"] = "optimizer"
+
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed command plus resolved executable.
+            cmd,
+            input=_codex_prompt(prompt=prompt, system_prompt=system_prompt),
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            check=False,
+            env=env,
+        )
+        if proc.returncode != 0:
+            stderr = proc.stderr.strip()
+            raise RuntimeError(f"codex CLI exited {proc.returncode}: {stderr[:500]}")
+        content = output_path.read_text(encoding="utf-8").strip()
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError(f"codex CLI timed out after {_TIMEOUT_SECONDS}s") from exc
+    finally:
+        try:
+            output_path.unlink()
+        except OSError:
+            pass
+
+    if not content:
+        raise RuntimeError("codex CLI returned empty output")
+    return content
+
+
+def _temporary_output_path() -> Path:
+    handle = tempfile.NamedTemporaryFile(prefix="claude-smart-codex-", delete=False)
+    try:
+        return Path(handle.name)
+    finally:
+        handle.close()
+
+
+def _codex_prompt(*, prompt: str, system_prompt: str) -> str:
+    if not system_prompt:
+        return prompt
+    return f"{system_prompt}\n\n## Task\n{prompt}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from claude_smart import cs_cite, ids, publish, runtime, state
+from claude_smart import cs_cite, ids, internal_call, publish, runtime, state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,6 +110,16 @@ def _scan_transcript_for_assistant_text(entries: list[dict[str, Any]]) -> str:
         message = entry.get("message") or {}
         parts.extend(_extract_text_blocks(message.get("content")))
     return "\n\n".join(parts)
+
+
+def _scan_transcript_for_user_text(entries: list[dict[str, Any]]) -> str:
+    """Return the user text that opened the current transcript turn."""
+    for entry in reversed(entries):
+        if not _is_user_turn_boundary(entry):
+            continue
+        message = entry.get("message") or {}
+        return "\n\n".join(_extract_text_blocks(message.get("content")))
+    return ""
 
 
 def _is_user_turn_boundary(entry: dict[str, Any]) -> bool:
@@ -349,6 +359,11 @@ def handle(payload: dict[str, Any]) -> None:
         path = Path(transcript_path)
         if path.is_file():
             entries = _load_transcript_with_retry(path)
+
+    if runtime.is_codex():
+        prompt = payload.get("prompt") or _scan_transcript_for_user_text(entries)
+        if internal_call.is_codex_internal_prompt(prompt):
+            return
 
     last_assistant_message = payload.get("last_assistant_message")
     assistant_text = (

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -29,6 +29,9 @@ Detection signals, OR'd:
   - ``payload.cwd`` resolves inside the reflexio submodule. Catches
     direct interactive ``claude`` runs from inside reflexio (manual
     debugging) that would otherwise pollute the corpus.
+  - Known Codex-internal prompt templates (title generation and home-screen
+    suggestions). These are model calls made by Codex itself, not user
+    coding turns, and must never be reflected into claude-smart memory.
 """
 
 from __future__ import annotations
@@ -41,6 +44,19 @@ from claude_smart import runtime
 
 _ENTRYPOINT_VAR = "CLAUDE_CODE_ENTRYPOINT"
 _INTERACTIVE_ENTRYPOINT = "cli"
+_CODEX_TITLE_PROMPT_PREFIX = (
+    "You are a helpful assistant. You will be presented with a user prompt, "
+    "and your job is to provide a short title for a task"
+)
+_CODEX_SUGGESTIONS_PROMPT_PREFIX = "# Overview\n\nGenerate 0 to 3 "
+_CODEX_SUGGESTIONS_PROMPT_MARKER = (
+    "hyperpersonalized suggestions for what this user can do with Codex "
+    "in this local project:"
+)
+_CODEX_SUGGESTIONS_APPS_MARKER = (
+    "Get an understanding of the user's intent and goals by deeply viewing "
+    "their connected apps."
+)
 
 # Reflexio submodule lives at <repo>/reflexio when this package runs from
 # a dev checkout (<repo>/plugin/src/claude_smart/internal_call.py); anchor
@@ -75,6 +91,8 @@ def is_internal_invocation(payload: dict[str, Any]) -> bool:
     entrypoint = os.environ.get(_ENTRYPOINT_VAR)
     if entrypoint and entrypoint != _INTERACTIVE_ENTRYPOINT:
         return True
+    if runtime.is_codex() and is_codex_internal_prompt(payload.get("prompt")):
+        return True
     cwd = payload.get("cwd")
     if not isinstance(cwd, str) or not cwd:
         return False
@@ -87,3 +105,15 @@ def is_internal_invocation(payload: dict[str, Any]) -> bool:
     except ValueError:
         return False
     return True
+
+
+def is_codex_internal_prompt(prompt: Any) -> bool:
+    """True for Codex's own UI/task prompts, not user-authored turns."""
+    if not isinstance(prompt, str):
+        return False
+    text = prompt.strip()
+    return text.startswith(_CODEX_TITLE_PROMPT_PREFIX) or (
+        text.startswith(_CODEX_SUGGESTIONS_PROMPT_PREFIX)
+        and _CODEX_SUGGESTIONS_PROMPT_MARKER in text
+        and _CODEX_SUGGESTIONS_APPS_MARKER in text
+    )

--- a/plugin/src/claude_smart/optimizer_assistant.py
+++ b/plugin/src/claude_smart/optimizer_assistant.py
@@ -2,22 +2,24 @@
 
 Reflexio's ``LocalScriptAssistant`` sends one JSON payload on stdin and expects
 one JSON object on stdout. This module bridges that protocol to a guarded
-``claude -p`` subprocess so candidate playbooks can be evaluated against Claude
-Code without re-entering claude-smart/reflexio hooks.
+local CLI subprocess so candidate playbooks can be evaluated against the active
+host without re-entering claude-smart/reflexio hooks.
 """
 
 from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Any
 
 from claude_smart import internal_call, runtime
 
-_CLAUDE_TIMEOUT_SECONDS = 300
+_CLI_TIMEOUT_SECONDS = 300
 _READ_ONLY_TOOLS = "Read,Grep,Glob,LS"
 _MUTATING_TOOLS = "Bash,Edit,Write,MultiEdit,NotebookEdit"
 
@@ -33,7 +35,7 @@ def main() -> int:
         messages = _validated_list(payload, "messages")
         playbooks = _validated_list(payload, "playbooks")
         prompt, system_prompt = _build_prompt(messages, playbooks)
-        content = _run_claude(prompt=prompt, system_prompt=system_prompt)
+        content = _run_local_cli(prompt=prompt, system_prompt=system_prompt)
     except Exception as exc:  # noqa: BLE001 - script errors become LocalScript failures.
         sys.stderr.write(f"{type(exc).__name__}: {exc}\n")
         return 1
@@ -134,6 +136,12 @@ def _render_transcript(messages: list[dict[str, str]]) -> str:
     )
 
 
+def _run_local_cli(*, prompt: str, system_prompt: str) -> str:
+    if runtime.is_codex():
+        return _run_codex(prompt=prompt, system_prompt=system_prompt)
+    return _run_claude(prompt=prompt, system_prompt=system_prompt)
+
+
 def _run_claude(*, prompt: str, system_prompt: str) -> str:
     cli_path = shutil.which("claude") or "claude"
     # This is an evaluation rollout, not a real user session: allow local
@@ -167,13 +175,13 @@ def _run_claude(*, prompt: str, system_prompt: str) -> str:
             input=prompt,
             capture_output=True,
             text=True,
-            timeout=_CLAUDE_TIMEOUT_SECONDS,
+            timeout=_CLI_TIMEOUT_SECONDS,
             check=False,
             env=env,
         )
     except subprocess.TimeoutExpired as exc:
         raise OptimizerAssistantError(
-            f"claude CLI timed out after {_CLAUDE_TIMEOUT_SECONDS}s"
+            f"claude CLI timed out after {_CLI_TIMEOUT_SECONDS}s"
         ) from exc
     except FileNotFoundError as exc:
         raise OptimizerAssistantError("claude CLI not found on PATH") from exc
@@ -197,6 +205,78 @@ def _run_claude(*, prompt: str, system_prompt: str) -> str:
     if not isinstance(content, str):
         raise OptimizerAssistantError("claude CLI JSON output missing result/response")
     return content
+
+
+def _run_codex(*, prompt: str, system_prompt: str) -> str:
+    cli_path = shutil.which("codex") or "codex"
+    output_path = _temporary_output_path()
+    cmd = [
+        cli_path,
+        "exec",
+        "--sandbox",
+        "read-only",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "--ignore-rules",
+        "--output-last-message",
+        str(output_path),
+        "-",
+    ]
+
+    env = os.environ.copy()
+    env[runtime.HOST_ENV] = runtime.HOST_CODEX
+    env[runtime.INTERNAL_ENV] = "1"
+    env[internal_call._ENTRYPOINT_VAR] = "optimizer"  # noqa: SLF001
+
+    try:
+        proc = subprocess.run(  # noqa: S603 - command is fixed plus resolved executable.
+            cmd,
+            input=_codex_prompt(prompt=prompt, system_prompt=system_prompt),
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise OptimizerAssistantError(
+            f"codex CLI timed out after {_CLI_TIMEOUT_SECONDS}s"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise OptimizerAssistantError("codex CLI not found on PATH") from exc
+
+    try:
+        content = output_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise OptimizerAssistantError("codex CLI did not write output") from exc
+    finally:
+        try:
+            output_path.unlink()
+        except OSError:
+            pass
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise OptimizerAssistantError(
+            f"codex CLI exited {proc.returncode}: {stderr[:500]}"
+        )
+    if not content:
+        raise OptimizerAssistantError("codex CLI returned empty output")
+    return content
+
+
+def _temporary_output_path() -> Path:
+    handle = tempfile.NamedTemporaryFile(prefix="claude-smart-codex-", delete=False)
+    try:
+        return Path(handle.name)
+    finally:
+        handle.close()
+
+
+def _codex_prompt(*, prompt: str, system_prompt: str) -> str:
+    if not system_prompt:
+        return prompt
+    return f"{system_prompt}\n\n## Task\n{prompt}"
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -156,8 +156,16 @@ def test_hook_commands_pass_explicit_host() -> None:
 
 def test_codex_hooks_use_expected_events_and_marketplace_fallback() -> None:
     hooks = _read_json("plugin/hooks/codex-hooks.json")["hooks"]
+    codex_env = (REPO_ROOT / "plugin" / "scripts" / "_codex_env.sh").read_text()
+    backend_service = (
+        REPO_ROOT / "plugin" / "scripts" / "backend-service.sh"
+    ).read_text()
     assert set(hooks) == {"SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"}
     assert "PreToolUse" not in hooks
+    assert 'CLAUDE_SMART_HOST="codex"' in codex_env
+    assert 'CLAUDE_SMART_CLI_PATH="$PLUGIN_ROOT/scripts/codex-claude-compat.py"' in (
+        backend_service
+    )
     for command in _command_hooks("plugin/hooks/codex-hooks.json"):
         assert "_codex_env.sh" in command
         assert "printenv PATH" not in command
@@ -238,6 +246,48 @@ def test_codex_stop_prefers_last_assistant_message(session_dir, monkeypatch) -> 
     assert records[-1]["role"] == "Assistant"
     assert records[-1]["content"] == "final answer from codex"
     assert calls and calls[0]["project_id"] == "demo"
+
+
+def test_codex_stop_skips_internal_prompt_from_transcript(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    calls: list[dict[str, Any]] = []
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "message": {
+                            "content": (
+                                "You are a helpful assistant. You will be presented "
+                                "with a user prompt, and your job is to provide a "
+                                "short title for a task that will be created from "
+                                "that prompt."
+                            )
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "Fix bug"}]},
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.setattr(
+        stop.publish, "publish_unpublished", lambda **kw: calls.append(kw)
+    )
+
+    stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
+
+    assert state.read_all("s1") == []
+    assert calls == []
 
 
 def test_codex_stop_resolves_text_citations_from_last_assistant_message(

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import stat
@@ -16,6 +17,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LIB = REPO_ROOT / "plugin" / "scripts" / "_lib.sh"
 SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
+CODEX_COMPAT = REPO_ROOT / "plugin" / "scripts" / "codex-claude-compat.py"
 
 
 def _minimal_path(tmp_path: Path, *names: str) -> str:
@@ -171,6 +173,53 @@ def test_dashboard_build_writes_marker_when_npm_missing(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert marker.is_file()
     assert "npm is not on PATH" in marker.read_text()
+
+
+def test_codex_claude_compat_translates_claude_contract(tmp_path: Path) -> None:
+    output_file = tmp_path / "captured-output-path"
+    codex = tmp_path / "codex"
+    codex.write_text(
+        "#!/bin/sh\n"
+        "while [ \"$#\" -gt 0 ]; do\n"
+        "  if [ \"$1\" = \"--output-last-message\" ]; then\n"
+        "    shift\n"
+        "    out=\"$1\"\n"
+        "  fi\n"
+        "  shift || exit 1\n"
+        "done\n"
+        "cat > \"$out.prompt\"\n"
+        "printf 'codex reply' > \"$out\"\n"
+    )
+    codex.chmod(codex.stat().st_mode | stat.S_IXUSR)
+    env = _isolated_env(tmp_path)
+    env["PATH"] = _minimal_path(tmp_path, "cat", "python3")
+    env["CLAUDE_SMART_CODEX_PATH"] = str(codex)
+    env["TMPDIR"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            str(CODEX_COMPAT),
+            "-p",
+            "--output-format",
+            "json",
+            "--model",
+            "claude-sonnet-4-6",
+            "--append-system-prompt",
+            "system rules",
+        ],
+        input="answer this",
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"result": "codex reply"}
+    prompt_files = list(tmp_path.glob("claude-smart-codex-*.prompt"))
+    assert len(prompt_files) == 1
+    assert prompt_files[0].read_text() == "system rules\n\n## Task\nanswer this"
+    assert not output_file.exists()
 
 
 def test_install_private_node_installs_from_verified_archive(tmp_path: Path) -> None:

--- a/tests/test_internal_call.py
+++ b/tests/test_internal_call.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from claude_smart import internal_call
+from claude_smart import internal_call, runtime
 from claude_smart.internal_call import is_internal_invocation
 
 
@@ -93,3 +93,61 @@ def test_returns_false_for_interactive_entrypoint(
     monkeypatch.delenv("CLAUDE_SMART_INTERNAL", raising=False)
     monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
     assert is_internal_invocation({}) is False
+
+
+def test_returns_true_for_codex_title_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLAUDE_SMART_INTERNAL", raising=False)
+    runtime.set_host(runtime.HOST_CODEX)
+
+    assert (
+        is_internal_invocation(
+            {
+                "prompt": (
+                    "You are a helpful assistant. You will be presented with a user "
+                    "prompt, and your job is to provide a short title for a task "
+                    "that will be created from that prompt."
+                )
+            }
+        )
+        is True
+    )
+
+
+def test_returns_true_for_codex_suggestions_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CLAUDE_SMART_INTERNAL", raising=False)
+    runtime.set_host(runtime.HOST_CODEX)
+
+    assert (
+        is_internal_invocation(
+            {
+                "prompt": (
+                    "# Overview\n\nGenerate 0 to 3 hyperpersonalized suggestions "
+                    "for what this user can do with Codex in this local project: "
+                    "/tmp/repo\n\nGet an understanding of the user's intent and "
+                    "goals by deeply viewing their connected apps."
+                )
+            }
+        )
+        is True
+    )
+
+
+def test_codex_prompt_fingerprints_do_not_apply_to_claude_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CLAUDE_SMART_INTERNAL", raising=False)
+    runtime.set_host(runtime.HOST_CLAUDE_CODE)
+
+    assert (
+        is_internal_invocation(
+            {
+                "prompt": (
+                    "You are a helpful assistant. You will be presented with a user "
+                    "prompt, and your job is to provide a short title for a task."
+                )
+            }
+        )
+        is False
+    )

--- a/tests/test_optimizer_assistant.py
+++ b/tests/test_optimizer_assistant.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from claude_smart import optimizer_assistant
+from claude_smart import optimizer_assistant, runtime
 
 
 def _run_main(monkeypatch, payload):
@@ -76,6 +76,56 @@ def test_optimizer_assistant_invokes_claude_and_emits_content(monkeypatch, key) 
     assert "Be concise." in system_prompt
     assert "User: first" in system_prompt
     assert "Assistant: seen" in system_prompt
+
+
+def test_optimizer_assistant_invokes_codex_for_codex_host(
+    monkeypatch, tmp_path
+) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    calls = []
+    output_path = tmp_path / "last-message.txt"
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        output_path.write_text("codex reply")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(optimizer_assistant, "_temporary_output_path", lambda: output_path)
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which",
+        lambda name: "/bin/codex" if name == "codex" else None,
+    )
+    monkeypatch.setattr("claude_smart.optimizer_assistant.subprocess.run", fake_run)
+
+    rc, stdout, stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "seen"},
+                {"role": "user", "content": "answer now"},
+            ],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": "summaries"}],
+        },
+    )
+
+    assert rc == 0
+    assert stderr == ""
+    assert json.loads(stdout) == {"content": "codex reply"}
+    cmd, kwargs = calls[0]
+    assert cmd[:2] == ["/bin/codex", "exec"]
+    assert "--output-last-message" in cmd
+    assert cmd[cmd.index("--sandbox") + 1] == "read-only"
+    assert "--ask-for-approval" not in cmd
+    assert "--skip-git-repo-check" in cmd
+    assert "--ephemeral" in cmd
+    assert "--ignore-rules" in cmd
+    assert kwargs["input"].endswith("## Task\nanswer now")
+    assert "Be concise." in kwargs["input"]
+    assert "Assistant: seen" in kwargs["input"]
+    assert kwargs["env"]["CLAUDE_SMART_HOST"] == "codex"
+    assert kwargs["env"]["CLAUDE_SMART_INTERNAL"] == "1"
+    assert kwargs["env"]["CLAUDE_CODE_ENTRYPOINT"] == "optimizer"
 
 
 def test_optimizer_assistant_rejects_invalid_stdin(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Skip Codex UI/internal prompts, including task-title and home-screen suggestion prompts, before they are published to claude-smart memory.
- Route Reflexio local generation through a Codex compatibility wrapper instead of assuming the Claude CLI exists under Codex.
- Make optimizer assistant calls host-aware so Codex uses `codex exec` with internal-call guard environment variables.
- Add regression coverage for Codex internal prompt filtering, transcript-only Stop events, backend wrapper selection, and the wrapper CLI contract.

## Root Cause

Codex can invoke plugin hooks for its own UI/model tasks, and those prompt shapes were not classified as internal. Separately, Reflexio still calls the configured local provider with Claude CLI flags, so pointing Codex installations directly at the raw `codex` binary leaked unsupported arguments and failed extraction.

## Validation

- `uv run --project plugin pytest`
- `uvx ruff check plugin/scripts/codex-claude-compat.py plugin/src/claude_smart/events/stop.py plugin/src/claude_smart/internal_call.py plugin/src/claude_smart/optimizer_assistant.py tests/test_codex_support.py tests/test_install_scripts.py tests/test_internal_call.py tests/test_optimizer_assistant.py`
- `bash -n plugin/scripts/_codex_env.sh && bash -n plugin/scripts/backend-service.sh`
- Installed/restarted claude-smart under Codex with `~/.reflexio/plugin-root` and `~/plugins/claude-smart` forced to the local plugin checkout.
- Verified `~/.claude-smart/backend.log` registered the local `plugin/scripts/codex-claude-compat.py` provider and showed successful publish/extraction without `ask-for-approval` or unsupported-argument errors.
- Ran a live `codex exec` marker prompt and confirmed the exact marker response was captured by the hook path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for executing requests through Codex CLI as an alternative backend
  * Implemented detection and filtering of internal prompts in Codex environments

* **Documentation**
  * Updated CLI path resolution documentation for environment configuration

* **Tests**
  * Added comprehensive test coverage for Codex CLI integration and internal prompt detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->