### PR TITLE
[codex] Smooth Codex local installation

### DIFF
--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -12,6 +12,7 @@
 "use strict";
 
 const { execSync, spawn } = require("child_process");
+const crypto = require("crypto");
 const {
   appendFileSync,
   cpSync,
@@ -21,7 +22,8 @@ const {
   rmSync,
   writeFileSync,
 } = require("fs");
-const { homedir } = require("os");
+const https = require("https");
+const { homedir, tmpdir } = require("os");
 const { dirname, join } = require("path");
 
 const DEFAULT_MARKETPLACE_SOURCE = "ReflexioAI/claude-smart";
@@ -52,6 +54,8 @@ const CODEX_REQUIRED_FILES = [
   ".agents/plugins/marketplace.json",
   "plugin/.codex-plugin/plugin.json",
   "plugin/hooks/codex-hooks.json",
+  "plugin/scripts/codex-claude-compat.py",
+  "plugin/scripts/codex-hook.js",
   "plugin/scripts/_codex_env.sh",
 ];
 const CODEX_CLI_TIMEOUT_MS = 30_000;
@@ -175,13 +179,256 @@ function seedReflexioEnv() {
   const existing = existsSync(REFLEXIO_ENV_PATH)
     ? readFileSync(REFLEXIO_ENV_PATH, "utf8")
     : "";
-  const flags = ["CLAUDE_SMART_USE_LOCAL_CLI", "CLAUDE_SMART_USE_LOCAL_EMBEDDING"];
+  const flags = [
+    "CLAUDE_SMART_USE_LOCAL_CLI",
+    "CLAUDE_SMART_USE_LOCAL_EMBEDDING",
+  ];
   const missing = flags.filter((f) => !new RegExp(`^${f}=`, "m").test(existing));
   if (missing.length === 0) return [];
   const prefix = existing && !existing.endsWith("\n") ? "\n" : "";
   const body = missing.map((f) => `${f}=1`).join("\n") + "\n";
   appendFileSync(REFLEXIO_ENV_PATH, prefix + body);
   return missing;
+}
+
+function isWindows() {
+  return process.platform === "win32";
+}
+
+function runChecked(command, args, options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env || process.env,
+      shell: isWindows() && /\.(?:cmd|bat)$/i.test(command),
+      stdio: "inherit",
+      windowsHide: true,
+    });
+    child.on("exit", (code) => resolve(typeof code === "number" ? code : 1));
+    child.on("error", () => resolve(1));
+  });
+}
+
+function downloadFile(url, dest) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if (
+        response.statusCode &&
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location
+      ) {
+        downloadFile(new URL(response.headers.location, url).toString(), dest)
+          .then(resolve, reject);
+        response.resume();
+        return;
+      }
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`download failed (${response.statusCode}) for ${url}`));
+        return;
+      }
+      const chunks = [];
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("end", () => {
+        writeFileSync(dest, Buffer.concat(chunks));
+        resolve();
+      });
+    });
+    request.on("error", reject);
+    request.setTimeout(120_000, () => request.destroy(new Error(`download timed out for ${url}`)));
+  });
+}
+
+function resolveCommand(names, extraDirs = []) {
+  const pathParts = [
+    ...extraDirs,
+    ...(process.env.PATH || "").split(process.platform === "win32" ? ";" : ":"),
+  ].filter(Boolean);
+  for (const dir of pathParts) {
+    for (const name of names) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function privateNodeRoot() {
+  return join(homedir(), ".claude-smart", "node", "current");
+}
+
+function privateNodeBinDirs() {
+  const root = privateNodeRoot();
+  return [join(root, "bin"), root];
+}
+
+function resolvePrivateNode() {
+  return resolveCommand(isWindows() ? ["node.exe", "node"] : ["node"], privateNodeBinDirs());
+}
+
+function resolvePrivateNpm() {
+  return resolveCommand(
+    isWindows() ? ["npm.cmd", "npm.exe", "npm"] : ["npm"],
+    privateNodeBinDirs(),
+  );
+}
+
+function runtimeEnv(extraDirs = []) {
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  const dirs = [
+    ...extraDirs,
+    ...privateNodeBinDirs(),
+    join(homedir(), ".local", "bin"),
+    join(homedir(), ".cargo", "bin"),
+  ];
+  return {
+    ...process.env,
+    PATH: `${dirs.join(delimiter)}${delimiter}${process.env.PATH || ""}`,
+  };
+}
+
+async function ensureWindowsPrivateNode() {
+  if (!isWindows()) return null;
+  const existing = resolvePrivateNode();
+  const existingNpm = resolvePrivateNpm();
+  if (existing && existingNpm) return { node: existing, npm: existingNpm };
+
+  const major = process.env.CLAUDE_SMART_NODE_LTS_MAJOR || "22";
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  const baseUrl = process.env.CLAUDE_SMART_NODE_BASE_URL || `https://nodejs.org/dist/latest-v${major}.x`;
+  const nodeRoot = join(homedir(), ".claude-smart", "node");
+  const temp = join(tmpdir(), `claude-smart-node-${process.pid}`);
+  mkdirSync(nodeRoot, { recursive: true });
+  rmSync(temp, { recursive: true, force: true });
+  mkdirSync(temp, { recursive: true });
+
+  const sumsPath = join(temp, "SHASUMS256.txt");
+  await downloadFile(`${baseUrl}/SHASUMS256.txt`, sumsPath);
+  const sums = readFileSync(sumsPath, "utf8");
+  const match = sums
+    .split(/\r?\n/)
+    .map((line) => line.trim().split(/\s+/))
+    .find((parts) => parts[1] && new RegExp(`^node-v[^ ]+-win-${arch}\\.zip$`).test(parts[1]));
+  if (!match) throw new Error(`could not resolve Node.js win-${arch} archive from ${baseUrl}`);
+  const [expectedHash, archiveName] = match;
+  const archivePath = join(temp, archiveName);
+  await downloadFile(`${baseUrl}/${archiveName}`, archivePath);
+  const actualHash = crypto.createHash("sha256").update(readFileSync(archivePath)).digest("hex");
+  if (actualHash !== expectedHash) {
+    throw new Error(`Node.js checksum verification failed for ${archiveName}`);
+  }
+
+  const powershell = resolveCommand(["powershell.exe", "powershell", "pwsh"]);
+  if (!powershell) throw new Error("PowerShell is required to extract private Node.js on Windows");
+  const extractDir = join(temp, "extract");
+  mkdirSync(extractDir, { recursive: true });
+  const code = await runChecked(
+    powershell,
+    [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      "$ProgressPreference='SilentlyContinue'; Expand-Archive -LiteralPath $env:ARCHIVE_PATH -DestinationPath $env:DEST_DIR -Force",
+    ],
+    { env: { ...process.env, ARCHIVE_PATH: archivePath, DEST_DIR: extractDir } },
+  );
+  if (code !== 0) throw new Error(`Node.js archive extraction failed for ${archiveName}`);
+  const extracted = join(extractDir, archiveName.replace(/\.zip$/, ""));
+  const current = privateNodeRoot();
+  rmSync(current, { recursive: true, force: true });
+  cpSync(extracted, current, { recursive: true, force: true });
+  rmSync(temp, { recursive: true, force: true });
+
+  const node = resolvePrivateNode();
+  const npm = resolvePrivateNpm();
+  if (!node || !npm) throw new Error("private Node.js install completed but node/npm are not usable");
+  return { node, npm };
+}
+
+function resolveUv() {
+  return resolveCommand(isWindows() ? ["uv.exe", "uv"] : ["uv"], [
+    join(homedir(), ".local", "bin"),
+    join(homedir(), ".cargo", "bin"),
+  ]);
+}
+
+async function ensureWindowsUv() {
+  let uv = resolveUv();
+  if (uv) return uv;
+  const powershell = resolveCommand(["powershell.exe", "powershell", "pwsh"]);
+  if (!powershell) throw new Error("PowerShell is required to install uv on Windows");
+  const code = await runChecked(powershell, [
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    "irm https://astral.sh/uv/install.ps1 | iex",
+  ]);
+  if (code !== 0) throw new Error("uv install via PowerShell failed");
+  uv = resolveUv();
+  if (!uv) throw new Error("uv install reported success but uv.exe was not found");
+  return uv;
+}
+
+function quoteCommandPart(part) {
+  return `"${String(part).replace(/"/g, '\\"')}"`;
+}
+
+function patchCodexHooksForWindows(pluginRoot, nodePath) {
+  const hookPath = join(pluginRoot, "hooks", "codex-hooks.json");
+  const parsed = JSON.parse(readFileSync(hookPath, "utf8"));
+  const runner = join(pluginRoot, "scripts", "codex-hook.js");
+  const command = (...args) => [nodePath, runner, ...args].map(quoteCommandPart).join(" ");
+  const sessionHooks = parsed.hooks.SessionStart?.[0]?.hooks || [];
+  if (sessionHooks[0]) sessionHooks[0].command = command("ensure-root");
+  if (sessionHooks[1]) sessionHooks[1].command = command("backend");
+  if (sessionHooks[2]) sessionHooks[2].command = command("dashboard");
+  if (sessionHooks[3]) sessionHooks[3].command = command("hook", "session-start");
+  const userPrompt = parsed.hooks.UserPromptSubmit?.[0]?.hooks?.[0];
+  if (userPrompt) userPrompt.command = command("hook", "user-prompt");
+  const postTool = parsed.hooks.PostToolUse?.[0]?.hooks?.[0];
+  if (postTool) postTool.command = command("hook", "post-tool");
+  const stop = parsed.hooks.Stop?.[0]?.hooks?.[0];
+  if (stop) stop.command = command("hook", "stop");
+  writeFileSync(hookPath, JSON.stringify(parsed, null, 2) + "\n");
+}
+
+function ensureWindowsPluginRoot(pluginRoot) {
+  const reflexioDir = dirname(REFLEXIO_ENV_PATH);
+  const link = join(reflexioDir, "plugin-root");
+  mkdirSync(reflexioDir, { recursive: true });
+  rmSync(link, { recursive: true, force: true });
+  try {
+    require("fs").symlinkSync(pluginRoot, link, "junction");
+  } catch {
+    writeFileSync(join(reflexioDir, "plugin-root.txt"), `${pluginRoot}\n`);
+  }
+}
+
+async function bootstrapWindowsCodexCache(pluginRoot) {
+  if (!isWindows()) return;
+  process.stdout.write("Preparing Windows Codex runtime for claude-smart hooks...\n");
+  const nodeRuntime = await ensureWindowsPrivateNode();
+  patchCodexHooksForWindows(pluginRoot, nodeRuntime.node);
+  ensureWindowsPluginRoot(pluginRoot);
+  const uv = await ensureWindowsUv();
+  const env = runtimeEnv([dirname(uv), ...privateNodeBinDirs()]);
+  let code = await runChecked(
+    uv,
+    ["sync", "--locked", "--python", "3.12", "--quiet"],
+    { cwd: pluginRoot, env },
+  );
+  if (code !== 0) throw new Error(`uv sync failed in ${pluginRoot}`);
+
+  const dashboardDir = join(pluginRoot, "dashboard");
+  if (existsSync(dashboardDir)) {
+    code = await runChecked(nodeRuntime.npm, ["ci"], { cwd: dashboardDir, env });
+    if (code !== 0) throw new Error(`npm ci failed in ${dashboardDir}`);
+    code = await runChecked(nodeRuntime.npm, ["run", "build"], { cwd: dashboardDir, env });
+    if (code !== 0) throw new Error(`npm run build failed in ${dashboardDir}`);
+  }
 }
 
 function printHelp() {
@@ -760,6 +1007,7 @@ async function runInstallCodex() {
   try {
     cacheDir = installCodexPluginCache(join(marketplaceRoot, CODEX_MARKETPLACE_PLUGIN_PATH));
     process.stdout.write(`Installed Codex plugin cache at ${cacheDir}.\n`);
+    await bootstrapWindowsCodexCache(cacheDir);
   } catch (err) {
     process.stderr.write(
       `error: automatic Codex plugin install failed: ${err && err.message ? err.message : err}\n`,

--- a/plugin/hooks/codex-hooks.json
+++ b/plugin/hooks/codex-hooks.json
@@ -7,22 +7,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/ensure-plugin-root.sh\" \"$_R\" || true",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/ensure-plugin-root.sh\" \"$_R\" || true",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/backend-service.sh\" start",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/backend-service.sh\" start",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/dashboard-service.sh\" start",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/dashboard-service.sh\" start",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex session-start",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex session-start",
             "timeout": 30,
             "statusMessage": "Loading claude-smart context"
           }
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex user-prompt",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex user-prompt",
             "timeout": 15
           }
         ]
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex post-tool",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex post-tool",
             "timeout": 15
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/plugins/claude-smart\" \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex stop",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/hook_entry.sh\" codex stop",
             "timeout": 30
           }
         ]

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     # Pulls in onnxruntime + tokenizers; the ~80 MB ONNX model itself is
     # downloaded on first use, not at install time.
     "chromadb>=0.5",
+    "einops>=0.8.0",
 ]
 
 [project.scripts]

