### PR TITLE
feat(session-end + hook-log + backend): paired-protocol learning loop fixes

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -102,7 +102,7 @@
           {
             "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/hook_entry.sh\" claude-code session-end",
-            "timeout": 60
+            "timeout": 300
           },
           {
             "type": "command",

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -206,16 +206,21 @@ case "$CMD" in
     export INTERACTION_CLEANUP_THRESHOLD="${INTERACTION_CLEANUP_THRESHOLD:-500}"
     export INTERACTION_CLEANUP_DELETE_COUNT="${INTERACTION_CLEANUP_DELETE_COUNT:-200}"
 
-    # --no-reload: uvicorn's reloader forks a supervisor; makes
-    # bookkeeping harder and we don't need hot-reload for a user-facing
-    # service. Detach via claude_smart_spawn_detached so the same code
-    # path covers Linux (setsid), macOS (python3 os.setsid), and Windows
     # (nohup; no process groups). backend-log-runner.sh owns stdout/stderr
     # capture so process output cannot grow backend.log past its cap.
+    #
+    # --workers: reflexio defaults to 2 (zero-downtime worker recycling
+    # for server deployments). For a single-user Claude Code plugin
+    # that's pure overhead: ~1.1 GB extra RSS, periodic 5–10 s spawn
+    # hiccups during worker rotation, and SQLite can't accept concurrent
+    # writers anyway. Default to 1 here; opt in to N via
+    # CLAUDE_SMART_BACKEND_WORKERS for power users running concurrent
+    # Claude Code sessions or wanting zero-downtime recycling.
+    workers="${CLAUDE_SMART_BACKEND_WORKERS:-1}"
     claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
       "$LOG_FILE" "$LOG_MAX_BYTES" -- \
       uv run --project "$PLUGIN_ROOT" --quiet \
-      reflexio services start --only backend --no-reload
+      reflexio services start --only backend --no-reload --workers "$workers"
     svc_pid=$!
     # Record the spawned pid, not a pgid sampled with ps. On POSIX,
     # setsid/python os.setsid make this pid the new process group leader;

--- a/plugin/src/claude_smart/events/session_end.py
+++ b/plugin/src/claude_smart/events/session_end.py
@@ -7,12 +7,23 @@ from typing import Any
 from claude_smart import ids, publish
 
 
-def handle(payload: dict[str, Any]) -> None:
+def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
+    """Flush any remaining buffered turns to reflexio.
+
+    Args:
+        payload (dict[str, Any]): Claude Code hook payload.
+
+    Returns:
+        tuple[PublishStatus, int] | None: The ``(status, count)`` tuple
+            from ``publish.publish_unpublished`` so the dispatcher's
+            forensic hook log captures the publish outcome. ``None``
+            when the payload had no ``session_id``.
+    """
     session_id = payload.get("session_id")
     if not session_id:
-        return
+        return None
     project_id = ids.resolve_project_id(payload.get("cwd"))
-    publish.publish_unpublished(
+    return publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
         force_extraction=False,

--- a/plugin/src/claude_smart/events/session_end.py
+++ b/plugin/src/claude_smart/events/session_end.py
@@ -59,10 +59,18 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
         transcript_path=payload.get("transcript_path"),
     )
 
+    # ``force_extraction=True`` makes the reflexio server run the
+    # extractor synchronously for this publish, so by the time the HTTP
+    # call returns the playbook (if any) is already committed. SessionEnd
+    # is the final flush — the user/agent is already going away — so
+    # adding a few extra seconds here trades nothing for "snapshot_playbooks()
+    # reads after this point see the just-extracted rows." Stop hooks
+    # (the per-turn flushes) stay async so they don't slow interactive
+    # generation.
     return publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
-        force_extraction=False,
+        force_extraction=True,
         skip_aggregation=False,
     )
 

--- a/plugin/src/claude_smart/events/session_end.py
+++ b/plugin/src/claude_smart/events/session_end.py
@@ -1,10 +1,39 @@
-"""SessionEnd hook — flush any remaining interactions; extraction runs async."""
+"""SessionEnd hook — flush any remaining interactions; extraction runs async.
+
+When ``Stop`` never fires during a session (autonomous agentic loops
+that don't reach ``stop_reason=end_turn``), the buffer at SessionEnd
+time can contain orphan ``Assistant_tool`` records with no closing
+``Assistant`` anchor. The ``state.unpublished_slice`` contract folds
+tool records into the *next* Assistant turn's ``tools_used``; without
+that anchor, every buffered tool call is silently dropped at publish
+time and reflexio receives only the original User prompt.
+
+This module synthesises a closing Assistant record from whatever
+assistant text the Claude Code transcript still has, so the publish
+carries the full tool record stream instead of just the User prompt.
+A short placeholder string is used when the transcript is unreadable.
+"""
 
 from __future__ import annotations
 
+import logging
+import time
+from pathlib import Path
 from typing import Any
 
-from claude_smart import ids, publish
+from claude_smart import ids, publish, state
+from claude_smart.events.stop import (
+    _read_transcript_entries,
+    _scan_transcript_for_assistant_text,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Fallback Assistant content used when the transcript is missing,
+# unreadable, or has no recoverable assistant text. The string is
+# distinctive so a future audit can grep for it and quantify how often
+# a session ended without any model response.
+_PLACEHOLDER_ASSISTANT_TEXT = "<session ended without final assistant response>"
 
 
 def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
@@ -23,9 +52,126 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
     if not session_id:
         return None
     project_id = ids.resolve_project_id(payload.get("cwd"))
+
+    _maybe_synthesize_assistant_anchor(
+        session_id=session_id,
+        project_id=project_id,
+        transcript_path=payload.get("transcript_path"),
+    )
+
     return publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
         force_extraction=False,
         skip_aggregation=False,
     )
+
+
+def _maybe_synthesize_assistant_anchor(
+    *,
+    session_id: str,
+    project_id: str,
+    transcript_path: Any,
+) -> None:
+    """Append a closing Assistant record when the unpublished tail
+    holds orphan ``Assistant_tool`` rows.
+
+    Walks the post-watermark slice of the buffer and looks for a tail
+    pattern of ``Assistant_tool`` records that aren't followed by an
+    ``Assistant`` record. If that's the case, scans the Claude Code
+    transcript for whatever final assistant text is recoverable and
+    appends one synthetic ``Assistant`` record so
+    ``state.unpublished_slice`` can fold the tools into its
+    ``tools_used`` field at publish time.
+
+    Args:
+        session_id (str): Claude Code session id for the state buffer.
+        project_id (str): Resolved project_id used as the synthetic
+            record's ``user_id`` (matches Stop's convention).
+        transcript_path (Any): The ``transcript_path`` value from the
+            hook payload — accepted as ``Any`` because Claude Code may
+            send a string, ``None``, or omit the key entirely.
+
+    Returns:
+        None
+    """
+    records = state.read_all(session_id)
+    if not _tail_has_orphan_tools(records):
+        return
+
+    assistant_text = _recover_assistant_text(transcript_path)
+    state.append(
+        session_id,
+        {
+            "ts": int(time.time()),
+            "role": "Assistant",
+            "content": assistant_text,
+            "user_id": project_id,
+            "synthesised_by": "session_end_anchor",
+        },
+    )
+    _LOGGER.info(
+        "session_end: synthesised Assistant anchor for %s (len=%d)",
+        session_id,
+        len(assistant_text),
+    )
+
+
+def _tail_has_orphan_tools(records: list[dict[str, Any]]) -> bool:
+    """Return True when the post-watermark tail ends with one or more
+    ``Assistant_tool`` records with no closing ``Assistant`` record.
+
+    Walks records from the latest ``published_up_to`` marker forward;
+    tracks the most recent record role. The tail is considered "orphan"
+    when at least one ``Assistant_tool`` was seen after the watermark
+    and no ``Assistant`` record was seen *after* the last
+    ``Assistant_tool``.
+
+    Args:
+        records (list[dict[str, Any]]): The full buffered record list
+            as returned by ``state.read_all``.
+
+    Returns:
+        bool: True if a synthetic anchor would unblock publishing tool
+            records that would otherwise be dropped.
+    """
+    # Find the most recent published_up_to watermark.
+    published = 0
+    for rec in records:
+        if "published_up_to" in rec:
+            published = rec["published_up_to"]
+
+    tail = records[published:]
+    saw_orphan_tool = False
+    for rec in tail:
+        role = rec.get("role")
+        if role == "Assistant_tool":
+            saw_orphan_tool = True
+        elif role == "Assistant":
+            saw_orphan_tool = False
+    return saw_orphan_tool
+
+
+def _recover_assistant_text(transcript_path: Any) -> str:
+    """Return whatever assistant text the transcript still has, or a placeholder.
+
+    Args:
+        transcript_path (Any): Raw value from the hook payload.
+
+    Returns:
+        str: Concatenated current-turn assistant text from the
+            transcript, or ``_PLACEHOLDER_ASSISTANT_TEXT`` when the
+            transcript is unset, missing, or yields nothing.
+    """
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return _PLACEHOLDER_ASSISTANT_TEXT
+    path = Path(transcript_path)
+    if not path.is_file():
+        return _PLACEHOLDER_ASSISTANT_TEXT
+    try:
+        entries = _read_transcript_entries(path)
+    except OSError as exc:
+        _LOGGER.debug("session_end transcript read failed: %s", exc)
+        return _PLACEHOLDER_ASSISTANT_TEXT
+    text = _scan_transcript_for_assistant_text(entries)
+    return text or _PLACEHOLDER_ASSISTANT_TEXT

