### PR TITLE
[codex] Surface host CLI provider failures

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Technical reference for how `claude-smart` wires Claude Code's lifecycle hooks t
    - `SessionEnd` — flushes the remaining buffer with `force_extraction=True`.
 2. **Local state buffer** — JSONL per session at `~/.claude-smart/sessions/{session_id}.jsonl`. Offline-safe.
 3. **Reflexio backend** (submodule at `reflexio/`) — SQLite storage, hybrid search, preference/skill extraction, dedup, status lifecycle (`CURRENT` → `ARCHIVED`). Runs on `localhost:8071`.
-4. **Claude Code LLM provider** — a LiteLLM custom provider registered inside reflexio. Every generation call (extraction, update, dedup, evaluation) subprocesses `claude -p --output-format json`, so no OpenAI/Anthropic key is needed for the learning loop.
+4. **Local host LLM provider** — a LiteLLM custom provider registered inside reflexio. Every generation call (extraction, update, dedup, evaluation) subprocesses the active host CLI (`claude -p` under Claude Code, `codex exec` under Codex), so no OpenAI/Anthropic key is needed for the learning loop.
 
 ## Data flow
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -28,7 +28,7 @@ Tunables read by the plugin at runtime. Most users don't need to touch these —
 | `CLAUDE_SMART_USE_LOCAL_CLI` | `0` (installer sets `1`) | Route generation through the active host CLI (`claude` for Claude Code, `codex` for Codex). Written to `~/.reflexio/.env` by `claude-smart install`. |
 | `CLAUDE_SMART_USE_LOCAL_EMBEDDING` | `0` (installer sets `1`) | Use the in-process ONNX embedder (requires `chromadb`). Written to `~/.reflexio/.env` by `claude-smart install`. |
 | `CLAUDE_SMART_ENABLE_OPTIMIZER` | enabled unless set to `0` | Hook-side env var that controls shared skill optimization and rollups during `SessionStart`. Set it in Claude Code settings, not `~/.reflexio/.env`. |
-| `CLAUDE_SMART_CLI_PATH` | `claude` on Claude Code; Codex compatibility wrapper on Codex | Override the executable Reflexio calls for local generation. |
+| `CLAUDE_SMART_CLI_PATH` | `claude` on Claude Code; Codex compatibility wrapper or `codex` on Codex | Override the executable Reflexio calls for local generation. |
 | `CLAUDE_SMART_STATE_DIR` | `~/.claude-smart/sessions/` | Where the per-session JSONL buffer lives. |
 | `CLAUDE_SMART_BACKEND_AUTOSTART` | `1` | Set to `0` to stop the SessionStart hook from spawning the reflexio backend on `localhost:8071`. |
 | `CLAUDE_SMART_DASHBOARD_AUTOSTART` | `1` | Set to `0` to stop the SessionStart hook from spawning the Next.js dashboard on `localhost:3001`. |

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -41,9 +41,8 @@ PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 
 if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
   if [ "${CLAUDE_SMART_HOST:-claude-code}" = "codex" ]; then
-    # Reflexio's provider still calls CLAUDE_SMART_CLI_PATH with Claude CLI
-    # flags. Use a small compatibility executable that translates that narrow
-    # contract to `codex exec`.
+    # Prefer the compatibility executable for older provider entrypoints; the
+    # provider can also resolve `codex` directly when this override is absent.
     export CLAUDE_SMART_CLI_PATH="$PLUGIN_ROOT/scripts/codex-claude-compat.py"
   elif _cs_cli_path=$(command -v claude 2>/dev/null) && [ -n "$_cs_cli_path" ]; then
     export CLAUDE_SMART_CLI_PATH="$_cs_cli_path"
@@ -59,6 +58,37 @@ LOG_FILE="$STATE_DIR/backend.log"
 mkdir -p "$STATE_DIR"
 
 emit_ok() { echo '{"continue":true,"suppressOutput":true}'; }
+
+emit_start_failure() {
+  reason="$1"
+  if py=$(claude_smart_resolve_python 2>/dev/null); then
+    "$py" - "$reason" <<'PY'
+import json
+import sys
+
+reason = sys.argv[1].strip()
+message = (
+    "> **claude-smart learning backend is not running.** "
+    "Interactions are being buffered locally, but learning will not publish "
+    "until the backend starts.\n"
+)
+if reason:
+    message += f">\n> Last startup error: `{reason}`\n"
+message += (
+    ">\n> Make sure the local model provider is available: Claude Code needs "
+    "`claude`, Codex needs `codex`. Then run `/claude-smart:restart`."
+)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": message,
+    }
+}))
+PY
+  else
+    emit_ok
+  fi
+}
 
 # Tree-kill the recorded process. Delegates to claude_smart_kill_tree
 # (POSIX: signal the process group; Windows: taskkill /T /F /PID).
@@ -189,6 +219,14 @@ case "$CMD" in
       backend_healthy && break
       sleep 1
     done
+    if ! backend_healthy; then
+      pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
+      if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+        reason=$(tail -n 120 "$LOG_FILE" 2>/dev/null | grep -E "No LLM provider available|No generation-capable LLM provider available|CLI not found|skipping provider registration|Application startup failed" | tail -n 1 | sed 's/^[[:space:]]*//')
+        emit_start_failure "$reason"
+        exit 0
+      fi
+    fi
     emit_ok
     ;;
   stop)


### PR DESCRIPTION
## Summary
- start Reflexio with local host CLI generation enabled by default in claude-smart service scripts
- surface a SessionStart warning when backend startup fails because no generation provider is available
- document the active host CLI behavior and bump the reflexio submodule to ReflexioAI/reflexio#69

## Related
- Depends on ReflexioAI/reflexio#69

## Validation
- bash -n plugin/scripts/backend-service.sh
- uv run --project plugin pytest tests
- Reflexio PR validation: uv run --project reflexio ruff check reflexio/server/llm/providers/claude_code_provider.py reflexio/server/llm/model_defaults.py tests/server/llm/test_claude_code_provider.py
- Reflexio PR validation: uv run --project reflexio pytest reflexio/tests/server/llm/test_claude_code_provider.py reflexio/tests/server/llm/test_model_defaults.py -n 0 --no-cov
- Reflexio PR validation: uv run --project reflexio pytest reflexio/tests/server/llm -n 0 --no-cov