--- a/plugin/scripts/codex-claude-compat.py
+++ b/plugin/scripts/codex-claude-compat.py
@@ -29,7 +29,7 @@ _TIMEOUT_SECONDS = 120
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     try:
-        system_prompt = _parse_supported_args(argv)
+        output_format, system_prompt = _parse_supported_args(argv)
         content = _run_codex(
             prompt=sys.stdin.read(),
             system_prompt=system_prompt,
@@ -38,12 +38,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"codex-claude-compat: {exc}", file=sys.stderr)
         return 1
 
-    json.dump({"result": content}, sys.stdout, ensure_ascii=False)
+    payload = {"result": content}
+    if output_format == "stream-json":
+        payload = {"type": "result", "subtype": "success", "result": content}
+    json.dump(payload, sys.stdout, ensure_ascii=False)
     sys.stdout.write("\n")
     return 0
 
 
-def _parse_supported_args(argv: list[str]) -> str:
+def _parse_supported_args(argv: list[str]) -> tuple[str, str]:
+    output_format = "json"
     system_prompt = ""
     idx = 0
     while idx < len(argv):
@@ -51,9 +55,14 @@ def _parse_supported_args(argv: list[str]) -> str:
         if arg == "-p":
             idx += 1
         elif arg == "--output-format":