--- a/plugin/src/claude_smart/events/session_start.py
+++ b/plugin/src/claude_smart/events/session_start.py
@@ -15,8 +15,15 @@ from claude_smart.stall_banner import render_banner
 # Claude-smart's preferred extraction cadence — more frequent, smaller windows
 # than reflexio's out-of-box 10/5. Applied idempotently to the reflexio server
 # on every SessionStart via Adapter.apply_extraction_defaults.
-_CLAUDE_SMART_WINDOW_SIZE = 5
-_CLAUDE_SMART_STRIDE_SIZE = 3
+#
+# Env-var overrides let benchmark harnesses (SWE-bench Verified, in particular)
+# run with ``CLAUDE_SMART_STRIDE_SIZE=1`` so a single short autonomous session
+# triggers extraction on its sole publish instead of being silently filtered
+# out by the stride pre-filter (``new < stride_size``). Production users keep
+# the defaults; the values are only read on SessionStart, so a launcher that
+# sets the env var has predictable effect for the entire Claude Code session.
+_CLAUDE_SMART_WINDOW_SIZE = int(os.environ.get("CLAUDE_SMART_WINDOW_SIZE", "5"))
+_CLAUDE_SMART_STRIDE_SIZE = int(os.environ.get("CLAUDE_SMART_STRIDE_SIZE", "3"))
 # Optimizer is on by default. Set this env var to "0" to skip pushing the
 # claude-smart optimizer defaults on SessionStart (kill switch).
 _DISABLE_OPTIMIZER_ENV = "CLAUDE_SMART_ENABLE_OPTIMIZER"

--- a/plugin/src/claude_smart/events/session_start.py
+++ b/plugin/src/claude_smart/events/session_start.py
@@ -22,8 +22,25 @@ from claude_smart.stall_banner import render_banner
 # out by the stride pre-filter (``new < stride_size``). Production users keep
 # the defaults; the values are only read on SessionStart, so a launcher that
 # sets the env var has predictable effect for the entire Claude Code session.
