### PR TITLE
[codex] Filter title-only stop responses

### DIFF
--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -267,6 +267,12 @@ def _parse_plan_decision(text: str) -> str | None:
     return None
 
 
+def _has_unpublished_user_turn(session_id: str) -> bool:
+    """True when the session buffer already has a user turn awaiting publish."""
+    _, interactions = state.unpublished_slice(state.read_all(session_id))
+    return any(item.get("role") == "User" for item in interactions)
+
+
 def _scan_transcript_for_cs_cite_ids(entries: list[dict[str, Any]]) -> list[str]:
     """Scan the current assistant turn for ``cs-cite`` Bash tool_use calls.
 
@@ -360,8 +366,10 @@ def handle(payload: dict[str, Any]) -> None:
         if path.is_file():
             entries = _load_transcript_with_retry(path)
 
+    prompt = payload.get("prompt") or (
+        _scan_transcript_for_user_text(entries) if runtime.is_codex() else ""
+    )
     if runtime.is_codex():
-        prompt = payload.get("prompt") or _scan_transcript_for_user_text(entries)
         if internal_call.is_codex_internal_prompt(prompt):
             return
 
@@ -373,6 +381,13 @@ def handle(payload: dict[str, Any]) -> None:
         and last_assistant_message
         else _scan_transcript_for_assistant_text(entries)
     )
+    if (
+        runtime.is_codex()
+        and internal_call.is_codex_title_response(assistant_text)
+        and not prompt
+        and not _has_unpublished_user_turn(session_id)
+    ):
+        return
     transcript_cited_ids = _scan_transcript_for_cs_cite_ids(entries)
     text_cited_ids = cs_cite.parse_text_citations(assistant_text)
     cited_ids = [*text_cited_ids, *transcript_cited_ids]

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -36,6 +36,7 @@ Detection signals, OR'd:
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -116,4 +117,26 @@ def is_codex_internal_prompt(prompt: Any) -> bool:
         text.startswith(_CODEX_SUGGESTIONS_PROMPT_PREFIX)
         and _CODEX_SUGGESTIONS_PROMPT_MARKER in text
         and _CODEX_SUGGESTIONS_APPS_MARKER in text
+    )
+
+
+def is_codex_title_response(content: Any) -> bool:
+    """True for Codex's title-generator response body.
+
+    Codex can run a separate title-generation task whose Stop payload contains
+    only the assistant response, e.g. ``{"title":"Fix tests"}``, with no
+    corresponding user turn. That metadata is useful to Codex's UI, but it is
+    not a user interaction and should not be published to reflexio.
+    """
+    if not isinstance(content, str):
+        return False
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return False
+    return (
+        isinstance(parsed, dict)
+        and set(parsed) == {"title"}
+        and isinstance(parsed.get("title"), str)
+        and bool(parsed["title"].strip())
     )

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -289,6 +289,56 @@ def test_codex_stop_skips_internal_prompt_from_transcript(
     assert calls == []
 
 
+def test_codex_stop_skips_orphan_title_response(session_dir, monkeypatch) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        stop.publish, "publish_unpublished", lambda **kw: calls.append(kw)
+    )
+
+    stop.handle(
+        {
+            "session_id": "s1",
+            "cwd": str(REPO_ROOT),
+            "last_assistant_message": '{"title":"Find claude-smart install type"}',
+            "transcript_path": "/does/not/exist.jsonl",
+        }
+    )
+
+    assert state.read_all("s1") == []
+    assert calls == []
+
+
+def test_codex_stop_keeps_user_requested_title_json(session_dir, monkeypatch) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        stop.publish, "publish_unpublished", lambda **kw: calls.append(kw)
+    )
+    state.append(
+        "s1",
+        {
+            "role": "User",
+            "content": "Return only a JSON title for the task.",
+            "user_id": "demo",
+        },
+    )
+
+    stop.handle(
+        {
+            "session_id": "s1",
+            "cwd": str(REPO_ROOT),
+            "last_assistant_message": '{"title":"Fix docs"}',
+            "transcript_path": "/does/not/exist.jsonl",
+        }
+    )
+
+    records = state.read_all("s1")
+    assert records[-1]["role"] == "Assistant"
+    assert records[-1]["content"] == '{"title":"Fix docs"}'
+    assert calls
+
+
 def test_codex_stop_resolves_text_citations_from_last_assistant_message(
     session_dir, monkeypatch
 ) -> None:

--- a/tests/test_internal_call.py
+++ b/tests/test_internal_call.py
@@ -113,6 +113,32 @@ def test_returns_true_for_codex_title_prompt(monkeypatch: pytest.MonkeyPatch) ->
     )
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        '{"title":"Find claude-smart install type"}',
+        '{ "title": "Install local claude-smart plugin" }',
+    ],
+)
+def test_detects_codex_title_response(content: str) -> None:
+    assert internal_call.is_codex_title_response(content) is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "",
+        "not json",
+        '{"title": ""}',
+        '{"title": "real", "body": "extra"}',
+        '["title", "real"]',
+        {"title": "real"},
+    ],
+)
+def test_rejects_non_title_responses(content: object) -> None:
+    assert internal_call.is_codex_title_response(content) is False
+
+
 def test_returns_true_for_codex_suggestions_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- detect Codex title-generator response bodies shaped like `{"title": ...}`
- skip title-only Stop events when there is no prompt or unpublished user turn
- add regression coverage that drops orphan title JSON while preserving user-requested title JSON

## Why
Codex can create internal task-title model calls that surface as assistant-only Stop payloads. Without filtering, claude-smart publishes those UI metadata rows as real Reflexio interactions.

## Validation
- `uvx ruff check plugin/src/claude_smart/internal_call.py plugin/src/claude_smart/events/stop.py tests/test_codex_support.py tests/test_internal_call.py`
- `uv run --project plugin pytest tests`
- commit pre-hook reran `uv run --project plugin pytest tests`