+            if idx + 1 >= len(argv):
+                raise ValueError("--output-format requires a value")
+            output_format = argv[idx + 1]
             idx += 2
         elif arg == "--model":
             idx += 2
+        elif arg in {"--verbose", "--include-partial-messages"}:
+            idx += 1
         elif arg == "--append-system-prompt":
             if idx + 1 >= len(argv):
                 raise ValueError("--append-system-prompt requires a value")
@@ -61,7 +70,9 @@ def _parse_supported_args(argv: list[str]) -> str:
             idx += 2
         else:
             raise ValueError(f"unsupported Claude CLI argument: {arg}")
-    return system_prompt
+    if output_format not in {"json", "stream-json"}:
+        raise ValueError(f"unsupported --output-format: {output_format}")
+    return output_format, system_prompt
 
 
 def _run_codex(*, prompt: str, system_prompt: str) -> str:

--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+
+const HOME = os.homedir();
+const STATE_DIR = path.join(HOME, ".claude-smart");
+const REFLEXIO_DIR = path.join(HOME, ".reflexio");
+const DEFAULT_BACKEND_PORT = 8071;
+const FALLBACK_BACKEND_PORT = 8072;
+const DASHBOARD_PORT = 3001;
+
+function emitOk() {
+  process.stdout.write('{"continue":true,"suppressOutput":true}\n');
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function appendLog(name, line) {
+  ensureDir(STATE_DIR);
+  fs.appendFileSync(path.join(STATE_DIR, name), `${line}\n`);
+}
+
+function pluginRoot() {
+  for (const value of [process.env.CLAUDE_PLUGIN_ROOT, process.env.PLUGIN_ROOT]) {
+    if (value && fs.existsSync(path.join(value, "pyproject.toml"))) {
+      return path.resolve(value);
+    }
+  }
+  const fromScript = path.resolve(__dirname, "..");
+  if (fs.existsSync(path.join(fromScript, "pyproject.toml"))) return fromScript;
+  const cacheRoot = path.join(HOME, ".codex", "plugins", "cache", "reflexioai", "claude-smart");
+  try {
+    const versions = fs
+      .readdirSync(cacheRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(cacheRoot, entry.name))
+      .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+    for (const candidate of versions) {
+      if (fs.existsSync(path.join(candidate, "pyproject.toml"))) return candidate;
+    }
+  } catch {
+    // Fall through to the stable plugin-root link.
+  }
+  return path.join(REFLEXIO_DIR, "plugin-root");
+}
+
+function prependRuntimePath() {
+  const privateNode = path.join(STATE_DIR, "node", "current");
+  const parts = [
+    path.join(privateNode, "bin"),
+    privateNode,
+    path.join(HOME, ".local", "bin"),
+    path.join(HOME, ".cargo", "bin"),
+  ];
+  process.env.PATH = `${parts.join(path.delimiter)}${path.delimiter}${process.env.PATH || ""}`;
+}
+
+function commandPath(names) {
+  const pathParts = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+  for (const dir of pathParts) {
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function uvPath() {
+  return commandPath(process.platform === "win32" ? ["uv.exe", "uv"] : ["uv"]);
+}
+
+function npmPath() {
+  return commandPath(process.platform === "win32" ? ["npm.cmd", "npm.exe", "npm"] : ["npm"]);
+}
+
+function stateFile(name) {
+  return path.join(STATE_DIR, name);
+}
+
+function backendUrlFile() {
+  return stateFile("backend-url");
+}
+
+function writeBackendUrl(port) {
+  ensureDir(STATE_DIR);
+  fs.writeFileSync(backendUrlFile(), `http://localhost:${port}/\n`);
+}
+
+function codexCompatPath(root) {
+  return path.join(root, "scripts", "codex-claude-compat.py");
+}
+
+function readBackendUrl() {
+  if (process.env.REFLEXIO_URL) return process.env.REFLEXIO_URL;
+  try {
+    const value = fs.readFileSync(backendUrlFile(), "utf8").trim();
+    if (value) return value;
+  } catch {
+    // Fall through to default.
+  }
+  return `http://localhost:${DEFAULT_BACKEND_PORT}/`;
+}
+
+function healthOk(port, pathname, markerHeader) {
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: pathname,
+        method: "GET",
+        timeout: 1200,
+      },
+      (res) => {
+        const ok = res.statusCode && res.statusCode >= 200 && res.statusCode < 400;
+        const markerOk = markerHeader ? Boolean(res.headers[markerHeader]) : true;
+        res.resume();
+        resolve(Boolean(ok && markerOk));
+      },
+    );
+    req.on("timeout", () => req.destroy());
+    req.on("error", () => resolve(false));
+    req.end();
+  });
+}
+
+function portOccupied(port) {
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/",
+        method: "GET",
+        timeout: 900,
+      },
+      (res) => {
+        res.resume();
+        resolve(true);
+      },
+    );
+    req.on("timeout", () => req.destroy());
+    req.on("error", (err) => {
+      resolve(err && err.code !== "ECONNREFUSED");
+    });
+    req.end();
+  });
+}
+
+async function waitForHealth(port, pathname, markerHeader, attempts) {
+  for (let i = 0; i < attempts; i += 1) {
+    if (await healthOk(port, pathname, markerHeader)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  return false;
+}
+
+function detached(command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: options.cwd,
+    env: options.env || process.env,
+    detached: true,
+    shell: process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command),
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  child.unref();
+  return child.pid;
+}
+
+function readPid(file) {
+  try {
+    const value = fs.readFileSync(file, "utf8").trim();
+    return value ? Number(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+function pidAlive(pid) {
+  if (!pid || Number.isNaN(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writePid(file, pid) {
+  ensureDir(path.dirname(file));
+  fs.writeFileSync(file, `${pid}\n`);
+}
+
+function ensurePluginRoot(root) {
+  ensureDir(REFLEXIO_DIR);
+  const link = path.join(REFLEXIO_DIR, "plugin-root");
+  try {
+    fs.rmSync(link, { recursive: true, force: true });
+  } catch {
+    // Ignore and try to recreate below.
+  }
+  try {
+    fs.symlinkSync(root, link, process.platform === "win32" ? "junction" : "dir");
+  } catch {
+    fs.writeFileSync(path.join(REFLEXIO_DIR, "plugin-root.txt"), `${root}\n`);
+  }
+}
+
+async function startBackend(root) {
+  if (process.env.CLAUDE_SMART_BACKEND_AUTOSTART === "0") {
+    emitOk();
+    return;
+  }
+  const pidFile = path.join(STATE_DIR, "backend.pid");
+  for (const port of [DEFAULT_BACKEND_PORT, FALLBACK_BACKEND_PORT]) {
+    if (pidAlive(readPid(pidFile)) && await healthOk(port, "/health")) {
+      writeBackendUrl(port);
+      emitOk();
+      return;
+    }
+    if (await healthOk(port, "/health")) {
+      writeBackendUrl(port);
+      emitOk();
+      return;
+    }
+  }
+  const uv = uvPath();
+  if (!uv) {
+    appendLog("backend.log", "[claude-smart] backend: uv not on PATH; skipping");
+    emitOk();
+    return;
+  }
+  let selectedPort = DEFAULT_BACKEND_PORT;
+  if (await portOccupied(DEFAULT_BACKEND_PORT)) {
+    appendLog("backend.log", "[claude-smart] backend: port 8071 occupied; trying 8072");
+    selectedPort = FALLBACK_BACKEND_PORT;
+  }
+  const backendUrl = `http://localhost:${selectedPort}/`;
+  const env = {
+    ...process.env,
+    BACKEND_PORT: String(selectedPort),
+    REFLEXIO_URL: backendUrl,
+    CLAUDE_SMART_USE_LOCAL_CLI: process.env.CLAUDE_SMART_USE_LOCAL_CLI || "1",
+    CLAUDE_SMART_USE_LOCAL_EMBEDDING: process.env.CLAUDE_SMART_USE_LOCAL_EMBEDDING || "1",
+    CLAUDE_SMART_HOST: "codex",
+    CLAUDE_SMART_CLI_PATH: process.env.CLAUDE_SMART_CLI_PATH || codexCompatPath(root),
+    INTERACTION_CLEANUP_THRESHOLD: process.env.INTERACTION_CLEANUP_THRESHOLD || "500",
+    INTERACTION_CLEANUP_DELETE_COUNT: process.env.INTERACTION_CLEANUP_DELETE_COUNT || "200",
+  };
+  const pid = detached(
+    uv,
+    [
+      "run",
+      "--project",
+      root,
+      "--quiet",
+      "reflexio",
+      "services",
+      "start",
+      "--only",
+      "backend",
+      "--no-reload",
+    ],
+    { cwd: root, env },
+  );
+  writePid(pidFile, pid);
+  if (await waitForHealth(selectedPort, "/health", null, 10)) {
+    writeBackendUrl(selectedPort);
+  }
+  emitOk();
+}
+
+async function startDashboard(root) {
+  if (process.env.CLAUDE_SMART_DASHBOARD_AUTOSTART === "0") {
+    emitOk();
+    return;
+  }
+  const dashboard = path.join(root, "dashboard");
+  if (!fs.existsSync(dashboard)) {
+    emitOk();
+    return;
+  }
+  const pidFile = path.join(STATE_DIR, "dashboard.pid");
+  if (
+    pidAlive(readPid(pidFile)) &&
+    await healthOk(DASHBOARD_PORT, "/api/health", "x-claude-smart-dashboard")
+  ) {
+    emitOk();
+    return;
+  }
+  const npm = npmPath();
+  if (!npm) {
+    appendLog("dashboard.log", "[claude-smart] dashboard: npm not on PATH; skipping");
+    emitOk();
+    return;
+  }
+  if (!fs.existsSync(path.join(dashboard, ".next"))) {
+    const buildPidFile = path.join(STATE_DIR, "dashboard-build.pid");
+    if (!pidAlive(readPid(buildPidFile))) {
+      const pid = detached(npm, ["run", "build"], { cwd: dashboard });
+      writePid(buildPidFile, pid);
+      appendLog("dashboard.log", "[claude-smart] dashboard: .next missing; started background build");
+    }
+    emitOk();
+    return;
+  }
+  const env = {
+    ...process.env,
+    PORT: String(DASHBOARD_PORT),
+    REFLEXIO_URL: readBackendUrl(),
+    CLAUDE_SMART_DASHBOARD_WORKSPACE: process.cwd(),
+  };
+  const pid = detached(npm, ["run", "start"], { cwd: dashboard, env });
+  writePid(pidFile, pid);
+  await waitForHealth(DASHBOARD_PORT, "/api/health", "x-claude-smart-dashboard", 5);
+  emitOk();
+}
+
+function runHook(root, event) {
+  const uv = uvPath();
+  if (!uv) {
+    appendLog("backend.log", "[claude-smart] hook: uv not on PATH; skipping");
+    emitOk();
+    return 0;
+  }
+  const input = fs.readFileSync(0);
+  const result = spawnSync(
+    uv,
+    ["run", "--project", root, "--quiet", "python", "-m", "claude_smart.hook", "codex", event],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        REFLEXIO_URL: readBackendUrl(),
+        CLAUDE_SMART_HOST: "codex",
+        CLAUDE_SMART_CLI_PATH: process.env.CLAUDE_SMART_CLI_PATH || codexCompatPath(root),
+      },
+      input,
+      stdio: ["pipe", "inherit", "inherit"],
+      windowsHide: true,
+    },
+  );
+  return typeof result.status === "number" ? result.status : 1;
+}
+
+async function main() {
+  prependRuntimePath();
+  const root = pluginRoot();
+  process.env.PLUGIN_ROOT = root;
+  process.env.CLAUDE_PLUGIN_ROOT = root;
+  const action = process.argv[2] || "hook";
+  if (action === "ensure-root") {
+    ensurePluginRoot(root);
+    emitOk();
+    return 0;
+  }
+  if (action === "backend") {
+    await startBackend(root);
+    return 0;
+  }
+  if (action === "dashboard") {
+    await startDashboard(root);
+    return 0;
+  }
+  if (action === "hook") {
+    return runHook(root, process.argv[3] || "session-start");
+  }
+  emitOk();
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    appendLog("backend.log", `[claude-smart] codex hook failed: ${err && err.stack ? err.stack : err}`);
+    emitOk();
+  });

--- a/plugin/scripts/ensure-plugin-root.sh
+++ b/plugin/scripts/ensure-plugin-root.sh
@@ -51,7 +51,8 @@ if [ "$FOLLOW" = "1" ]; then
 fi
 
 # Cache-tracking: if the link currently resolves to a path under the
-# managed plugin cache (~/.claude/plugins/cache/), always retarget it to
+# managed plugin cache (~/.claude/plugins/cache/ or ~/.codex/plugins/cache/),
+# always retarget it to
 # $TARGET. Plugin updates leave old version directories behind, so a
 # valid pyproject.toml at the stale target is not proof the link is
 # fresh. Links pointing outside the cache (e.g., a user's local-dev
@@ -60,7 +61,7 @@ if [ -L "$LINK" ]; then
     # Literal target string, not realpath: we compare against what was written by ln -s.
     CURRENT="$(readlink "$LINK" 2>/dev/null || true)"
     case "$CURRENT" in
-        "$HOME/.claude/plugins/cache/"*)
+        "$HOME/.claude/plugins/cache/"*|"$HOME/.codex/plugins/cache/"*)
             CURRENT_NORM="${CURRENT%/}"
             TARGET_NORM="${TARGET%/}"
             if [ "$CURRENT_NORM" != "$TARGET_NORM" ]; then

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -311,7 +311,6 @@ if ! grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$REFLEXIO_ENV"; then
   printf '# Use the in-process ONNX embedder (chromadb) — no API key for semantic search\nCLAUDE_SMART_USE_LOCAL_EMBEDDING=1\n' >> "$REFLEXIO_ENV"
   echo "[claude-smart] appended CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 to $REFLEXIO_ENV" >&2
 fi
-
 # Migrate stale REFLEXIO_URL from reflexio's library default (8081) to the
 # plugin backend port (8071). Matches the quoted and unquoted forms but
 # requires paired quotes, so malformed or deliberately different values

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -76,6 +76,8 @@ _CODEX_REQUIRED_FILES = (
     Path(".agents/plugins/marketplace.json"),
     Path("plugin/.codex-plugin/plugin.json"),
     Path("plugin/hooks/codex-hooks.json"),
+    Path("plugin/scripts/codex-claude-compat.py"),
+    Path("plugin/scripts/codex-hook.js"),
     Path("plugin/scripts/_codex_env.sh"),
 )
 _COPYTREE_IGNORE = shutil.ignore_patterns(
@@ -110,7 +112,10 @@ def _seed_reflexio_env() -> list[str]:
     _REFLEXIO_ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
     _REFLEXIO_ENV_PATH.touch(exist_ok=True)
     existing = _REFLEXIO_ENV_PATH.read_text()
-    flags = ("CLAUDE_SMART_USE_LOCAL_CLI", "CLAUDE_SMART_USE_LOCAL_EMBEDDING")
+    flags = (
+        "CLAUDE_SMART_USE_LOCAL_CLI",
+        "CLAUDE_SMART_USE_LOCAL_EMBEDDING",
+    )
     missing = [f for f in flags if f"{f}=" not in existing]
     if not missing:
         return []

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -423,6 +423,7 @@ version = "0.2.26"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
+    { name = "einops" },
     { name = "reflexio-ai" },
 ]
 
@@ -434,6 +435,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "chromadb", specifier = ">=0.5" },
+    { name = "einops", specifier = ">=0.8.0" },
     { name = "reflexio-ai", specifier = ">=0.2.22" },
 ]
 