-_CLAUDE_SMART_WINDOW_SIZE = int(os.environ.get("CLAUDE_SMART_WINDOW_SIZE", "5"))
-_CLAUDE_SMART_STRIDE_SIZE = int(os.environ.get("CLAUDE_SMART_STRIDE_SIZE", "3"))
+#
+# Parsing is defensive: a non-integer env value falls back to the default
+# rather than raising at import time. SessionStart is the hook that wires up
+# every subsequent hook, so an import-time crash here would silently disable
+# the whole plugin for the session.
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+_CLAUDE_SMART_WINDOW_SIZE = _int_env("CLAUDE_SMART_WINDOW_SIZE", 5)
+_CLAUDE_SMART_STRIDE_SIZE = _int_env("CLAUDE_SMART_STRIDE_SIZE", 3)
 # Optimizer is on by default. Set this env var to "0" to skip pushing the
 # claude-smart optimizer defaults on SessionStart (kill switch).
 _DISABLE_OPTIMIZER_ENV = "CLAUDE_SMART_ENABLE_OPTIMIZER"

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -308,10 +308,23 @@ def _resolve_cited_items(session_id: str, cited_ids: list[str]) -> list[dict[str
     return resolved
 
 
-def handle(payload: dict[str, Any]) -> None:
+def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
+    """Drain the buffered assistant turn to reflexio.
+
+    Args:
+        payload (dict[str, Any]): Claude Code hook payload.
+
+    Returns:
+        tuple[PublishStatus, int] | None: The ``(status, count)`` tuple
+            from ``publish.publish_unpublished`` so the dispatcher can
+            include it in the forensic hook log. ``None`` is returned
+            only when the handler short-circuits before publishing (no
+            ``session_id`` in the payload, or Codex internal-prompt
+            detection skipped the fire).
+    """
     session_id = payload.get("session_id")
     if not session_id:
-        return
+        return None
 
     # Always append an Assistant record, even when the turn emitted only
     # tool calls and no text. ``state.unpublished_slice`` folds any
@@ -332,7 +345,7 @@ def handle(payload: dict[str, Any]) -> None:
     )
     if runtime.is_codex():
         if internal_call.is_codex_internal_prompt(prompt):
-            return
+            return None
 
     last_assistant_message = payload.get("last_assistant_message")
     assistant_text = (
@@ -374,7 +387,7 @@ def handle(payload: dict[str, Any]) -> None:
     if cited_items:
         record["cited_items"] = cited_items
     state.append(session_id, record)
-    publish.publish_unpublished(
+    return publish.publish_unpublished(
         session_id=session_id,
         project_id=project_id,
         force_extraction=False,

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -5,6 +5,13 @@ The plugin's ``hook_entry.sh`` calls either
 ``python -m claude_smart.hook <host> <event>`` once per hook invocation.
 This module reads the hook JSON from stdin, routes to the matching handler,
 and makes sure no unhandled exception ever propagates.
+
+Every fire produces one structured JSON line in
+``~/.claude-smart/hook.log`` via ``hook_log.log_event`` — covers the
+event name, session id, internal-invocation skip, handler outcome
+(``ok`` / ``raised:<Exc>`` / ``unknown_event``), and for Stop/SessionEnd
+the publish status + count. The log is the forensic trail for chasing
+"hook didn't publish" mysteries from a single file.
 """
 
 from __future__ import annotations
@@ -12,15 +19,20 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
-from claude_smart import runtime
+from claude_smart import hook_log, ids, runtime
 from claude_smart.internal_call import is_internal_invocation
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _load_handlers() -> dict[str, Callable[[dict[str, Any]], None]]:
+# Stop and SessionEnd return ``(PublishStatus, int)`` so the dispatcher can
+# log the publish outcome; the other handlers return ``None`` (or nothing).
+# Use ``Any`` here rather than two specialised typedefs — the dispatcher
+# narrows at the call site via ``isinstance(result, tuple)``.
+def _load_handlers() -> dict[str, Callable[[dict[str, Any]], Any]]:
     from claude_smart.events import (
         post_tool,
         pre_tool,
@@ -92,6 +104,15 @@ def main(argv: list[str] | None = None) -> int:
     # handlers so we don't publish the extractor's system prompt back
     # into reflexio. See claude_smart.internal_call for detection logic.
     if is_internal_invocation(payload):
+        hook_log.log_event(
+            event=event,
+            host=host,
+            session_id=payload.get("session_id"),
+            project_id=ids.resolve_project_id(payload.get("cwd")),
+            cwd=payload.get("cwd"),
+            internal_skipped=True,
+            handler_status="ok",
+        )
         emit_continue()
         return 0
 
@@ -99,14 +120,38 @@ def main(argv: list[str] | None = None) -> int:
     handler = handlers.get(event)
     if handler is None:
         _LOGGER.warning("unknown hook event: %s", event)
+        hook_log.log_event(
+            event=event,
+            host=host,
+            session_id=payload.get("session_id"),
+            project_id=ids.resolve_project_id(payload.get("cwd")),
+            cwd=payload.get("cwd"),
+            handler_status="unknown_event",
+        )
         emit_continue()
         return 0
 
+    handler_status = "ok"
+    publish_status: str | None = None
+    publish_count: int | None = None
     try:
-        handler(payload)
+        result = handler(payload)
+        if isinstance(result, tuple) and len(result) == 2:
+            publish_status, publish_count = result
     except Exception as exc:  # noqa: BLE001 — hooks must never crash the session.
         _LOGGER.exception("hook handler %s raised: %s", event, exc)
+        handler_status = f"raised:{type(exc).__name__}: {exc}"
         emit_continue()
+    hook_log.log_event(
+        event=event,
+        host=host,
+        session_id=payload.get("session_id"),
+        project_id=ids.resolve_project_id(payload.get("cwd")),
+        cwd=payload.get("cwd"),
+        handler_status=handler_status,
+        publish_status=publish_status,
+        publish_count=publish_count,
+    )
     return 0
 
 

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -141,7 +141,11 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # noqa: BLE001 — hooks must never crash the session.
         _LOGGER.exception("hook handler %s raised: %s", event, exc)
         handler_status = f"raised:{type(exc).__name__}: {exc}"
-        emit_continue()
+    # Always emit the JSON continue response — Claude Code's hook contract
+    # expects one on stdout regardless of whether the handler succeeded or
+    # raised. Skipping it on the success path would leave the hook silent
+    # and the session would block waiting for a reply.
+    emit_continue()
     hook_log.log_event(
         event=event,
         host=host,

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -1,0 +1,145 @@
+"""Structured, append-only log of every hook fire and its outcome.
+
+Why a dedicated log rather than relying on the Python ``logging`` module:
+hooks run as short-lived subprocesses with no preconfigured handler, so
+``_LOGGER.warning(...)`` calls silently vanish to stderr that Claude Code
+captures but typically does not surface. The dispatcher already wraps
+handlers in a broad ``except`` (so a hook crash never breaks the user's
+session) — without a forensic trail the silent-fail mode is invisible.
+
+This module writes one JSON line per hook fire to
+``~/.claude-smart/hook.log`` from ``hook.main`` after the handler returns.
+The Stop and SessionEnd handlers additionally piggyback their publish
+outcome into the record so the chain hook→adapter→backend is fully
+observable from a single file.
+
+Failure policy: every public function in this module swallows all
+``OSError``/``Exception`` paths. Logging is best-effort; a stuck disk
+or read-only ``$HOME`` must never abort an in-progress hook.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Anchored on $HOME so unit tests can monkeypatch ``_LOG_PATH`` to a
+# tmp_path. The directory is created lazily on first write — keeping
+# import side-effect-free matches the rest of the package.
+_LOG_PATH = Path.home() / ".claude-smart" / "hook.log"
+
+_TRUNCATE_LIMIT = 4096
+
+
+def log_event(
+    *,
+    event: str,
+    host: str,
+    session_id: Any = None,
+    project_id: Any = None,
+    cwd: Any = None,
+    internal_skipped: bool = False,
+    handler_status: str = "ok",
+    publish_status: str | None = None,
+    publish_count: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Append one JSON record describing a hook fire.
+
+    Args:
+        event (str): Hook event name (``"stop"``, ``"user-prompt"``, …).
+        host (str): Host identifier (``"claude-code"`` / ``"codex"``).
+        session_id (Any): Claude Code session id from the payload, or
+            ``None`` when the payload didn't carry one.
+        project_id (Any): Project-id resolved from ``cwd``. Optional.
+        cwd (Any): Working directory reported by the hook payload.
+            Optional — preserved verbatim so a future audit can correlate
+            fires against workspace directories.
+        internal_skipped (bool): True when ``is_internal_invocation``
+            short-circuited the dispatcher (reflexio-internal sub-claude
+            calls, or invocations from inside the reflexio submodule).
+        handler_status (str): ``"ok"`` for a clean return, ``"unknown_event"``
+            when no handler is registered, or ``"raised:<ExcClass>: <msg>"``
+            when the handler raised — formatted by ``hook.main``.
+        publish_status (str | None): Status returned by
+            ``publish.publish_unpublished`` (``"ok"`` / ``"failed"`` /
+            ``"nothing"``). Only emitted by Stop + SessionEnd.
+        publish_count (int | None): Interaction count from the same
+            tuple. ``None`` when the handler doesn't publish.
+        extra (dict[str, Any] | None): Free-form fields preserved as-is.
+
+    Returns:
+        None
+    """
+    record: dict[str, Any] = {
+        "ts": int(time.time()),
+        "event": event,
+        "host": host,
+        "session_id": _truncate(session_id),
+        "project_id": _truncate(project_id),
+        "cwd": _truncate(cwd),
+        "internal_skipped": bool(internal_skipped),
+        "handler_status": _truncate(handler_status),
+    }
+    if publish_status is not None:
+        record["publish_status"] = publish_status
+        record["publish_count"] = int(publish_count or 0)
+    if extra:
+        for key, value in extra.items():
+            if key in record:
+                continue
+            record[key] = _truncate(value)
+
+    try:
+        line = json.dumps(record, ensure_ascii=False, default=str) + "\n"
+    except (TypeError, ValueError) as exc:
+        _LOGGER.debug("hook_log: json encode failed: %s", exc)
+        return
+
+    path = log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Open mode "a" is atomic on POSIX for writes <= PIPE_BUF (4 KiB);
+        # we truncate fields above to stay below that and avoid a heavier
+        # ``flock`` dance that the hook fire path can't afford.
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+    except OSError as exc:
+        _LOGGER.debug("hook_log: write to %s failed: %s", path, exc)
+
+
+def log_path() -> Path:
+    """Return the active log path, honouring ``CLAUDE_SMART_HOOK_LOG``.
+
+    Resolution order:
+
+    1. ``CLAUDE_SMART_HOOK_LOG`` env var — escape hatch for tests and
+       advanced users who want the log elsewhere.
+    2. ``_LOG_PATH`` module attribute — what monkeypatched tests override.
+    3. ``~/.claude-smart/hook.log`` — the default.
+
+    Returns:
+        Path: The absolute path to write to.
+    """
+    override = os.environ.get("CLAUDE_SMART_HOOK_LOG")
+    if override:
+        return Path(override)
+    return _LOG_PATH
+
+
+def _truncate(value: Any) -> Any:
+    """Cap string values to ``_TRUNCATE_LIMIT`` chars so single-line writes
+    stay below the POSIX atomic-append limit.
+
+    Non-string values pass through unchanged; the json encoder handles
+    them. ``None`` becomes ``null`` in the JSON, which is what we want.
+    """
+    if isinstance(value, str) and len(value) > _TRUNCATE_LIMIT:
+        return value[:_TRUNCATE_LIMIT] + "…"
+    return value

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -20,6 +20,7 @@ or read-only ``$HOME`` must never abort an in-progress hook.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -35,6 +36,12 @@ _LOGGER = logging.getLogger(__name__)
 _LOG_PATH = Path.home() / ".claude-smart" / "hook.log"
 
 _TRUNCATE_LIMIT = 4096
+
+# Hard cap on ``hook.log`` size. At ~400 bytes/line and ~50 lines per
+# typical session, 5 MB ≈ 12k records ≈ a few hundred sessions of recent
+# forensic history — enough to debug the last week, bounded so a power
+# user's log can't grow unbounded.
+_MAX_LOG_BYTES = 5 * 1024 * 1024
 
 
 def log_event(
@@ -112,6 +119,13 @@ def log_event(
             fh.write(line)
     except OSError as exc:
         _LOGGER.debug("hook_log: write to %s failed: %s", path, exc)
+        return
+
+    # Rotate AFTER the append so the just-written record always survives,
+    # even on the call that crosses the cap. A single oversized record
+    # still gets through and is dropped by the *next* rotation when the
+    # file is read back.
+    _maybe_rotate(path)
 
 
 def log_path() -> Path:
@@ -143,3 +157,70 @@ def _truncate(value: Any) -> Any:
     if isinstance(value, str) and len(value) > _TRUNCATE_LIMIT:
         return value[:_TRUNCATE_LIMIT] + "…"
     return value
+
+
+def _maybe_rotate(path: Path) -> None:
+    """Cap ``path`` at ``_MAX_LOG_BYTES`` by dropping the oldest half in place.
+
+    The fast path is a single ``stat`` syscall — when the file is under
+    the cap (the overwhelmingly common case on every fire) we do nothing.
+    When over the cap we read the file, find the first newline at-or-after
+    the midpoint byte, and atomically replace the original with the bytes
+    *after* that newline. Splitting on a newline boundary preserves the
+    JSON Lines invariant: every retained line is a complete record.
+
+    We picked this over ``logging.handlers.RotatingFileHandler`` because:
+
+    1. ``hook_log`` deliberately avoids the ``logging`` framework — see
+       module docstring. Adding a handler reintroduces the configuration
+       fragility we were dodging.
+    2. ``RotatingFileHandler`` produces ``hook.log.1``, ``hook.log.2`` …
+       sidecar files; our forensic story is "one file, tail it". Users
+       have already wired up tooling around that path.
+    3. In-place truncate-to-second-half is O(n) on the rare rotation
+       event and zero-cost on every other write. Backup file management
+       would add steady-state inode pressure for no benefit.
+
+    Args:
+        path (Path): The log file to inspect. Need not exist — the
+            ``FileNotFoundError`` branch of the ``stat`` call returns
+            cleanly via the ``OSError`` guard.
+
+    Returns:
+        None
+    """
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        _LOGGER.debug("hook_log: stat for rotation failed: %s", exc)
+        return
+
+    if size < _MAX_LOG_BYTES:
+        return
+
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        _LOGGER.debug("hook_log: read for rotation failed: %s", exc)
+        return
+
+    midpoint = len(data) // 2
+    cut = data.find(b"\n", midpoint)
+    # ``find`` returns -1 when the second half has no newline at all,
+    # meaning the file is one giant record with no framing left to
+    # preserve. Drop the lot rather than split a record mid-byte.
+    tail = b"" if cut == -1 else data[cut + 1 :]
+
+    # Atomic replace: write to a sibling temp file then rename. This
+    # avoids the truncation window where a concurrent reader would see
+    # an empty file, and matches the contract that ``hook.log`` always
+    # contains complete JSONL framing.
+    tmp_path = path.with_name(path.name + ".rot")
+    try:
+        tmp_path.write_bytes(tail)
+        tmp_path.replace(path)
+    except OSError as exc:
+        _LOGGER.debug("hook_log: rotation rename failed: %s", exc)
+        # Best-effort cleanup of the temp file; ignore failures.
+        with contextlib.suppress(OSError):
+            tmp_path.unlink(missing_ok=True)

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -25,8 +25,17 @@ import json
 import logging
 import os
 import time
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
+
+# ``fcntl`` is POSIX-only. On Windows we skip the cross-process lock and
+# accept the unlikely rotation race (claude-smart is primarily a POSIX
+# tool for Claude Code's plugin runtime).
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover — exercised on Windows only
+    _fcntl = None  # type: ignore[assignment]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,20 +129,33 @@ def log_event(
     path = log_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # Open mode "a" is atomic on POSIX for writes <= PIPE_BUF (4 KiB);
-        # we truncate fields above to stay below that and avoid a heavier
-        # ``flock`` dance that the hook fire path can't afford.
-        with path.open("a", encoding="utf-8") as fh:
-            fh.write(line)
     except OSError as exc:
-        _LOGGER.debug("hook_log: write to %s failed: %s", path, exc)
+        _LOGGER.debug("hook_log: mkdir for %s failed: %s", path.parent, exc)
         return
 
-    # Rotate AFTER the append so the just-written record always survives,
-    # even on the call that crosses the cap. A single oversized record
-    # still gets through and is dropped by the *next* rotation when the
-    # file is read back.
-    _maybe_rotate(path)
+    # Hold an exclusive cross-process flock through the entire append +
+    # rotate critical section. The original rationale ("POSIX atomic
+    # append below PIPE_BUF") protects the *append* alone but not the
+    # ``read_bytes → write tmp → rename`` rotation sequence: a concurrent
+    # appender that lands between rotation's read and rename has its
+    # record silently dropped by the rename. The lock closes that gap.
+    #
+    # On Windows ``_fcntl`` is None and writes proceed unlocked — same
+    # behaviour as before. The original PIPE_BUF-based append atomicity
+    # is preserved by ``_TRUNCATE_LIMIT`` keeping each record below 4 KiB.
+    with _rotation_lock(path):
+        try:
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(line)
+        except OSError as exc:
+            _LOGGER.debug("hook_log: write to %s failed: %s", path, exc)
+            return
+
+        # Rotate AFTER the append so the just-written record always survives,
+        # even on the call that crosses the cap. A single oversized record
+        # still gets through and is dropped by the *next* rotation when the
+        # file is read back.
+        _maybe_rotate(path)
 
 
 def log_path() -> Path:
@@ -165,6 +187,51 @@ def _truncate(value: Any) -> Any:
     if isinstance(value, str) and len(value) > _TRUNCATE_LIMIT:
         return value[:_TRUNCATE_LIMIT] + "…"
     return value
+
+
+@contextlib.contextmanager
+def _rotation_lock(path: Path) -> Iterator[None]:
+    """Hold an exclusive cross-process flock on a sibling ``.lock`` file.
+
+    Serialises every ``log_event`` call against itself so the rotation
+    ``read_bytes → write tmp → rename`` sequence cannot interleave with a
+    concurrent append. On Windows or when the lock cannot be acquired
+    (no ``fcntl``, read-only parent, etc.) the lock degrades to a no-op
+    and the caller proceeds unlocked — matches the pre-existing
+    best-effort policy of this module.
+
+    Args:
+        path (Path): The log file path; the lock file is a sibling at
+            ``<path>.lock``.
+
+    Yields:
+        None.
+    """
+    if _fcntl is None:
+        yield
+        return
+    lock_path = path.with_name(path.name + ".lock")
+    fh: IO[bytes] | None = None
+    try:
+        fh = lock_path.open("ab")
+    except OSError as exc:
+        _LOGGER.debug("hook_log: lock open %s failed: %s", lock_path, exc)
+        yield
+        return
+    try:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX)
+    except OSError as exc:
+        _LOGGER.debug("hook_log: flock acquire failed: %s", exc)
+        fh.close()
+        yield
+        return
+    try:
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+        with contextlib.suppress(OSError):
+            fh.close()
 
 
 def _maybe_rotate(path: Path) -> None:

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -96,7 +96,15 @@ def log_event(
     }
     if publish_status is not None:
         record["publish_status"] = publish_status
-        record["publish_count"] = int(publish_count or 0)
+        try:
+            record["publish_count"] = int(
+                publish_count if publish_count is not None else 0
+            )
+        except (TypeError, ValueError):
+            # Defensive: a hostile caller passing an unparseable publish_count
+            # must not abort the hook fire. Treat as zero, the record still
+            # writes with publish_status preserved.
+            record["publish_count"] = 0
     if extra:
         for key, value in extra.items():
             if key in record:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1304,6 +1304,46 @@ def test_session_start_applies_claude_smart_extraction_defaults(
     assert applied == [{"window_size": 5, "stride_size": 3}]
 
 
+def test_session_start_honours_extraction_env_overrides(
+    session_dir, monkeypatch
+) -> None:
+    """CLAUDE_SMART_WINDOW_SIZE / STRIDE_SIZE env vars override the defaults."""
+    # The module-level constants are read at import time, so reload after
+    # monkeypatching the env to make the overrides take effect.
+    import importlib
+
+    monkeypatch.setenv("CLAUDE_SMART_WINDOW_SIZE", "2")
+    monkeypatch.setenv("CLAUDE_SMART_STRIDE_SIZE", "1")
+    import claude_smart.events.session_start as ss
+
+    importlib.reload(ss)
+
+    applied: list[dict[str, Any]] = []
+
+    class Stub:
+        def apply_extraction_defaults(self, **kwargs):
+            applied.append(kwargs)
+            return True
+
+        def apply_optimizer_defaults(self, **_kw):
+            return True
+
+        def fetch_all(self, **_kw):
+            return ([], [], [])
+
+    monkeypatch.setattr(ss, "Adapter", lambda *a, **kw: Stub())
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    try:
+        ss.handle({"session_id": "s1", "source": "startup"})
+        assert applied == [{"window_size": 2, "stride_size": 1}]
+    finally:
+        # Reload again with env unset so other tests see the real defaults.
+        monkeypatch.delenv("CLAUDE_SMART_WINDOW_SIZE", raising=False)
+        monkeypatch.delenv("CLAUDE_SMART_STRIDE_SIZE", raising=False)
+        importlib.reload(ss)
+
+
 def test_session_start_skips_optimizer_defaults_when_opted_out(
     session_dir, monkeypatch
 ) -> None:
@@ -1568,6 +1608,30 @@ def test_session_end_synthesises_anchor_when_buffer_ends_with_orphan_tools(
     assert synth[0]["role"] == "Assistant"
     assert synth[0]["content"] == "final assistant text"
     assert published_kwargs["session_id"] == "s_orphan"
+    # SessionEnd publishes synchronously so the snapshot read after the
+    # hook returns sees any just-extracted rows.
+    assert published_kwargs["force_extraction"] is True
+
+
+def test_session_end_uses_force_extraction_for_final_flush(
+    session_dir, monkeypatch
+) -> None:
+    """Every SessionEnd publish must set force_extraction=True so the
+    extractor finishes before snapshot_playbooks() reads."""
+    from claude_smart import state
+    from claude_smart.events import session_end
+
+    state.append("s_force", {"role": "User", "content": "ping", "user_id": "p"})
+
+    published_kwargs: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished",
+        lambda **kwargs: (published_kwargs.update(kwargs) or ("ok", 1)),
+    )
+    session_end.handle({"session_id": "s_force", "cwd": "/tmp/p"})
+    assert published_kwargs["force_extraction"] is True
+    # And skip_aggregation stays False — the rollup still happens.
+    assert published_kwargs["skip_aggregation"] is False
 
 
 def test_session_end_uses_placeholder_when_transcript_missing(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1498,3 +1498,156 @@ def test_pre_tool_emits_continue_when_search_empty(session_dir, monkeypatch) -> 
         "continue": True,
         "suppressOutput": True,
     }
+
+
+# -----------------------------------------------------------------------------
+# session_end — synthesises Assistant anchor for orphan tool records
+# -----------------------------------------------------------------------------
+
+
+def test_session_end_synthesises_anchor_when_buffer_ends_with_orphan_tools(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    """When Stop never fires, the buffer ends with orphan Assistant_tool
+    records. SessionEnd must append a synthetic Assistant record so the
+    tool stream survives the publish."""
+    from claude_smart import state
+    from claude_smart.events import session_end
+
+    state.append("s_orphan", {"role": "User", "content": "go", "user_id": "p1"})
+    state.append(
+        "s_orphan",
+        {
+            "role": "Assistant_tool",
+            "tool_name": "Bash",
+            "tool_input": {"command": "pytest"},
+            "tool_output": "passed",
+            "status": "success",
+        },
+    )
+    state.append(
+        "s_orphan",
+        {
+            "role": "Assistant_tool",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "foo.py"},
+            "tool_output": "...",
+            "status": "success",
+        },
+    )
+
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {"type": "user", "message": {"content": "go"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "final assistant text"}]
+                },
+            },
+        ],
+    )
+
+    published_kwargs: dict[str, Any] = {}
+
+    def fake_publish(**kwargs):
+        published_kwargs.update(kwargs)
+        return ("ok", 1)
+
+    monkeypatch.setattr("claude_smart.publish.publish_unpublished", fake_publish)
+
+    result = session_end.handle(
+        {"session_id": "s_orphan", "cwd": "/tmp/p1", "transcript_path": str(transcript)}
+    )
+    assert result == ("ok", 1)
+
+    records = state.read_all("s_orphan")
+    synth = [r for r in records if r.get("synthesised_by") == "session_end_anchor"]
+    assert len(synth) == 1
+    assert synth[0]["role"] == "Assistant"
+    assert synth[0]["content"] == "final assistant text"
+    assert published_kwargs["session_id"] == "s_orphan"
+
+
+def test_session_end_uses_placeholder_when_transcript_missing(
+    session_dir, monkeypatch
+) -> None:
+    """No transcript_path → synthetic Assistant uses the placeholder string."""
+    from claude_smart import state
+    from claude_smart.events import session_end
+
+    state.append("s_nopath", {"role": "User", "content": "do it", "user_id": "p"})
+    state.append(
+        "s_nopath",
+        {
+            "role": "Assistant_tool",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_output": "",
+            "status": "success",
+        },
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished", lambda **_: ("ok", 1)
+    )
+    session_end.handle({"session_id": "s_nopath", "cwd": "/tmp/p"})
+    records = state.read_all("s_nopath")
+    synth = [r for r in records if r.get("synthesised_by") == "session_end_anchor"]
+    assert len(synth) == 1
+    assert "session ended without final assistant response" in synth[0]["content"]
+
+
+def test_session_end_skips_anchor_when_assistant_already_present(
+    session_dir, monkeypatch
+) -> None:
+    """If the buffer tail already has an Assistant record (Stop fired
+    correctly), SessionEnd must not append a duplicate."""
+    from claude_smart import state
+    from claude_smart.events import session_end
+
+    state.append("s_clean", {"role": "User", "content": "do it", "user_id": "p"})
+    state.append(
+        "s_clean",
+        {
+            "role": "Assistant_tool",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_output": "",
+            "status": "success",
+        },
+    )
+    state.append(
+        "s_clean",
+        {"role": "Assistant", "content": "done", "user_id": "p"},
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished", lambda **_: ("ok", 1)
+    )
+    session_end.handle({"session_id": "s_clean", "cwd": "/tmp/p"})
+    records = state.read_all("s_clean")
+    synth = [r for r in records if r.get("synthesised_by") == "session_end_anchor"]
+    assert synth == []
+
+
+def test_session_end_skips_anchor_when_no_tools(session_dir, monkeypatch) -> None:
+    """Empty buffer (no orphan tools) → no synthetic record appended."""
+    from claude_smart import state
+    from claude_smart.events import session_end
+
+    state.append("s_empty", {"role": "User", "content": "go", "user_id": "p"})
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished", lambda **_: ("ok", 0)
+    )
+    session_end.handle({"session_id": "s_empty", "cwd": "/tmp/p"})
+    records = state.read_all("s_empty")
+    synth = [r for r in records if r.get("synthesised_by") == "session_end_anchor"]
+    assert synth == []
+
+
+def test_session_end_without_session_id_returns_none(session_dir) -> None:
+    """No session_id in the payload → short-circuit, no publish, no state."""
+    from claude_smart.events import session_end
+
+    result = session_end.handle({})
+    assert result is None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1344,6 +1344,31 @@ def test_session_start_honours_extraction_env_overrides(
         importlib.reload(ss)
 
 
+def test_session_start_falls_back_to_defaults_on_garbage_env_values(
+    session_dir, monkeypatch
+) -> None:
+    """A non-integer env value must fall back to the default rather than
+    raising at import time. Addresses CodeRabbit review on PR #30:
+    SessionStart is the hook that wires every other hook, so an
+    import-time crash here silently disables the whole plugin.
+    """
+    import importlib
+
+    monkeypatch.setenv("CLAUDE_SMART_WINDOW_SIZE", "not-an-int")
+    monkeypatch.setenv("CLAUDE_SMART_STRIDE_SIZE", "")
+    import claude_smart.events.session_start as ss
+
+    # Must not raise on reload.
+    importlib.reload(ss)
+    try:
+        assert ss._CLAUDE_SMART_WINDOW_SIZE == 5  # default
+        assert ss._CLAUDE_SMART_STRIDE_SIZE == 3  # default
+    finally:
+        monkeypatch.delenv("CLAUDE_SMART_WINDOW_SIZE", raising=False)
+        monkeypatch.delenv("CLAUDE_SMART_STRIDE_SIZE", raising=False)
+        importlib.reload(ss)
+
+
 def test_session_start_skips_optimizer_defaults_when_opted_out(
     session_dir, monkeypatch
 ) -> None:

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -1,0 +1,195 @@
+"""Tests for the forensic hook event log."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from claude_smart import hook, hook_log
+
+
+@pytest.fixture
+def hook_log_path(tmp_path, monkeypatch) -> Path:
+    """Redirect ``hook_log`` writes to a per-test tmp path."""
+    log_path = tmp_path / "hook.log"
+    monkeypatch.setattr(hook_log, "_LOG_PATH", log_path)
+    monkeypatch.delenv("CLAUDE_SMART_HOOK_LOG", raising=False)
+    return log_path
+
+
+def _read_lines(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+# -----------------------------------------------------------------------------
+# hook_log.log_event — direct unit tests
+# -----------------------------------------------------------------------------
+
+
+def test_log_event_writes_one_jsonl_record(hook_log_path) -> None:
+    hook_log.log_event(
+        event="stop",
+        host="claude-code",
+        session_id="sess-1",
+        project_id="proj-1",
+        cwd="/some/dir",
+        handler_status="ok",
+        publish_status="ok",
+        publish_count=2,
+    )
+    records = _read_lines(hook_log_path)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event"] == "stop"
+    assert rec["host"] == "claude-code"
+    assert rec["session_id"] == "sess-1"
+    assert rec["project_id"] == "proj-1"
+    assert rec["cwd"] == "/some/dir"
+    assert rec["handler_status"] == "ok"
+    assert rec["publish_status"] == "ok"
+    assert rec["publish_count"] == 2
+    assert rec["internal_skipped"] is False
+    assert isinstance(rec["ts"], int)
+
+
+def test_log_event_appends_across_calls(hook_log_path) -> None:
+    hook_log.log_event(event="stop", host="claude-code", session_id="a")
+    hook_log.log_event(event="user-prompt", host="claude-code", session_id="b")
+    records = _read_lines(hook_log_path)
+    assert [r["event"] for r in records] == ["stop", "user-prompt"]
+
+
+def test_log_event_omits_publish_fields_when_handler_did_not_publish(
+    hook_log_path,
+) -> None:
+    hook_log.log_event(event="user-prompt", host="claude-code", session_id="s")
+    rec = _read_lines(hook_log_path)[0]
+    assert "publish_status" not in rec
+    assert "publish_count" not in rec
+
+
+def test_log_event_truncates_oversized_strings(hook_log_path) -> None:
+    long_cwd = "x" * (hook_log._TRUNCATE_LIMIT + 100)
+    hook_log.log_event(event="stop", host="claude-code", cwd=long_cwd)
+    rec = _read_lines(hook_log_path)[0]
+    # truncation leaves the marker char appended
+    assert len(rec["cwd"]) == hook_log._TRUNCATE_LIMIT + 1
+    assert rec["cwd"].endswith("…")
+
+
+def test_log_event_tolerates_readonly_log_dir(tmp_path, monkeypatch) -> None:
+    """A read-only parent must not abort the hook fire."""
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses the read-only bit")
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)
+    try:
+        monkeypatch.setattr(hook_log, "_LOG_PATH", locked / "sub" / "hook.log")
+        monkeypatch.delenv("CLAUDE_SMART_HOOK_LOG", raising=False)
+        # Must not raise.
+        hook_log.log_event(event="stop", host="claude-code")
+    finally:
+        locked.chmod(0o700)
+
+
+def test_log_path_honors_env_override(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "override.log"
+    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", str(target))
+    hook_log.log_event(event="stop", host="claude-code")
+    assert target.is_file()
+    assert _read_lines(target)[0]["event"] == "stop"
+
+
+# -----------------------------------------------------------------------------
+# hook.main dispatcher → log records
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stdin_payload(monkeypatch):
+    """Helper that pipes a JSON dict to ``sys.stdin`` for ``hook.main``."""
+
+    def _set(payload: dict[str, Any]) -> None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+    return _set
+
+
+def test_dispatcher_logs_unknown_event(hook_log_path, stdin_payload) -> None:
+    stdin_payload({"session_id": "s1", "cwd": "/tmp"})
+    hook.main(["claude-code", "made-up-event"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "made-up-event"
+    assert rec["handler_status"] == "unknown_event"
+
+
+def test_dispatcher_logs_internal_skipped(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    monkeypatch.setenv("CLAUDE_SMART_INTERNAL", "1")
+    stdin_payload({"session_id": "s2", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "stop"
+    assert rec["internal_skipped"] is True
+    assert rec["handler_status"] == "ok"
+    # The internal-skip path doesn't publish — no publish fields.
+    assert "publish_status" not in rec
+
+
+def test_dispatcher_logs_handler_exception(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    def boom(_payload: dict[str, Any]) -> None:
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": boom})
+    stdin_payload({"session_id": "s3", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "stop"
+    assert rec["handler_status"].startswith("raised:RuntimeError:")
+    assert "kaboom" in rec["handler_status"]
+
+
+def test_dispatcher_logs_publish_outcome_from_stop(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    def stop_ok(_payload: dict[str, Any]) -> tuple[str, int]:
+        return ("ok", 3)
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_ok})
+    stdin_payload({"session_id": "s4", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["event"] == "stop"
+    assert rec["handler_status"] == "ok"
+    assert rec["publish_status"] == "ok"
+    assert rec["publish_count"] == 3
+
+
+def test_dispatcher_logs_nothing_publish_status(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    def stop_nothing(_payload: dict[str, Any]) -> tuple[str, int]:
+        return ("nothing", 0)
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_nothing})
+    stdin_payload({"session_id": "s5", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["publish_status"] == "nothing"
+    assert rec["publish_count"] == 0

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -364,3 +365,100 @@ def test_log_rotation_tolerates_read_failure(
     # Must not raise. The append succeeds; rotation's read fails and is
     # swallowed; the caller sees a clean return.
     hook_log.log_event(event="stop", host="claude-code", session_id="post")
+
+
+@pytest.mark.skipif(
+    not hasattr(hook_log, "_fcntl") or hook_log._fcntl is None,
+    reason="flock-based rotation lock is POSIX-only",
+)
+def test_log_event_lock_serialises_rotation_and_append(
+    hook_log_path, monkeypatch
+) -> None:
+    """A concurrent append fired mid-rotation must not be silently dropped.
+
+    Regression for CodeRabbit review on PR #30: the rotation
+    ``read_bytes → write tmp → rename`` sequence used to race with a
+    concurrent appender — a record landing in the original file between
+    the read and the rename was overwritten by the rename and lost. The
+    exclusive flock around append + rotate closes that gap.
+
+    Forces the race deterministically: thread A's ``log_event`` triggers
+    rotation and is paused inside ``Path.replace``; thread B's
+    ``log_event`` fires while A is paused. Without the lock, B would
+    append to the original file and A's pending replace would then
+    overwrite that append with the pre-B snapshot — B's record is lost.
+    With the lock, B blocks on the flock until A releases, then writes
+    to the post-rotation file. The test asserts both records survive.
+    """
+    # Prime with a high cap so no rotation fires during priming.
+    monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", 100_000)
+    for i in range(8):
+        hook_log.log_event(
+            event="stop", host="claude-code", session_id=f"prime-{i:02d}"
+        )
+    primed_size = hook_log_path.stat().st_size
+    assert primed_size > 0
+
+    # Drop the cap below the primed size so the *next* log_event rotates.
+    monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", primed_size - 1)
+
+    # Pause ONLY the first ``Path.replace`` call on the log file — that's
+    # the rotator's. The appender is either blocked by the lock (good)
+    # or runs concurrently and never reaches ``replace`` itself (we let
+    # it finish a single append; rotation can happen freely afterwards).
+    replace_called = threading.Event()
+    replace_may_finish = threading.Event()
+    appender_finished = threading.Event()
+    call_count = {"n": 0}
+    real_replace = Path.replace
+
+    def paused_replace(self: Path, target: Any) -> Path:
+        if Path(target) == hook_log_path:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                replace_called.set()
+                assert replace_may_finish.wait(timeout=5.0)
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", paused_replace)
+
+    def rotator() -> None:
+        hook_log.log_event(
+            event="stop", host="claude-code", session_id="rotator-record"
+        )
+
+    def appender() -> None:
+        assert replace_called.wait(timeout=5.0)
+        hook_log.log_event(
+            event="stop", host="claude-code", session_id="appender-record"
+        )
+        appender_finished.set()
+
+    t_rot = threading.Thread(target=rotator, name="rotator")
+    t_app = threading.Thread(target=appender, name="appender")
+    t_rot.start()
+    t_app.start()
+
+    # Rotator is paused at replace. With the lock held, the appender's
+    # log_event call is blocked acquiring the flock — give it generous
+    # wall time to attempt and queue.
+    assert replace_called.wait(timeout=5.0)
+    completed_early = appender_finished.wait(timeout=0.5)
+    assert not completed_early, (
+        "appender finished before rotator released the lock — the lock "
+        "isn't actually serialising rotation against concurrent appends, "
+        "so a record could be silently dropped under real concurrency."
+    )
+
+    replace_may_finish.set()
+    t_rot.join(timeout=5.0)
+    t_app.join(timeout=5.0)
+    assert not t_rot.is_alive()
+    assert not t_app.is_alive()
+
+    final = _read_lines(hook_log_path)
+    session_ids = {r["session_id"] for r in final}
+    assert "appender-record" in session_ids, (
+        "appender's record was dropped by rotation — the lock did not "
+        f"serialise the rotation/append. File has: {sorted(session_ids)}"
+    )

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -195,6 +195,35 @@ def test_dispatcher_logs_nothing_publish_status(
     assert rec["publish_count"] == 0
 
 
+def test_log_event_tolerates_unparseable_publish_count(hook_log_path) -> None:
+    """A non-int publish_count must not raise — the hook is best-effort.
+
+    Addresses CodeRabbit review on PR #30: ``int(publish_count or 0)``
+    used to raise TypeError on garbage callers, breaking the "never abort
+    a hook fire" contract. Defensive coercion falls back to 0.
+    """
+    # Object value with no usable int conversion.
+    hook_log.log_event(
+        event="stop",
+        host="claude-code",
+        publish_status="ok",
+        publish_count=object(),  # type: ignore[arg-type]
+    )
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["publish_status"] == "ok"
+    assert rec["publish_count"] == 0  # fell back to default
+
+    # And a string that can't be parsed as int.
+    hook_log.log_event(
+        event="stop",
+        host="claude-code",
+        publish_status="ok",
+        publish_count="not-a-number",  # type: ignore[arg-type]
+    )
+    rec = _read_lines(hook_log_path)[1]
+    assert rec["publish_count"] == 0
+
+
 # -----------------------------------------------------------------------------
 # hook_log — bounded rotation
 # -----------------------------------------------------------------------------

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -193,3 +193,108 @@ def test_dispatcher_logs_nothing_publish_status(
     rec = _read_lines(hook_log_path)[0]
     assert rec["publish_status"] == "nothing"
     assert rec["publish_count"] == 0
+
+
+# -----------------------------------------------------------------------------
+# hook_log — bounded rotation
+# -----------------------------------------------------------------------------
+
+
+def test_log_rotates_when_over_max_bytes(hook_log_path, monkeypatch) -> None:
+    """When the file crosses the cap, the oldest half is dropped and the
+    most-recent records survive."""
+    # Shrink the cap to make rotation testable without writing 5 MB.
+    monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", 500)
+
+    # Each record below is well under 500 B, but ~30 of them will cross
+    # the cap and trigger at least one rotation.
+    for i in range(60):
+        hook_log.log_event(
+            event="stop",
+            host="claude-code",
+            session_id=f"sess-{i:04d}",
+        )
+
+    # Total size must stay roughly bounded by the cap. The "roughly"
+    # allowance covers the single record that pushes us over before the
+    # next rotation reclaims half. In practice <= cap + one record.
+    final_size = hook_log_path.stat().st_size
+    assert final_size <= hook_log._MAX_LOG_BYTES * 2, (
+        f"expected size <= {hook_log._MAX_LOG_BYTES * 2}, got {final_size}"
+    )
+
+    # The most-recent record must still be present — rotation drops the
+    # oldest half, never the tail.
+    records = _read_lines(hook_log_path)
+    assert records, "rotation must not empty the file"
+    session_ids = [r["session_id"] for r in records]
+    assert "sess-0059" in session_ids
+    # And the very oldest must be gone.
+    assert "sess-0000" not in session_ids
+
+
+def test_log_does_not_rotate_when_under_max_bytes(
+    hook_log_path, monkeypatch
+) -> None:
+    """A single small record never triggers rotation; bytes are byte-stable
+    across subsequent reads."""
+    monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", 5 * 1024 * 1024)
+
+    hook_log.log_event(event="stop", host="claude-code", session_id="only")
+    snapshot_bytes = hook_log_path.read_bytes()
+    snapshot_records = _read_lines(hook_log_path)
+
+    # A subsequent rotation check on the same under-cap file must be a
+    # no-op — the bytes on disk are identical.
+    hook_log._maybe_rotate(hook_log_path)
+    assert hook_log_path.read_bytes() == snapshot_bytes
+    assert _read_lines(hook_log_path) == snapshot_records
+
+
+def test_log_rotation_preserves_jsonl_framing(
+    hook_log_path, monkeypatch
+) -> None:
+    """After rotation, every surviving line parses as JSON — no record is
+    split mid-byte by the cut."""
+    monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", 400)
+
+    for i in range(50):
+        hook_log.log_event(
+            event="user-prompt",
+            host="claude-code",
+            session_id=f"s-{i:03d}",
+        )
+
+    raw = hook_log_path.read_text(encoding="utf-8")
+    lines = [line for line in raw.split("\n") if line]
+    # Every retained line must be valid JSON — this catches the
+    # split-record regression the midpoint-then-newline cut prevents.
+    for line in lines:
+        parsed = json.loads(line)
+        assert "event" in parsed
+        assert parsed["event"] == "user-prompt"
+
+
+def test_log_rotation_tolerates_read_failure(
+    hook_log_path, monkeypatch
+) -> None:
+    """If the rotation read fails (disk error, EACCES, etc.) ``log_event``
+    must still return cleanly — hook fires are never aborted by logging."""
+    # Prime the file at the default (large) cap so the prime write itself
+    # never rotates — we want rotation to fire on the *next* call, where
+    # we'll sabotage it.
+    hook_log.log_event(event="stop", host="claude-code", session_id="prime")
+    assert hook_log_path.stat().st_size > 0
+
+    # Shrink the cap so the next write definitely triggers rotation.
+    monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", 1)
+
+    # Sabotage the rotation read step.
+    def boom(self: Path) -> bytes:
+        raise OSError("simulated read failure")
+
+    monkeypatch.setattr(Path, "read_bytes", boom)
+
+    # Must not raise. The append succeeds; rotation's read fails and is
+    # swallowed; the caller sees a clean return.
+    hook_log.log_event(event="stop", host="claude-code", session_id="post")

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -91,6 +91,8 @@ def test_log_event_truncates_oversized_strings(hook_log_path) -> None:
 
 def test_log_event_tolerates_readonly_log_dir(tmp_path, monkeypatch) -> None:
     """A read-only parent must not abort the hook fire."""
+    if not hasattr(os, "geteuid"):
+        pytest.skip("read-only permission semantics test is POSIX-specific")
     if os.geteuid() == 0:
         pytest.skip("root bypasses the read-only bit")
     locked = tmp_path / "locked"
@@ -193,6 +195,41 @@ def test_dispatcher_logs_nothing_publish_status(
     rec = _read_lines(hook_log_path)[0]
     assert rec["publish_status"] == "nothing"
     assert rec["publish_count"] == 0
+
+
+def test_dispatcher_emits_continue_on_handler_success(
+    hook_log_path, stdin_payload, monkeypatch, capsys
+) -> None:
+    """The success path must emit the ``{"continue": true}`` JSON on stdout.
+
+    Regression: an earlier version only emitted on the exception path,
+    leaving successful hook fires silent and blocking the parent session.
+    """
+
+    def stop_ok(_payload: dict[str, Any]) -> tuple[str, int]:
+        return ("ok", 1)
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_ok})
+    stdin_payload({"session_id": "s-success", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    out = capsys.readouterr().out
+    assert '"continue": true' in out
+
+
+def test_dispatcher_emits_continue_on_handler_exception(
+    hook_log_path, stdin_payload, monkeypatch, capsys
+) -> None:
+    """The exception path must also emit ``{"continue": true}`` — the
+    parent session never blocks regardless of handler outcome."""
+
+    def boom(_payload: dict[str, Any]) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": boom})
+    stdin_payload({"session_id": "s-exc", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    out = capsys.readouterr().out
+    assert '"continue": true' in out
 
 
 def test_log_event_tolerates_unparseable_publish_count(hook_log_path) -> None:


### PR DESCRIPTION
## Summary

Claude-smart-side fixes to make the SWE-bench Verified paired-protocol learning loop work end-to-end. Adds forensic visibility, fixes silent-failure modes, tunes single-user-plugin defaults, hardens defensive parsing.

## What changes (in stack order)

| # | Topic | Why |
|---|---|---|
| 1 | **Structured hook log** at `~/.claude-smart/hook.log` (originally PR #28) | Dispatcher's broad `except Exception` was eating silent hook crashes. New `hook_log.log_event` writes one JSON line per fire. Bounded at 5 MB via in-place truncate-to-second-half — no `RotatingFileHandler` sidecar files, JSONL framing preserved |
| 2 | **SessionEnd Assistant anchor** for orphan tool records | `state.unpublished_slice` folds `Assistant_tool` records into the *next* `Assistant` turn's `tools_used`. In autonomous SWE-bench runs where Stop never fires (no `stop_reason=end_turn`), the buffer ends with N orphan tool records and zero anchor → publish payload is just the User prompt. SessionEnd now synthesises a closing Assistant record from whatever transcript text is recoverable, so the tool stream survives the publish |
| 3 | **Env-overridable stride/window** in `events/session_start.py` + **`force_extraction=True` on SessionEnd** | The benchmark needs `CLAUDE_SMART_STRIDE_SIZE=1` so a single-publish session triggers extraction. SessionEnd publish runs synchronously so the snapshot read by the harness sees the extracted rows. Env parsing wrapped in `_int_env` helper with `ValueError` fallback to prevent import-time crashes from garbage values |
| 4 | **`--workers 1`** default + `CLAUDE_SMART_BACKEND_WORKERS` env override + **SessionEnd hook timeout 60s → 300s** | reflexio defaults to `--workers 2` for server deployments — wastes ~1.1 GB RSS for a single-user plugin where SQLite can't accept concurrent writers anyway. Drop to 1. Bump SessionEnd hook timeout so `force_extraction`'s synchronous wait isn't SIGKILLed by Claude Code's 60s default before the agentic extractor LLM call (60-180s on Sonnet) completes |
| 5 | **Defensive coercion** in `hook_log` (`publish_count`) + nested-submodule pointer bump | CodeRabbit findings: `int(publish_count or 0)` now wrapped in `try/except`; nested `reflexio` submodule bumped to current main so standalone clones get up-to-date reflexio |

## Companion PRs

| Repo | PR | Topic |
|--|--|--|
| reflexio-enterprise | [#74](https://github.com/ReflexioAI/reflexio-enterprise/pull/74) | Harness side (uses this PR's env override + sync extraction + forensic log) |
| reflexio | [#65](https://github.com/ReflexioAI/reflexio/pull/65) | Tool-calling support for the claude-code provider |
| reflexio | [#73](https://github.com/ReflexioAI/reflexio/pull/73) | Per-call cosine-similarity score logging in `_vector_rank_rows` (diagnostic) |

## End-to-end validation

Paired `pallets__flask-5014` run with the full stack:

```
Run A: terminated_by=sentinel, 19 turns, 85s, rules_extracted_count=2
Run B: terminated_by=sentinel, 16 turns, 52s, rules_extracted_count=1, cs_injections_count=18
```

Transcript review of Run B confirms the agent followed the playbook's recipe step-by-step:

| Playbook step | Run B tool call |
|--|--|
| "Locate the class with grep" | `grep -n "class Blueprint"` |
| "Read the `__init__`" | `Read blueprints.py:117 + 60 lines` |
| "Insert guard before existing validation" | `Edit blueprints.py` |
| "Verify with `python -c` snippet" | `python -c "from flask import Blueprint; Blueprint('', __name__); ..."` |
| "Run `pytest -q -W ignore::DeprecationWarning`" | **Verbatim string match** |
| "Detour to skip: don't `-k` filter, use `grep FAILED` instead" | `... \| grep "FAILED\|AttributeError"` |

The `-W ignore::DeprecationWarning` flag combination is a verbatim string from the playbook — the agent has no other source for it. Run B was **2× more efficient in tool-call count and 39% faster** in wall-clock vs Run A.

## Test plan

- [x] Full plugin test suite: 287 passed (was 284 → +3 new for defensive-parsing regression coverage). 3 pre-existing `test_install_scripts` failures unchanged on `origin/main`.
- [x] Ruff + pyright clean on every modified file.
- [x] Rebased on current `origin/main` (incorporates #29 codex title filter + #31 codex wrapper improvements).
- [x] CodeRabbit review threads on env-var parsing, `publish_count` coercion, and rotation-race comments all addressed.

## Follow-ups (not in this PR)

- **Rotation race window** in `_maybe_rotate` (CodeRabbit thread): low-frequency risk for single-user-plugin context; follow-up can add `fcntl.flock`. [Discussion](https://github.com/ReflexioAI/claude-smart/pull/30#discussion_r3255601536).
- **Nested reflexio submodule** in claude-smart: bumped to current main here; another bump should follow once reflexio [#65](https://github.com/ReflexioAI/reflexio/pull/65) lands so the tool-plumbing changes flow to standalone clones.
