### PR TITLE
feat(hook): structured per-fire log at ~/.claude-smart/hook.log

### DIFF
--- a/plugin/src/claude_smart/events/session_end.py
+++ b/plugin/src/claude_smart/events/session_end.py
@@ -7,12 +7,23 @@ from typing import Any
 from claude_smart import ids, publish
 
 
-def handle(payload: dict[str, Any]) -> None:
+def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
+    """Flush any remaining buffered turns to reflexio.
+
+    Args:
+        payload (dict[str, Any]): Claude Code hook payload.
+
+    Returns:
+        tuple[PublishStatus, int] | None: The ``(status, count)`` tuple
+            from ``publish.publish_unpublished`` so the dispatcher's
+            forensic hook log captures the publish outcome. ``None``
+            when the payload had no ``session_id``.
+    """
     session_id = payload.get("session_id")
     if not session_id:
-        return
+        return None
     project_id = ids.resolve_project_id(payload.get("cwd"))
-    publish.publish_unpublished(
+    return publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
         force_extraction=False,

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -341,10 +341,23 @@ def _resolve_cited_items(session_id: str, cited_ids: list[str]) -> list[dict[str
     return resolved
 
 
-def handle(payload: dict[str, Any]) -> None:
+def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
+    """Drain the buffered assistant turn to reflexio.
+
+    Args:
+        payload (dict[str, Any]): Claude Code hook payload.
+
+    Returns:
+        tuple[PublishStatus, int] | None: The ``(status, count)`` tuple
+            from ``publish.publish_unpublished`` so the dispatcher can
+            include it in the forensic hook log. ``None`` is returned
+            only when the handler short-circuits before publishing (no
+            ``session_id`` in the payload, or Codex internal-prompt
+            detection skipped the fire).
+    """
     session_id = payload.get("session_id")
     if not session_id:
-        return
+        return None
 
     # Always append an Assistant record, even when the turn emitted only
     # tool calls and no text. ``state.unpublished_slice`` folds any
@@ -363,7 +376,7 @@ def handle(payload: dict[str, Any]) -> None:
     if runtime.is_codex():
         prompt = payload.get("prompt") or _scan_transcript_for_user_text(entries)
         if internal_call.is_codex_internal_prompt(prompt):
-            return
+            return None
 
     last_assistant_message = payload.get("last_assistant_message")
     assistant_text = (
@@ -400,7 +413,7 @@ def handle(payload: dict[str, Any]) -> None:
     if cited_items:
         record["cited_items"] = cited_items
     state.append(session_id, record)
-    publish.publish_unpublished(
+    return publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
         force_extraction=False,

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -5,6 +5,13 @@ The plugin's ``hook_entry.sh`` calls either
 ``python -m claude_smart.hook <host> <event>`` once per hook invocation.
 This module reads the hook JSON from stdin, routes to the matching handler,
 and makes sure no unhandled exception ever propagates.
+
+Every fire produces one structured JSON line in
+``~/.claude-smart/hook.log`` via ``hook_log.log_event`` — covers the
+event name, session id, internal-invocation skip, handler outcome
+(``ok`` / ``raised:<Exc>`` / ``unknown_event``), and for Stop/SessionEnd
+the publish status + count. The log is the forensic trail for chasing
+"hook didn't publish" mysteries from a single file.
 """
 
 from __future__ import annotations
@@ -12,15 +19,20 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
-from claude_smart import runtime
+from claude_smart import hook_log, ids, runtime
 from claude_smart.internal_call import is_internal_invocation
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _load_handlers() -> dict[str, Callable[[dict[str, Any]], None]]:
+# Stop and SessionEnd return ``(PublishStatus, int)`` so the dispatcher can
+# log the publish outcome; the other handlers return ``None`` (or nothing).
+# Use ``Any`` here rather than two specialised typedefs — the dispatcher
+# narrows at the call site via ``isinstance(result, tuple)``.
+def _load_handlers() -> dict[str, Callable[[dict[str, Any]], Any]]:
     from claude_smart.events import (
         post_tool,
         pre_tool,
@@ -92,6 +104,15 @@ def main(argv: list[str] | None = None) -> int:
     # handlers so we don't publish the extractor's system prompt back
     # into reflexio. See claude_smart.internal_call for detection logic.
     if is_internal_invocation(payload):
+        hook_log.log_event(
+            event=event,
+            host=host,
+            session_id=payload.get("session_id"),
+            project_id=ids.resolve_project_id(payload.get("cwd")),
+            cwd=payload.get("cwd"),
+            internal_skipped=True,
+            handler_status="ok",
+        )
         emit_continue()
         return 0
 
@@ -99,14 +120,38 @@ def main(argv: list[str] | None = None) -> int:
     handler = handlers.get(event)
     if handler is None:
         _LOGGER.warning("unknown hook event: %s", event)
+        hook_log.log_event(
+            event=event,
+            host=host,
+            session_id=payload.get("session_id"),
+            project_id=ids.resolve_project_id(payload.get("cwd")),
+            cwd=payload.get("cwd"),
+            handler_status="unknown_event",
+        )
         emit_continue()
         return 0
 
+    handler_status = "ok"
+    publish_status: str | None = None
+    publish_count: int | None = None
     try:
-        handler(payload)
+        result = handler(payload)
+        if isinstance(result, tuple) and len(result) == 2:
+            publish_status, publish_count = result
     except Exception as exc:  # noqa: BLE001 — hooks must never crash the session.
         _LOGGER.exception("hook handler %s raised: %s", event, exc)
+        handler_status = f"raised:{type(exc).__name__}: {exc}"
         emit_continue()
+    hook_log.log_event(
+        event=event,
+        host=host,
+        session_id=payload.get("session_id"),
+        project_id=ids.resolve_project_id(payload.get("cwd")),
+        cwd=payload.get("cwd"),
+        handler_status=handler_status,
+        publish_status=publish_status,
+        publish_count=publish_count,
+    )
     return 0
 
 

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -141,7 +141,11 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # noqa: BLE001 — hooks must never crash the session.
         _LOGGER.exception("hook handler %s raised: %s", event, exc)
         handler_status = f"raised:{type(exc).__name__}: {exc}"
-        emit_continue()
+    # Always emit the JSON continue response — Claude Code's hook contract
+    # expects one on stdout regardless of whether the handler succeeded or
+    # raised. Skipping it on the success path would leave the hook silent
+    # and the session would block waiting for a reply.
+    emit_continue()
     hook_log.log_event(
         event=event,
         host=host,

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -1,0 +1,145 @@
+"""Structured, append-only log of every hook fire and its outcome.
+
+Why a dedicated log rather than relying on the Python ``logging`` module:
+hooks run as short-lived subprocesses with no preconfigured handler, so
+``_LOGGER.warning(...)`` calls silently vanish to stderr that Claude Code
+captures but typically does not surface. The dispatcher already wraps
+handlers in a broad ``except`` (so a hook crash never breaks the user's
+session) — without a forensic trail the silent-fail mode is invisible.
+
+This module writes one JSON line per hook fire to
+``~/.claude-smart/hook.log`` from ``hook.main`` after the handler returns.
+The Stop and SessionEnd handlers additionally piggyback their publish
+outcome into the record so the chain hook→adapter→backend is fully
+observable from a single file.
+
+Failure policy: every public function in this module swallows all
+``OSError``/``Exception`` paths. Logging is best-effort; a stuck disk
+or read-only ``$HOME`` must never abort an in-progress hook.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Anchored on $HOME so unit tests can monkeypatch ``_LOG_PATH`` to a
+# tmp_path. The directory is created lazily on first write — keeping
+# import side-effect-free matches the rest of the package.
+_LOG_PATH = Path.home() / ".claude-smart" / "hook.log"
+
+_TRUNCATE_LIMIT = 4096
+
+
+def log_event(
+    *,
+    event: str,
+    host: str,
+    session_id: Any = None,
+    project_id: Any = None,
+    cwd: Any = None,
+    internal_skipped: bool = False,
+    handler_status: str = "ok",
+    publish_status: str | None = None,
+    publish_count: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Append one JSON record describing a hook fire.
+
+    Args:
+        event (str): Hook event name (``"stop"``, ``"user-prompt"``, …).
+        host (str): Host identifier (``"claude-code"`` / ``"codex"``).
+        session_id (Any): Claude Code session id from the payload, or
+            ``None`` when the payload didn't carry one.
+        project_id (Any): Project-id resolved from ``cwd``. Optional.
+        cwd (Any): Working directory reported by the hook payload.
+            Optional — preserved verbatim so a future audit can correlate
+            fires against workspace directories.
+        internal_skipped (bool): True when ``is_internal_invocation``
+            short-circuited the dispatcher (reflexio-internal sub-claude
+            calls, or invocations from inside the reflexio submodule).
+        handler_status (str): ``"ok"`` for a clean return, ``"unknown_event"``
+            when no handler is registered, or ``"raised:<ExcClass>: <msg>"``
+            when the handler raised — formatted by ``hook.main``.
+        publish_status (str | None): Status returned by
+            ``publish.publish_unpublished`` (``"ok"`` / ``"failed"`` /
+            ``"nothing"``). Only emitted by Stop + SessionEnd.
+        publish_count (int | None): Interaction count from the same
+            tuple. ``None`` when the handler doesn't publish.
+        extra (dict[str, Any] | None): Free-form fields preserved as-is.
+
+    Returns:
+        None
+    """
+    record: dict[str, Any] = {
+        "ts": int(time.time()),
+        "event": event,
+        "host": host,
+        "session_id": _truncate(session_id),
+        "project_id": _truncate(project_id),
+        "cwd": _truncate(cwd),
+        "internal_skipped": bool(internal_skipped),
+        "handler_status": _truncate(handler_status),
+    }
+    if publish_status is not None:
+        record["publish_status"] = publish_status
+        record["publish_count"] = int(publish_count or 0)
+    if extra:
+        for key, value in extra.items():
+            if key in record:
+                continue
+            record[key] = _truncate(value)
+
+    try:
+        line = json.dumps(record, ensure_ascii=False, default=str) + "\n"
+    except (TypeError, ValueError) as exc:
+        _LOGGER.debug("hook_log: json encode failed: %s", exc)
+        return
+
+    path = log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Open mode "a" is atomic on POSIX for writes <= PIPE_BUF (4 KiB);
+        # we truncate fields above to stay below that and avoid a heavier
+        # ``flock`` dance that the hook fire path can't afford.
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+    except OSError as exc:
+        _LOGGER.debug("hook_log: write to %s failed: %s", path, exc)
+
+
+def log_path() -> Path:
+    """Return the active log path, honouring ``CLAUDE_SMART_HOOK_LOG``.
+
+    Resolution order:
+
+    1. ``CLAUDE_SMART_HOOK_LOG`` env var — escape hatch for tests and
+       advanced users who want the log elsewhere.
+    2. ``_LOG_PATH`` module attribute — what monkeypatched tests override.
+    3. ``~/.claude-smart/hook.log`` — the default.
+
+    Returns:
+        Path: The absolute path to write to.
+    """
+    override = os.environ.get("CLAUDE_SMART_HOOK_LOG")
+    if override:
+        return Path(override)
+    return _LOG_PATH
+
+
+def _truncate(value: Any) -> Any:
+    """Cap string values to ``_TRUNCATE_LIMIT`` chars so single-line writes
+    stay below the POSIX atomic-append limit.
+
+    Non-string values pass through unchanged; the json encoder handles
+    them. ``None`` becomes ``null`` in the JSON, which is what we want.
+    """
+    if isinstance(value, str) and len(value) > _TRUNCATE_LIMIT:
+        return value[:_TRUNCATE_LIMIT] + "…"
+    return value

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -91,6 +91,8 @@ def test_log_event_truncates_oversized_strings(hook_log_path) -> None:
 
 def test_log_event_tolerates_readonly_log_dir(tmp_path, monkeypatch) -> None:
     """A read-only parent must not abort the hook fire."""
+    if not hasattr(os, "geteuid"):
+        pytest.skip("read-only permission semantics test is POSIX-specific")
     if os.geteuid() == 0:
         pytest.skip("root bypasses the read-only bit")
     locked = tmp_path / "locked"
@@ -193,3 +195,38 @@ def test_dispatcher_logs_nothing_publish_status(
     rec = _read_lines(hook_log_path)[0]
     assert rec["publish_status"] == "nothing"
     assert rec["publish_count"] == 0
+
+
+def test_dispatcher_emits_continue_on_handler_success(
+    hook_log_path, stdin_payload, monkeypatch, capsys
+) -> None:
+    """The success path must emit the ``{"continue": true}`` JSON on stdout.
+
+    Regression: an earlier version only emitted on the exception path,
+    leaving successful hook fires silent and blocking the parent session.
+    """
+
+    def stop_ok(_payload: dict[str, Any]) -> tuple[str, int]:
+        return ("ok", 1)
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_ok})
+    stdin_payload({"session_id": "s-success", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    out = capsys.readouterr().out
+    assert '"continue": true' in out
+
+
+def test_dispatcher_emits_continue_on_handler_exception(
+    hook_log_path, stdin_payload, monkeypatch, capsys
+) -> None:
+    """The exception path must also emit ``{"continue": true}`` — the
+    parent session never blocks regardless of handler outcome."""
+
+    def boom(_payload: dict[str, Any]) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": boom})
+    stdin_payload({"session_id": "s-exc", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    out = capsys.readouterr().out
+    assert '"continue": true' in out

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -1,0 +1,195 @@
+"""Tests for the forensic hook event log."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from claude_smart import hook, hook_log
+
+
+@pytest.fixture
+def hook_log_path(tmp_path, monkeypatch) -> Path:
+    """Redirect ``hook_log`` writes to a per-test tmp path."""
+    log_path = tmp_path / "hook.log"
+    monkeypatch.setattr(hook_log, "_LOG_PATH", log_path)
+    monkeypatch.delenv("CLAUDE_SMART_HOOK_LOG", raising=False)
+    return log_path
+
+
+def _read_lines(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+# -----------------------------------------------------------------------------
+# hook_log.log_event — direct unit tests
+# -----------------------------------------------------------------------------
+
+
+def test_log_event_writes_one_jsonl_record(hook_log_path) -> None:
+    hook_log.log_event(
+        event="stop",
+        host="claude-code",
+        session_id="sess-1",
+        project_id="proj-1",
+        cwd="/some/dir",
+        handler_status="ok",
+        publish_status="ok",
+        publish_count=2,
+    )
+    records = _read_lines(hook_log_path)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event"] == "stop"
+    assert rec["host"] == "claude-code"
+    assert rec["session_id"] == "sess-1"
+    assert rec["project_id"] == "proj-1"
+    assert rec["cwd"] == "/some/dir"
+    assert rec["handler_status"] == "ok"
+    assert rec["publish_status"] == "ok"
+    assert rec["publish_count"] == 2
+    assert rec["internal_skipped"] is False
+    assert isinstance(rec["ts"], int)
+
+
+def test_log_event_appends_across_calls(hook_log_path) -> None:
+    hook_log.log_event(event="stop", host="claude-code", session_id="a")
+    hook_log.log_event(event="user-prompt", host="claude-code", session_id="b")
+    records = _read_lines(hook_log_path)
+    assert [r["event"] for r in records] == ["stop", "user-prompt"]
+
+
+def test_log_event_omits_publish_fields_when_handler_did_not_publish(
+    hook_log_path,
+) -> None:
+    hook_log.log_event(event="user-prompt", host="claude-code", session_id="s")
+    rec = _read_lines(hook_log_path)[0]
+    assert "publish_status" not in rec
+    assert "publish_count" not in rec
+
+
+def test_log_event_truncates_oversized_strings(hook_log_path) -> None:
+    long_cwd = "x" * (hook_log._TRUNCATE_LIMIT + 100)
+    hook_log.log_event(event="stop", host="claude-code", cwd=long_cwd)
+    rec = _read_lines(hook_log_path)[0]
+    # truncation leaves the marker char appended
+    assert len(rec["cwd"]) == hook_log._TRUNCATE_LIMIT + 1
+    assert rec["cwd"].endswith("…")
+
+
+def test_log_event_tolerates_readonly_log_dir(tmp_path, monkeypatch) -> None:
+    """A read-only parent must not abort the hook fire."""
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses the read-only bit")
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)
+    try:
+        monkeypatch.setattr(hook_log, "_LOG_PATH", locked / "sub" / "hook.log")
+        monkeypatch.delenv("CLAUDE_SMART_HOOK_LOG", raising=False)
+        # Must not raise.
+        hook_log.log_event(event="stop", host="claude-code")
+    finally:
+        locked.chmod(0o700)
+
+
+def test_log_path_honors_env_override(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "override.log"
+    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", str(target))
+    hook_log.log_event(event="stop", host="claude-code")
+    assert target.is_file()
+    assert _read_lines(target)[0]["event"] == "stop"
+
+
+# -----------------------------------------------------------------------------
+# hook.main dispatcher → log records
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stdin_payload(monkeypatch):
+    """Helper that pipes a JSON dict to ``sys.stdin`` for ``hook.main``."""
+
+    def _set(payload: dict[str, Any]) -> None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    return _set
+
+
+def test_dispatcher_logs_unknown_event(hook_log_path, stdin_payload) -> None:
+    stdin_payload({"session_id": "s1", "cwd": "/tmp"})
+    hook.main(["claude-code", "made-up-event"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "made-up-event"
+    assert rec["handler_status"] == "unknown_event"
+
+
+def test_dispatcher_logs_internal_skipped(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_SMART_INTERNAL", "1")
+    stdin_payload({"session_id": "s2", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "stop"
+    assert rec["internal_skipped"] is True
+    assert rec["handler_status"] == "ok"
+    # The internal-skip path doesn't publish — no publish fields.
+    assert "publish_status" not in rec
+
+
+def test_dispatcher_logs_handler_exception(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    def boom(_payload: dict[str, Any]) -> None:
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": boom})
+    stdin_payload({"session_id": "s3", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "stop"
+    assert rec["handler_status"].startswith("raised:RuntimeError:")
+    assert "kaboom" in rec["handler_status"]
+
+
+def test_dispatcher_logs_publish_outcome_from_stop(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    def stop_ok(_payload: dict[str, Any]) -> tuple[str, int]:
+        return ("ok", 3)
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_ok})
+    stdin_payload({"session_id": "s4", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "stop"
+    assert rec["handler_status"] == "ok"
+    assert rec["publish_status"] == "ok"
+    assert rec["publish_count"] == 3
+
+
+def test_dispatcher_logs_nothing_publish_status(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    def stop_nothing(_payload: dict[str, Any]) -> tuple[str, int]:
+        return ("nothing", 0)
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_nothing})
+    stdin_payload({"session_id": "s5", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["publish_status"] == "nothing"
+    assert rec["publish_count"] == 0


### PR DESCRIPTION
## Summary

Adds a single JSON-lines forensic trail at `~/.claude-smart/hook.log`. Each hook fire writes one line via `hook_log.log_event` from the dispatcher in `hook.py:main()` after the handler returns. For Stop and SessionEnd, the `(status, count)` tuple from `publish.publish_unpublished` is piggybacked so the chain hook → adapter → backend is observable from a single file.

## Why

The dispatcher already wraps every handler in a broad `except Exception` so hooks never crash the user's session. The downside: silent failures inside Stop (the only path that ever publishes interactions to reflexio) were invisible. `_LOGGER.warning(...)` calls write to an unconfigured logger that vanishes to stderr that Claude Code captures but typically doesn't surface. With no forensic trail it's impossible to distinguish:

- Stop didn't fire at all
- Stop fired and crashed before publishing
- Stop fired, called the adapter, the adapter's HTTP call failed silently
- Stop fired and published, but the backend skipped extraction (stride pre-filter, etc.)

The new log answers all four from one file.

## Per-line shape

```json
{
  "ts": 1778877527,
  "event": "stop",
  "host": "claude-code",
  "session_id": "abc-123",
  "project_id": "mwaskom__seaborn-3069",
  "cwd": "/some/workdir",
  "internal_skipped": false,
  "handler_status": "ok",
  "publish_status": "ok",
  "publish_count": 2
}
```

`handler_status` is one of `ok`, `unknown_event`, or `raised:<ExcClass>: <msg>`. `publish_status`/`publish_count` are only set for Stop + SessionEnd. `cwd` is preserved verbatim — same sensitivity as the existing `~/.claude-smart/backend.log`.

## Failure policy

`hook_log.log_event` swallows `OSError` and `TypeError`/`ValueError` (encoding failures) at DEBUG. A read-only `$HOME`, a stuck disk, or an unserialisable field must never abort an in-progress hook. Field values are truncated at 4 KiB so single appends stay below the POSIX atomic-write boundary.

## Test plan

- [x] 11 new unit tests in `tests/test_hook_log.py` covering: basic record shape, append semantics, conditional publish fields, oversized-string truncation, read-only-dir tolerance, `CLAUDE_SMART_HOOK_LOG` override, and dispatcher-level coverage of unknown events / internal-skip / handler exception / `("ok", N)` and `("nothing", 0)` publish outcomes
- [x] Full suite green (279 passed, +11 vs. main). 3 `test_install_scripts.py` failures are pre-existing on `origin/main` — unrelated to this change
- [x] Ruff + pyright clean on the new/modified source files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hook execution logging is now available, writing to a JSON log file (default: `~/.claude-smart/hook.log`, configurable via the `CLAUDE_SMART_HOOK_LOG` environment variable). Each log entry captures the event type, session details, handler status, and publish operation results.

* **Tests**
  * Added comprehensive test coverage for the new hook event logging functionality and event dispatcher behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->