@@ -614,6 +616,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
 ]
 
 [[package]]

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -169,9 +169,8 @@ def test_codex_hooks_use_expected_events_and_marketplace_fallback() -> None:
     for command in _command_hooks("plugin/hooks/codex-hooks.json"):
         assert "_codex_env.sh" in command
         assert "printenv PATH" not in command
-        assert command.find("$HOME/plugins/claude-smart") < command.find(
-            ".codex/plugins/cache/reflexioai/claude-smart"
-        )
+        assert "$HOME/plugins/claude-smart" not in command
+        assert "CLAUDE_PLUGIN_ROOT" in command
         assert ".codex/plugins/cache/reflexioai/claude-smart" in command
 
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 LIB = REPO_ROOT / "plugin" / "scripts" / "_lib.sh"
 SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
 CODEX_COMPAT = REPO_ROOT / "plugin" / "scripts" / "codex-claude-compat.py"
+CODEX_HOOK = REPO_ROOT / "plugin" / "scripts" / "codex-hook.js"
 
 
 def _minimal_path(tmp_path: Path, *names: str) -> str:
@@ -220,6 +221,89 @@ def test_codex_claude_compat_translates_claude_contract(tmp_path: Path) -> None:
     assert len(prompt_files) == 1
     assert prompt_files[0].read_text() == "system rules\n\n## Task\nanswer this"
     assert not output_file.exists()
+
+
+def test_codex_claude_compat_accepts_stream_json_flags(tmp_path: Path) -> None:
+    codex = tmp_path / "codex"
+    codex.write_text(
+        "#!/bin/sh\n"
+        "while [ \"$#\" -gt 0 ]; do\n"
+        "  if [ \"$1\" = \"--output-last-message\" ]; then\n"
+        "    shift\n"
+        "    out=\"$1\"\n"
+        "  fi\n"
+        "  shift || exit 1\n"
+        "done\n"
+        "printf 'stream reply' > \"$out\"\n"
+    )
+    codex.chmod(codex.stat().st_mode | stat.S_IXUSR)
+    env = _isolated_env(tmp_path)
+    env["PATH"] = _minimal_path(tmp_path, "python3")
+    env["CLAUDE_SMART_CODEX_PATH"] = str(codex)
+    env["TMPDIR"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            str(CODEX_COMPAT),
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+            "--model",
+            "claude-sonnet-4-6",
+        ],
+        input="answer this",
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "type": "result",
+        "subtype": "success",
+        "result": "stream reply",
+    }
+
+
+def test_codex_hook_ensure_root_tracks_active_plugin_root(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for codex hook wrapper tests")
+
+    local_root = tmp_path / "repo" / "plugin"
+    cache_root = (
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.2.26"
+    )
+    local_root.mkdir(parents=True)
+    cache_root.mkdir(parents=True)
+    (local_root / "pyproject.toml").write_text("[project]\nname='local'\n")
+    (cache_root / "pyproject.toml").write_text("[project]\nname='cache'\n")
+    reflexio = tmp_path / ".reflexio"
+    reflexio.mkdir()
+    (reflexio / "plugin-root").symlink_to(local_root, target_is_directory=True)
+
+    env = _isolated_env(tmp_path)
+    env["CLAUDE_PLUGIN_ROOT"] = str(cache_root)
+    result = subprocess.run(
+        [node, str(CODEX_HOOK), "ensure-root"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (reflexio / "plugin-root").resolve() == cache_root
+    assert json.loads(result.stdout) == {"continue": True, "suppressOutput": True}
 
 
 def test_install_private_node_installs_from_verified_archive(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a Node-based Codex hook wrapper so Windows installs do not depend on Bash for hooks, backend startup, or dashboard startup
- bootstrap Windows Codex installs with private Node/npm, uv, dashboard dependencies/build, and regenerated trusted hook commands
- route Codex generation through `codex-claude-compat.py` with stream-json compatibility instead of relying on a raw Claude CLI
- add `einops` to the plugin dependency set so remote-installed Codex caches can use the Nomic local embedder before the next Reflexio package release
- update the Reflexio submodule to ReflexioAI/reflexio#68 for Windows-safe PID paths and the upstream Nomic dependency declaration

## Failure mode

claude-smart should not silently run without a generation provider. Codex installs are expected to configure generation through the compatibility wrapper; if that provider cannot start or register, the backend/install should fail visibly so the user fixes the real issue.

## Validation

- `node --check bin/claude-smart.js`
- `node --check plugin/scripts/codex-hook.js`
- `python3 -m py_compile plugin/scripts/codex-claude-compat.py`
- `bash -n plugin/scripts/backend-service.sh plugin/scripts/ensure-plugin-root.sh plugin/scripts/smart-install.sh plugin/scripts/hook_entry.sh`
- `python3 -m json.tool plugin/hooks/codex-hooks.json`
- `uv run --project plugin pytest tests/test_codex_support.py tests/test_install_scripts.py tests/test_internal_call.py tests/test_optimizer_assistant.py -q`
- parent pre-commit full suite: `271 passed`
- local install validation: `node bin/claude-smart.js install --host codex`, verified trusted hooks, active plugin root in the Codex cache, no `~/plugins/claude-smart` hook override, `einops==0.8.2`, and compatibility-wrapper configuration
- remote branch install validation: `npx --yes github:ReflexioAI/claude-smart#codex/codex-install-windows-smooth install --host codex`, restarted backend/dashboard from the installed cache, verified health endpoints, provider registration through `~/.codex/plugins/cache/.../scripts/codex-claude-compat.py`, Nomic prewarm, and a persisted two-turn SQLite smoke session

## Related

- Uses ReflexioAI/reflexio#68 for the submodule update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Windows users now receive specialized runtime initialization for improved compatibility and installation experience
  * Local embeddings feature automatically enabled during setup

* **Improvements**
  * JSON output formatting expanded to support additional output modes
  * Plugin root discovery streamlined through centralized cache directory management
  * Codex hook integration capabilities enhanced for better workflow integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->