### PR TITLE
[codex] Harden vanilla OS dependency bootstrap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-smart",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "source": "./plugin",
       "description": "Learns user corrections and project playbooks via reflexio — uses Claude Code itself as the LLM backend (no external API key required)"
     }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dependency-platforms:
+    name: dependency platforms (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Check Python dependency lock
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            if [ "$(uname -m)" != "arm64" ]; then
+              echo "::warning::Skipping macOS runtime sync check because this runner is not Apple Silicon"
+              exit 0
+            fi
+            uv sync --project plugin --locked --dry-run --python 3.12
+          else
+            uv sync --project plugin --locked --dry-run --python 3.12 --python-platform x86_64-pc-windows-msvc
+          fi
+
+      - name: Check dashboard build
+        shell: bash
+        run: |
+          cd plugin/dashboard
+          npm ci
+          npm run build
+
   integration:
     name: integration (${{ matrix.os }}, node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -29,6 +29,8 @@ Tunables read by the plugin at runtime. Most users don't need to touch these —
 | `CLAUDE_SMART_ENABLE_OPTIMIZER` | enabled unless set to `0` | Hook-side env var that controls shared skill optimization and rollups during `SessionStart`. Set it in Claude Code settings, not `~/.reflexio/.env`. |
 | `CLAUDE_SMART_CLI_PATH` | `claude` on Claude Code; Codex compatibility wrapper or `codex` on Codex | Override the executable Reflexio calls for local generation. |
 | `CLAUDE_SMART_STATE_DIR` | `~/.claude-smart/sessions/` | Where the per-session JSONL buffer lives. |
+| `CLAUDE_SMART_NODE_LTS_MAJOR` | `22` | Major version used when the installer downloads private Node.js/npm into `~/.claude-smart/node/current`. |
+| `CLAUDE_SMART_NODE_BASE_URL` | `https://nodejs.org/dist/latest-v${CLAUDE_SMART_NODE_LTS_MAJOR}.x` | Override the Node.js download base URL for tests, mirrors, or recovery. |
 | `CLAUDE_SMART_BACKEND_AUTOSTART` | `1` | Set to `0` to stop the SessionStart hook from spawning the reflexio backend on `localhost:8071`. |
 | `CLAUDE_SMART_DASHBOARD_AUTOSTART` | `1` | Set to `0` to stop the SessionStart hook from spawning the Next.js dashboard on `localhost:3001`. |
 | `CLAUDE_SMART_BACKEND_STOP_ON_END` | `0` | Set to `1` to tear down the backend at `SessionEnd` instead of leaving it long-lived. |
@@ -40,6 +42,42 @@ Tunables read by the plugin at runtime. Most users don't need to touch these —
 claude-smart uses an in-process ONNX embedder (Chroma's `all-MiniLM-L6-v2`, 384-dim, zero-padded to reflexio's 512-dim schema). The model weights are downloaded on first use (~80 MB, cached under `~/.cache/chroma/onnx_models/`) — after that, no network calls for embedding. Runtime cost is a few milliseconds per short document on CPU.
 
 If you still want to use a cloud embedding provider (OpenAI, Gemini, etc.), omit `CLAUDE_SMART_USE_LOCAL_EMBEDDING` and set the corresponding API key in `~/.reflexio/.env` — reflexio will fall back to its standard provider-priority chain.
+
+## Install dependency policy
+
+Vanilla install support means the user has installed the host (`claude` or
+`codex`) and the chosen installer runner (`npx` needs Node, `uvx` needs uv), but
+does not need global Python, uv, Node/npm for plugin runtime, npm packages, or
+embedding model files. The plugin bootstraps runtime dependencies into user
+state:
+
+| Dependency | Installed/managed by | Location |
+| --- | --- | --- |
+| Python 3.12 env and Python packages | `uv sync --locked --python 3.12` | plugin `.venv` |
+| Runtime uv | installer if missing | `~/.local/bin` or `~/.cargo/bin` |
+| Runtime Node.js/npm | installer if missing | `~/.claude-smart/node/current` |
+| Dashboard packages/build | installer or first dashboard start | `plugin/dashboard/node_modules`, `plugin/dashboard/.next` |
+| Local embedding model | Chroma/ONNX on first use | `~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/` |
+
+Supported native vanilla targets are Apple Silicon macOS 14+ and Windows x64;
+Linux remains supported when host hooks run locally and wheels are available.
+Intel Mac, macOS 13 or older, and Windows ARM should fail before dependency sync
+with a visible unsupported-platform message because the current ML dependency
+stack does not publish a complete native wheel set for those targets.
+
+When changing dependencies, verify:
+
+```bash
+uv sync --project plugin --locked --dry-run --python 3.12 --python-platform x86_64-pc-windows-msvc
+uv sync --project plugin --locked --dry-run --python 3.12
+cd plugin/dashboard && npm ci && npm run build
+```
+
+Also check the published package surface:
+
+```bash
+npm pack --dry-run --json
+```
 
 ## Public terminology and storage names
 
@@ -189,7 +227,7 @@ Before running `make release`:
   ```bash
   cd reflexio && git pull && cd .. && git add reflexio && git commit -m "Bump reflexio submodule"
   ```
-- [ ] `npm publish --dry-run` tarball is still ~13 KB / 4 files — if it's larger, `files` in `package.json` is letting extra content through.
+- [ ] `npm pack --dry-run --json` includes the root wrapper, marketplace metadata, plugin payload, dashboard sources, README, and LICENSE, and excludes `.venv`, `node_modules`, `.next/cache`, and Python caches.
 - [ ] If you touched `pyproject.toml` dependencies, `uv build` succeeds locally and the wheel's `METADATA` doesn't carry a `file://` path dep (common failure when `[tool.uv.sources]` leaks into the published wheel).
 
 ## Common failures and fixes
@@ -296,6 +334,8 @@ uv run --project plugin claude-smart install --host codex
 ```
 
 Then fully restart Codex so hooks reload. The command installs `claude-smart` into `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/`, enables `[plugins."claude-smart@reflexioai"]`, enables Codex's hook feature flags, and seeds the per-hook trust entries in `~/.codex/config.toml`; `/plugins` should show it as installed from the **ReflexioAI** marketplace. Running `codex features enable plugin_hooks` by itself is not enough because it does not install the plugin or trust the individual hook entries.
+
+The packaged Node installer path (`node bin/claude-smart.js install --host codex`, or published `npx claude-smart install --host codex`) additionally bootstraps private Node/npm plus the uv-managed Python runtime, builds the dashboard, and patches Codex hooks to the Node wrapper. The Python `uv run` path is intentionally for local development from an already-prepared checkout.
 
 If you install or toggle `claude-smart` manually from `/plugins`, rerun `npx claude-smart install --host codex` (or the `uv run` equivalent) once afterward so the hook feature flags, plugin cache, and claude-smart hook trust state are re-prepared.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ claude plugin install claude-smart@reflexioai
 The plugin Setup hook installs its own `uv`, Python 3.12 environment, and
 private Node.js/npm runtime under `~/.claude-smart/` when they are missing, so
 you do not need to install Python or Node globally for the plugin/dashboard.
+On native Windows, Claude Code hooks still need a Git Bash-compatible `bash`
+until Claude Code exposes a single cross-platform hook command shape.
 
 To uninstall:
 
@@ -121,6 +123,11 @@ Then fully quit and reopen Codex so hooks reload.
 
 Requires the `codex` CLI on `PATH` and Node.js (for `npx`).
 
+The `npx` command needs Node.js only to launch the installer. The installed
+plugin uses a private Node.js/npm runtime and a `uv`-managed Python 3.12
+environment under `~/.claude-smart/`, so hooks and the dashboard do not depend
+on global Python, uv, Node, or npm after install.
+
 To uninstall:
 
 ```bash
@@ -132,6 +139,19 @@ Restart Codex after uninstalling. Learned data under `~/.reflexio/` and `~/.clau
 Developing the plugin itself? See [DEVELOPER.md](./DEVELOPER.md#developing-locally) for what the installer does, manual toggles via `/plugins`, and clone-based development.
 
 > **Not supported:** Claude Code Cowork, claude.ai/code web, or remote Codex environments without local plugin hooks — they run outside your local machine, so the local backend/dashboard and `~/.reflexio/` aren't reachable.
+
+### Vanilla OS support
+
+| Platform | Status | Notes |
+| --- | --- | --- |
+| Apple Silicon macOS 14+ | Supported | Runtime bootstrap installs private Node/npm, uv, Python 3.12 deps, and dashboard deps. |
+| Windows x64 | Supported | Runtime bootstrap uses PowerShell for uv/Node archive extraction and patches Codex hooks to the Node wrapper. |
+| Linux | Supported when host hooks are local | Existing Linux behavior is preserved; install coverage depends on available Python wheels. |
+| Intel Mac, macOS 13 or older, Windows ARM | Not supported | Current local embedding/ML dependencies do not publish a complete native wheel set for these targets. |
+
+Network access is required during first install for npm, PyPI/uv, Node.js, and
+the first local embedding model download. The ONNX model cache lives at
+`~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/`.
 
 ---
 
@@ -216,6 +236,7 @@ Advanced users can tune claude-smart via environment variables — see [DEVELOPE
 | `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/` | Codex's cached install of the `claude-smart` plugin from the `ReflexioAI` marketplace. |
 | `~/.reflexio/plugin-root` | Self-healed symlink to the active plugin dir (managed by `ensure-plugin-root.sh` — written on install, refreshed each `SessionStart`). Claude Code slash commands and Codex shell-command helpers resolve through it, so don't delete it; if you do, the next session will recreate it. |
 | `~/.claude-smart/sessions/{session_id}.jsonl` | Per-session buffer. User turns, assistant turns, tool invocations, `{"published_up_to": N}` watermarks. Safe to inspect and safe to delete — everything past the latest watermark has already been written to reflexio's DB. |
+| `~/.claude-smart/node/current/` | Private Node.js/npm runtime used by hooks and the dashboard after install. |
 | `~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/` | Cached ONNX weights (~86 MB, downloaded once). Delete to force a re-download. |
 
 For troubleshooting, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
   </a>
   <a href="plugin/pyproject.toml">
-    <img src="https://img.shields.io/badge/version-0.2.28-green.svg" alt="Version">
+    <img src="https://img.shields.io/badge/version-0.2.29-green.svg" alt="Version">
   </a>
   <a href="plugin/pyproject.toml">
     <img src="https://img.shields.io/badge/python-%3E%3D3.12-brightgreen.svg" alt="Python">

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -17,13 +17,18 @@ const {
   appendFileSync,
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
+  renameSync,
   rmSync,
+  statSync,
+  symlinkSync,
   writeFileSync,
 } = require("fs");
 const https = require("https");
-const { homedir, tmpdir } = require("os");
+const { arch, homedir, platform, release, tmpdir } = require("os");
 const { dirname, join } = require("path");
 
 const DEFAULT_MARKETPLACE_SOURCE = "ReflexioAI/claude-smart";
@@ -32,6 +37,8 @@ const CODEX_MARKETPLACE_NAME = "reflexioai";
 const CODEX_MARKETPLACE_DISPLAY_NAME = "ReflexioAI";
 const CODEX_PLUGIN_ID = `claude-smart@${CODEX_MARKETPLACE_NAME}`;
 const REFLEXIO_ENV_PATH = join(homedir(), ".reflexio", ".env");
+const REFLEXIO_DIR = join(homedir(), ".reflexio");
+const CLAUDE_SMART_STATE_DIR = join(homedir(), ".claude-smart");
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
 const PACKAGE_ROOT = dirname(dirname(__filename));
 const CODEX_MARKETPLACE_DIR = join(
@@ -193,8 +200,132 @@ function seedReflexioEnv() {
   return missing;
 }
 
+function findClaudeCodePluginRoot() {
+  const cacheRoot = join(homedir(), ".claude", "plugins", "cache", CODEX_MARKETPLACE_NAME, "claude-smart");
+  const candidates = [];
+  try {
+    for (const entry of readdirSync(cacheRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const candidate = join(cacheRoot, entry.name);
+      if (
+        existsSync(join(candidate, "pyproject.toml")) &&
+        existsSync(join(candidate, "scripts", "smart-install.sh"))
+      ) {
+        candidates.push(candidate);
+      }
+    }
+  } catch {
+    // Fall through to marketplace/package fallbacks.
+  }
+  candidates.sort((a, b) => {
+    try {
+      return statSync(b).mtimeMs - statSync(a).mtimeMs;
+    } catch {
+      return 0;
+    }
+  });
+  const fallbacks = [
+    join(homedir(), ".claude", "plugins", "marketplaces", CODEX_MARKETPLACE_NAME, "plugin"),
+    join(PACKAGE_ROOT, "plugin"),
+  ];
+  for (const candidate of [...candidates, ...fallbacks]) {
+    if (
+      existsSync(join(candidate, "pyproject.toml")) &&
+      existsSync(join(candidate, "scripts", "smart-install.sh"))
+    ) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function forcePluginRoot(pluginRoot) {
+  mkdirSync(REFLEXIO_DIR, { recursive: true });
+  const link = join(REFLEXIO_DIR, "plugin-root");
+  try {
+    const existing = lstatSync(link);
+    if (existing.isSymbolicLink() || existing.isFile()) {
+      rmSync(link, { force: true });
+    } else {
+      throw new Error(`refusing to replace non-symlink plugin-root at ${link}`);
+    }
+  } catch (err) {
+    if (err && err.code !== "ENOENT") throw err;
+  }
+  try {
+    // Use a symlink when possible so slash commands follow the active plugin root.
+    symlinkSync(pluginRoot, link, isWindows() ? "junction" : "dir");
+  } catch {
+    writeFileSync(join(REFLEXIO_DIR, "plugin-root.txt"), `${pluginRoot}\n`);
+  }
+}
+
+async function bootstrapClaudeCodeInstall() {
+  const pluginRoot = findClaudeCodePluginRoot();
+  if (!pluginRoot) {
+    throw new Error("could not locate installed Claude Code plugin root after install");
+  }
+  forcePluginRoot(pluginRoot);
+  const bash = resolveCommand(isWindows() ? ["bash.exe", "bash"] : ["bash"]);
+  if (!bash) {
+    throw new Error("bash is required to bootstrap claude-smart dependencies");
+  }
+  const code = await runChecked(bash, [join(pluginRoot, "scripts", "smart-install.sh")], {
+    cwd: pluginRoot,
+  });
+  if (code !== 0) {
+    throw new Error(`smart-install.sh failed in ${pluginRoot}`);
+  }
+  const failureMarker = join(CLAUDE_SMART_STATE_DIR, "install-failed");
+  if (existsSync(failureMarker)) {
+    const reason = readFileSync(failureMarker, "utf8").trim() || "unknown error";
+    throw new Error(reason);
+  }
+  return pluginRoot;
+}
+
 function isWindows() {
-  return process.platform === "win32";
+  return currentPlatform() === "win32";
+}
+
+function currentPlatform() {
+  return process.env.CLAUDE_SMART_TEST_PLATFORM || platform();
+}
+
+function currentArch() {
+  return process.env.CLAUDE_SMART_TEST_ARCH || arch();
+}
+
+function currentRelease() {
+  return process.env.CLAUDE_SMART_TEST_RELEASE || release();
+}
+
+function platformSupportError() {
+  const os = currentPlatform();
+  const cpu = currentArch();
+  if (os === "darwin") {
+    if (cpu !== "arm64") {
+      return "claude-smart currently supports Apple Silicon macOS 14+ only; Intel Mac is not supported because native ML wheels are unavailable.";
+    }
+    const darwinMajor = Number.parseInt(currentRelease().split(".")[0] || "0", 10);
+    if (!Number.isFinite(darwinMajor) || darwinMajor < 23) {
+      return "claude-smart currently supports macOS 14+ on Apple Silicon; macOS 13 and older are not supported because native ML wheels are unavailable.";
+    }
+    return null;
+  }
+  if (os === "win32") {
+    if (cpu !== "x64") {
+      return "claude-smart currently supports Windows x64 only; Windows ARM is not supported because native ML wheels are unavailable.";
+    }
+    return null;
+  }
+  if (os === "linux") return null;
+  return "claude-smart currently supports Apple Silicon macOS 14+, Windows x64, and Linux for vanilla installs.";
+}
+
+function assertSupportedRuntimePlatform() {
+  const message = platformSupportError();
+  if (message) throw new Error(message);
 }
 
 function runChecked(command, args, options = {}) {
@@ -245,7 +376,7 @@ function downloadFile(url, dest) {
 function resolveCommand(names, extraDirs = []) {
   const pathParts = [
     ...extraDirs,
-    ...(process.env.PATH || "").split(process.platform === "win32" ? ";" : ":"),
+    ...(process.env.PATH || "").split(isWindows() ? ";" : ":"),
   ].filter(Boolean);
   for (const dir of pathParts) {
     for (const name of names) {
@@ -265,19 +396,26 @@ function privateNodeBinDirs() {
   return [join(root, "bin"), root];
 }
 
+function resolvePrivateCommand(names) {
+  for (const dir of privateNodeBinDirs()) {
+    for (const name of names) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
 function resolvePrivateNode() {
-  return resolveCommand(isWindows() ? ["node.exe", "node"] : ["node"], privateNodeBinDirs());
+  return resolvePrivateCommand(isWindows() ? ["node.exe", "node"] : ["node"]);
 }
 
 function resolvePrivateNpm() {
-  return resolveCommand(
-    isWindows() ? ["npm.cmd", "npm.exe", "npm"] : ["npm"],
-    privateNodeBinDirs(),
-  );
+  return resolvePrivateCommand(isWindows() ? ["npm.cmd", "npm.exe", "npm"] : ["npm"]);
 }
 
 function runtimeEnv(extraDirs = []) {
-  const delimiter = process.platform === "win32" ? ";" : ":";
+  const delimiter = isWindows() ? ";" : ":";
   const dirs = [
     ...extraDirs,
     ...privateNodeBinDirs(),
@@ -290,14 +428,35 @@ function runtimeEnv(extraDirs = []) {
   };
 }
 
-async function ensureWindowsPrivateNode() {
-  if (!isWindows()) return null;
+function nodeArchiveSpec() {
+  const os = currentPlatform();
+  const cpu = currentArch();
+  let nodeOs = null;
+  let archiveExt = null;
+  if (os === "darwin") {
+    nodeOs = "darwin";
+    archiveExt = "tar.gz";
+  } else if (os === "win32") {
+    nodeOs = "win";
+    archiveExt = "zip";
+  } else if (os === "linux") {
+    nodeOs = "linux";
+    archiveExt = "tar.gz";
+  } else {
+    throw new Error(`unsupported OS for private Node.js install: ${os}`);
+  }
+  const nodeArch = cpu === "arm64" ? "arm64" : "x64";
+  return { nodeOs, nodeArch, archiveExt };
+}
+
+async function ensurePrivateNode() {
   const existing = resolvePrivateNode();
   const existingNpm = resolvePrivateNpm();
   if (existing && existingNpm) return { node: existing, npm: existingNpm };
 
+  assertSupportedRuntimePlatform();
   const major = process.env.CLAUDE_SMART_NODE_LTS_MAJOR || "22";
-  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  const { nodeOs, nodeArch, archiveExt } = nodeArchiveSpec();
   const baseUrl = process.env.CLAUDE_SMART_NODE_BASE_URL || `https://nodejs.org/dist/latest-v${major}.x`;
   const nodeRoot = join(homedir(), ".claude-smart", "node");
   const temp = join(tmpdir(), `claude-smart-node-${process.pid}`);
@@ -311,8 +470,8 @@ async function ensureWindowsPrivateNode() {
   const match = sums
     .split(/\r?\n/)
     .map((line) => line.trim().split(/\s+/))
-    .find((parts) => parts[1] && new RegExp(`^node-v[^ ]+-win-${arch}\\.zip$`).test(parts[1]));
-  if (!match) throw new Error(`could not resolve Node.js win-${arch} archive from ${baseUrl}`);
+    .find((parts) => parts[1] && new RegExp(`^node-v[^ ]+-${nodeOs}-${nodeArch}\\.${archiveExt.replace(/\./g, "\\.")}$`).test(parts[1]));
+  if (!match) throw new Error(`could not resolve Node.js ${nodeOs}-${nodeArch} archive from ${baseUrl}`);
   const [expectedHash, archiveName] = match;
   const archivePath = join(temp, archiveName);
   await downloadFile(`${baseUrl}/${archiveName}`, archivePath);
@@ -321,26 +480,56 @@ async function ensureWindowsPrivateNode() {
     throw new Error(`Node.js checksum verification failed for ${archiveName}`);
   }
 
-  const powershell = resolveCommand(["powershell.exe", "powershell", "pwsh"]);
-  if (!powershell) throw new Error("PowerShell is required to extract private Node.js on Windows");
   const extractDir = join(temp, "extract");
   mkdirSync(extractDir, { recursive: true });
-  const code = await runChecked(
-    powershell,
-    [
-      "-NoProfile",
-      "-ExecutionPolicy",
-      "Bypass",
-      "-Command",
-      "$ProgressPreference='SilentlyContinue'; Expand-Archive -LiteralPath $env:ARCHIVE_PATH -DestinationPath $env:DEST_DIR -Force",
-    ],
-    { env: { ...process.env, ARCHIVE_PATH: archivePath, DEST_DIR: extractDir } },
-  );
+  let code = 0;
+  if (archiveExt === "zip") {
+    const powershell = resolveCommand(["powershell.exe", "powershell", "pwsh"]);
+    if (!powershell) throw new Error("PowerShell is required to extract private Node.js on Windows");
+    code = await runChecked(
+      powershell,
+      [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "$ProgressPreference='SilentlyContinue'; Expand-Archive -LiteralPath $env:ARCHIVE_PATH -DestinationPath $env:DEST_DIR -Force",
+      ],
+      { env: { ...process.env, ARCHIVE_PATH: archivePath, DEST_DIR: extractDir } },
+    );
+  } else {
+    const tar = resolveCommand(["tar"]);
+    if (!tar) throw new Error("tar is required to extract private Node.js on macOS");
+    code = await runChecked(tar, ["-xzf", archivePath, "-C", extractDir]);
+  }
   if (code !== 0) throw new Error(`Node.js archive extraction failed for ${archiveName}`);
-  const extracted = join(extractDir, archiveName.replace(/\.zip$/, ""));
+  const extracted = join(extractDir, archiveName.replace(/\.zip$/, "").replace(/\.tar\.gz$/, ""));
   const current = privateNodeRoot();
-  rmSync(current, { recursive: true, force: true });
-  cpSync(extracted, current, { recursive: true, force: true });
+  // Atomic swap with rollback: move existing `current` to a backup first
+  // so a non-EXDEV failure (EACCES, EBUSY) does not leave the user with no
+  // private node at all. EXDEV (cross-device) falls back to cpSync.
+  const backup = `${current}.prev.${process.pid}`;
+  rmSync(backup, { recursive: true, force: true });
+  const hadCurrent = existsSync(current);
+  if (hadCurrent) renameSync(current, backup);
+  try {
+    try {
+      renameSync(extracted, current);
+    } catch (err) {
+      if (!err || err.code !== "EXDEV") throw err;
+      cpSync(extracted, current, {
+        recursive: true,
+        force: true,
+        verbatimSymlinks: true,
+      });
+    }
+  } catch (err) {
+    if (hadCurrent) {
+      try { renameSync(backup, current); } catch { /* leave backup for manual recovery */ }
+    }
+    throw err;
+  }
+  rmSync(backup, { recursive: true, force: true });
   rmSync(temp, { recursive: true, force: true });
 
   const node = resolvePrivateNode();
@@ -356,21 +545,33 @@ function resolveUv() {
   ]);
 }
 
-async function ensureWindowsUv() {
+async function ensureUv() {
   let uv = resolveUv();
   if (uv) return uv;
-  const powershell = resolveCommand(["powershell.exe", "powershell", "pwsh"]);
-  if (!powershell) throw new Error("PowerShell is required to install uv on Windows");
-  const code = await runChecked(powershell, [
-    "-NoProfile",
-    "-ExecutionPolicy",
-    "Bypass",
-    "-Command",
-    "irm https://astral.sh/uv/install.ps1 | iex",
-  ]);
-  if (code !== 0) throw new Error("uv install via PowerShell failed");
+  assertSupportedRuntimePlatform();
+  let code = 0;
+  if (isWindows()) {
+    const powershell = resolveCommand(["powershell.exe", "powershell", "pwsh"]);
+    if (!powershell) throw new Error("PowerShell is required to install uv on Windows");
+    code = await runChecked(powershell, [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      "irm https://astral.sh/uv/install.ps1 | iex",
+    ]);
+    if (code !== 0) throw new Error("uv install via PowerShell failed");
+  } else {
+    const installer = join(homedir(), ".claude-smart", "uv-install.sh");
+    mkdirSync(dirname(installer), { recursive: true });
+    await downloadFile("https://astral.sh/uv/install.sh", installer);
+    const sh = resolveCommand(["sh"]);
+    if (!sh) throw new Error("sh is required to install uv on macOS");
+    code = await runChecked(sh, [installer]);
+    if (code !== 0) throw new Error("uv install failed");
+  }
   uv = resolveUv();
-  if (!uv) throw new Error("uv install reported success but uv.exe was not found");
+  if (!uv) throw new Error("uv install reported success but uv was not found");
   return uv;
 }
 
@@ -378,50 +579,83 @@ function quoteCommandPart(part) {
   return `"${String(part).replace(/"/g, '\\"')}"`;
 }
 
-function patchCodexHooksForWindows(pluginRoot, nodePath) {
+function patchCodexHooksForNode(pluginRoot, nodePath) {
   const hookPath = join(pluginRoot, "hooks", "codex-hooks.json");
   const parsed = JSON.parse(readFileSync(hookPath, "utf8"));
   const runner = join(pluginRoot, "scripts", "codex-hook.js");
   const command = (...args) => [nodePath, runner, ...args].map(quoteCommandPart).join(" ");
-  const sessionHooks = parsed.hooks.SessionStart?.[0]?.hooks || [];
-  if (sessionHooks[0]) sessionHooks[0].command = command("ensure-root");
-  if (sessionHooks[1]) sessionHooks[1].command = command("backend");
-  if (sessionHooks[2]) sessionHooks[2].command = command("dashboard");
-  if (sessionHooks[3]) sessionHooks[3].command = command("hook", "session-start");
-  const userPrompt = parsed.hooks.UserPromptSubmit?.[0]?.hooks?.[0];
-  if (userPrompt) userPrompt.command = command("hook", "user-prompt");
-  const postTool = parsed.hooks.PostToolUse?.[0]?.hooks?.[0];
-  if (postTool) postTool.command = command("hook", "post-tool");
-  const stop = parsed.hooks.Stop?.[0]?.hooks?.[0];
-  if (stop) stop.command = command("hook", "stop");
+  // Dispatch by command content rather than index — entries can be added or
+  // reordered (e.g. the SessionStart install hook at index 0) without
+  // breaking the patch. Entries that must run as bash (smart-install.sh)
+  // are left untouched.
+  const patchOne = (original) => {
+    if (typeof original !== "string") return original;
+    if (original.includes("smart-install.sh")) return original;
+    if (original.includes("ensure-plugin-root.sh")) return command("ensure-root");
+    if (original.includes("backend-service.sh")) return command("backend");
+    if (original.includes("dashboard-service.sh")) return command("dashboard");
+    // Match `hook_entry.sh" codex session-start` and similar — between
+    // the script name, the host token, and the subcommand there may be
+    // closing quotes plus whitespace, so allow both as separators.
+    const hookMatch = original.match(/hook_entry\.sh\b[\s"']+(?:codex|claude-code)[\s"']+([\w-]+)/);
+    if (hookMatch) return command("hook", hookMatch[1]);
+    return original;
+  };
+  for (const event of Object.keys(parsed.hooks || {})) {
+    for (const block of parsed.hooks[event] || []) {
+      for (const hook of block.hooks || []) {
+        hook.command = patchOne(hook.command);
+      }
+    }
+  }
   writeFileSync(hookPath, JSON.stringify(parsed, null, 2) + "\n");
 }
 
-function ensureWindowsPluginRoot(pluginRoot) {
+function ensurePluginRoot(pluginRoot) {
   const reflexioDir = dirname(REFLEXIO_ENV_PATH);
   const link = join(reflexioDir, "plugin-root");
   mkdirSync(reflexioDir, { recursive: true });
   rmSync(link, { recursive: true, force: true });
   try {
-    require("fs").symlinkSync(pluginRoot, link, "junction");
+    require("fs").symlinkSync(pluginRoot, link, isWindows() ? "junction" : "dir");
   } catch {
     writeFileSync(join(reflexioDir, "plugin-root.txt"), `${pluginRoot}\n`);
   }
 }
 
-async function bootstrapWindowsCodexCache(pluginRoot) {
-  if (!isWindows()) return;
-  process.stdout.write("Preparing Windows Codex runtime for claude-smart hooks...\n");
-  const nodeRuntime = await ensureWindowsPrivateNode();
-  patchCodexHooksForWindows(pluginRoot, nodeRuntime.node);
-  ensureWindowsPluginRoot(pluginRoot);
-  const uv = await ensureWindowsUv();
+async function bootstrapPluginRuntime(pluginRoot) {
+  assertSupportedRuntimePlatform();
+  process.stdout.write("Preparing claude-smart runtime for hooks...\n");
+  const nodeRuntime = await ensurePrivateNode();
+  patchCodexHooksForNode(pluginRoot, nodeRuntime.node);
+  ensurePluginRoot(pluginRoot);
+  const uv = await ensureUv();
   const env = runtimeEnv([dirname(uv), ...privateNodeBinDirs()]);
+  const pyprojectPath = join(pluginRoot, "pyproject.toml");
+  const pyproject = existsSync(pyprojectPath) ? readFileSync(pyprojectPath, "utf8") : "";
+  if (/^\s*\[tool\.uv\.sources\]\s*$/m.test(pyproject)) {
+    const lockCode = await runChecked(
+      uv,
+      ["lock", "--quiet"],
+      { cwd: pluginRoot, env },
+    );
+    if (lockCode !== 0) throw new Error(`uv lock failed in ${pluginRoot}`);
+  }
   let code = await runChecked(
     uv,
     ["sync", "--locked", "--python", "3.12", "--quiet"],
     { cwd: pluginRoot, env },
   );
+  if (code !== 0) {
+    process.stderr.write(
+      `warning: quiet uv sync failed in ${pluginRoot}; retrying with full output.\n`,
+    );
+    code = await runChecked(
+      uv,
+      ["sync", "--locked", "--python", "3.12"],
+      { cwd: pluginRoot, env },
+    );
+  }
   if (code !== 0) throw new Error(`uv sync failed in ${pluginRoot}`);
 
   const dashboardDir = join(pluginRoot, "dashboard");
@@ -455,9 +689,10 @@ function printHelp() {
       `  1. Copies the bundled marketplace to ${CODEX_MARKETPLACE_DIR}`,
       "  2. codex plugin marketplace add <copied marketplace>",
       "  3. codex features enable hooks && codex features enable plugin_hooks",
-      "  4. Installs claude-smart into Codex's plugin cache and enables it",
-      "  5. Trusts and enables claude-smart hook entries in ~/.codex/config.toml",
-      "  6. Restart Codex.",
+      "  4. Installs private Node/npm, uv, Python deps, and dashboard deps as needed",
+      "  5. Installs claude-smart into Codex's plugin cache and enables it",
+      "  6. Trusts and enables claude-smart hook entries in ~/.codex/config.toml",
+      "  7. Restart Codex.",
       "",
       "Update:",
       "  npx claude-smart update                        Update to the latest version",
@@ -950,11 +1185,23 @@ async function runInstall(args) {
       `Seeded ${REFLEXIO_ENV_PATH} with ${added.join(", ")}.\n`,
     );
   }
+  try {
+    const pluginRoot = await bootstrapClaudeCodeInstall();
+    process.stdout.write(`Prepared claude-smart runtime at ${pluginRoot}.\n`);
+  } catch (err) {
+    process.stderr.write(
+      `error: claude-smart installed, but dependency bootstrap failed: ${err && err.message ? err.message : err}\n`,
+    );
+    process.stderr.write(
+      "Fix the issue above, then run /claude-smart:restart or restart Claude Code to retry.\n",
+    );
+    process.exit(1);
+  }
 
   process.stdout.write(
     [
       "",
-      "claude-smart installed. Restart Claude Code in your project.",
+      "claude-smart installed and dependencies are prepared. Restart Claude Code in your project.",
       "The reflexio backend and dashboard auto-start on session start.",
       "Opt out with CLAUDE_SMART_BACKEND_AUTOSTART=0 or CLAUDE_SMART_DASHBOARD_AUTOSTART=0.",
       "",
@@ -1009,7 +1256,7 @@ async function runInstallCodex() {
   try {
     cacheDir = installCodexPluginCache(join(marketplaceRoot, CODEX_MARKETPLACE_PLUGIN_PATH));
     process.stdout.write(`Installed Codex plugin cache at ${cacheDir}.\n`);
-    await bootstrapWindowsCodexCache(cacheDir);
+    await bootstrapPluginRuntime(cacheDir);
   } catch (err) {
     process.stderr.write(
       `error: automatic Codex plugin install failed: ${err && err.message ? err.message : err}\n`,
@@ -1113,7 +1360,18 @@ async function main() {
   process.exit(1);
 }
 
-main().catch((err) => {
-  process.stderr.write(`claude-smart: ${err && err.message ? err.message : err}\n`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(`claude-smart: ${err && err.message ? err.message : err}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  assertSupportedRuntimePlatform,
+  bootstrapPluginRuntime,
+  ensurePrivateNode,
+  ensureUv,
+  patchCodexHooksForNode,
+  platformSupportError,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Self-improving Claude Code plugin — learns from corrections via reflexio",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Self-improving Claude Code plugin — learns from corrections across sessions via reflexio",
   "author": {
     "name": "Yi Lu"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Self-improving coding assistant plugin — learns from corrections across sessions via reflexio",
   "author": {
     "name": "Yi Lu"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -16,6 +16,10 @@ under `~/.claude-smart/` when they are missing. If Node.js is already installed,
 `npx claude-smart install` is equivalent; if uv is already installed,
 `uvx claude-smart install` is equivalent.
 
+Supported vanilla native targets are Apple Silicon macOS 14+ and Windows x64.
+Intel Mac, macOS 13 or older, and Windows ARM fail early because the local
+embedding/ML dependency stack does not provide a complete native wheel set.
+
 Then restart Claude Code.
 
 ## Uninstall

--- a/plugin/hooks/codex-hooks.json
+++ b/plugin/hooks/codex-hooks.json
@@ -7,6 +7,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/smart-install.sh\" || true",
+            "timeout": 300
+          },
+          {
+            "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; [ -z \"$_R\" ] && _R=$(ls -dt \"$HOME/.codex/plugins/cache/reflexioai/claude-smart\"/*/ 2>/dev/null | head -n 1); [ -n \"$_R\" ] && . \"${_R%/}/scripts/_codex_env.sh\" && bash \"$_R/scripts/ensure-plugin-root.sh\" \"$_R\" || true",
             "timeout": 10
           },

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -19,6 +19,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/smart-install.sh\"",
+            "timeout": 300
+          }
+        ]
+      },
+      {
+        "matcher": "startup|clear|compact|resume",
+        "hooks": [
+          {
+            "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/reflexioai/plugin\"; bash \"$_R/scripts/ensure-plugin-root.sh\" \"$_R\" || true",
             "timeout": 10
           },

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-smart"
-version = "0.2.28"
+version = "0.2.29"
 description = "Self-improving Claude Code plugin — learns from corrections via reflexio"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/plugin/scripts/cli.sh
+++ b/plugin/scripts/cli.sh
@@ -32,9 +32,33 @@ if [ -f "$FAILURE_MARKER" ]; then
 fi
 
 if ! command -v uv >/dev/null 2>&1; then
-  echo "claude-smart: 'uv' not found on PATH." >&2
-  echo "Install it from https://docs.astral.sh/uv/ or restart Claude Code so the Setup hook can install it." >&2
-  exit 1
+  # Self-heal: the Setup/SessionStart hook may have been skipped (trust
+  # prompt declined, plugin enabled mid-session, etc.) leaving the install
+  # half-done. Run smart-install.sh inline so the user does not have to
+  # restart Claude Code just to recover.
+  # Guard against recursion: if smart-install.sh ever shells back through
+  # this wrapper (e.g. a future migration step) we must not loop forever.
+  if [ "${CLAUDE_SMART_BOOTSTRAPPING:-}" = "1" ]; then
+    echo "claude-smart: bootstrap recursion detected; aborting." >&2
+    exit 1
+  fi
+  if [ -x "$PLUGIN_ROOT/scripts/smart-install.sh" ]; then
+    echo "claude-smart: 'uv' not found — bootstrapping dependencies (~1-3 min on first install)..." >&2
+    CLAUDE_SMART_BOOTSTRAPPING=1 bash "$PLUGIN_ROOT/scripts/smart-install.sh" >&2
+    claude_smart_prepend_astral_bins
+    claude_smart_prepend_node_bins
+  fi
+  if ! command -v uv >/dev/null 2>&1; then
+    if [ -f "$FAILURE_MARKER" ]; then
+      msg="$(cat "$FAILURE_MARKER" 2>/dev/null || echo "unknown error")"
+      echo "claude-smart: install failed: $msg" >&2
+      echo "Fix the underlying issue and delete $FAILURE_MARKER to retry." >&2
+    else
+      echo "claude-smart: 'uv' not found on PATH after bootstrap attempt." >&2
+      echo "Install it from https://docs.astral.sh/uv/ or rerun $PLUGIN_ROOT/scripts/smart-install.sh manually." >&2
+    fi
+    exit 1
+  fi
 fi
 
 exec uv run --project "$PLUGIN_ROOT" --quiet python -m claude_smart.cli "$@"

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -20,16 +20,119 @@ REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 
 MARKER_DIR="$HOME/.claude-smart"
 FAILURE_MARKER="$MARKER_DIR/install-failed"
+SUCCESS_MARKER="$MARKER_DIR/install-complete"
+INSTALL_LOCK="$MARKER_DIR/install.lock"
 mkdir -p "$MARKER_DIR"
+
+# Serialize concurrent installer runs (SessionStart hook + slash-command
+# self-heal can both invoke this script). Wait for the active installer
+# rather than returning early, otherwise callers can re-check uv before
+# the first install has finished and report a false missing-dependency error.
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$INSTALL_LOCK"
+  if ! flock 9; then
+    echo "[claude-smart] install lock failed; continuing without serialization" >&2
+    echo '{"continue":true,"suppressOutput":true}'
+    exit 0
+  fi
+fi
+
 rm -f "$FAILURE_MARKER"
 
 write_failure() {
   local reason
   reason="$1"
   printf '%s\n' "$reason" > "$FAILURE_MARKER"
+  rm -f "$SUCCESS_MARKER"
   echo "[claude-smart] install failed: $reason" >&2
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
+}
+
+fingerprint_file() {
+  local path
+  path="$1"
+  if [ -f "$path" ]; then
+    cksum "$path" 2>/dev/null | awk '{print $1 ":" $2}'
+  else
+    printf 'missing\n'
+  fi
+}
+
+install_fingerprint() {
+  printf 'plugin_root=%s\n' "$PLUGIN_ROOT"
+  printf 'smart_install=%s\n' "$(fingerprint_file "$HERE/smart-install.sh")"
+  printf 'pyproject=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/pyproject.toml")"
+  printf 'uv_lock=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/uv.lock")"
+  # Resolved python interpreter — catches a system upgrade (3.12.4 → 3.12.5)
+  # that would otherwise let install_complete return true against a venv
+  # built against a now-deleted interpreter.
+  if command -v uv >/dev/null 2>&1; then
+    printf 'python=%s\n' "$(uv python find 3.12 2>/dev/null || echo missing)"
+  else
+    printf 'python=no-uv\n'
+  fi
+  if [ -d "$PLUGIN_ROOT/dashboard" ]; then
+    printf 'dashboard_pkg=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/dashboard/package.json")"
+    printf 'dashboard_lock=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/dashboard/package-lock.json")"
+  else
+    printf 'dashboard_pkg=none\n'
+    printf 'dashboard_lock=none\n'
+  fi
+}
+
+install_complete() {
+  [ -f "$SUCCESS_MARKER" ] || return 1
+  [ "$(cat "$SUCCESS_MARKER" 2>/dev/null || true)" = "$(install_fingerprint)" ] || return 1
+  command -v uv >/dev/null 2>&1 || return 1
+  [ -d "$PLUGIN_ROOT/.venv" ] || return 1
+  [ -f "$HOME/.reflexio/.env" ] || return 1
+  grep -q '^CLAUDE_SMART_USE_LOCAL_CLI=' "$HOME/.reflexio/.env" || return 1
+  grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$HOME/.reflexio/.env" || return 1
+  if [ -d "$PLUGIN_ROOT/dashboard" ]; then
+    [ -d "$PLUGIN_ROOT/dashboard/.next" ] || [ -f "$MARKER_DIR/dashboard-build.pid" ] || [ -f "$(claude_smart_dashboard_unavailable_marker)" ] || return 1
+  fi
+  return 0
+}
+
+write_success_marker() {
+  install_fingerprint > "$SUCCESS_MARKER"
+}
+
+preflight_supported_runtime_platform() {
+  local os_name machine darwin_major
+  os_name="$(uname -s 2>/dev/null || echo unknown)"
+  machine="$(uname -m 2>/dev/null || echo unknown)"
+  case "$os_name" in
+    Darwin*)
+      if [ "$machine" != "arm64" ]; then
+        write_failure "claude-smart currently supports Apple Silicon macOS 14+ only; Intel Mac is not supported because native ML wheels are unavailable."
+      fi
+      darwin_major="$(uname -r 2>/dev/null | awk -F. '{print $1}')"
+      case "$darwin_major" in
+        ''|*[!0-9]*)
+          write_failure "claude-smart could not determine the macOS version; Apple Silicon macOS 14+ is required."
+          ;;
+      esac
+      if [ "$darwin_major" -lt 23 ]; then
+        write_failure "claude-smart currently supports macOS 14+ on Apple Silicon; macOS 13 and older are not supported because native ML wheels are unavailable."
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      case "$machine" in
+        x86_64|amd64) : ;;
+        *)
+          write_failure "claude-smart currently supports Windows x64 only; Windows ARM is not supported because native ML wheels are unavailable."
+          ;;
+      esac
+      ;;
+    Linux*)
+      : # Existing Linux installs remain supported when package wheels are available.
+      ;;
+    *)
+      write_failure "claude-smart currently supports Apple Silicon macOS 14+, Windows x64, and Linux for vanilla installs."
+      ;;
+  esac
 }
 
 install_private_node() {
@@ -236,6 +339,13 @@ if [ "${CLAUDE_SMART_INSTALL_PRIVATE_NODE_ONLY:-}" = "1" ]; then
   exit $?
 fi
 
+preflight_supported_runtime_platform
+
+if install_complete; then
+  echo '{"continue":true,"suppressOutput":true}'
+  exit 0
+fi
+
 # Dev-mode only: when running from a git checkout, pull the reflexio
 # submodule so tests/benchmarks can use its sources. In install mode the
 # plugin lives under ~/.claude/plugins/cache and reflexio-ai resolves
@@ -381,5 +491,6 @@ if ! bash "$HERE/ensure-plugin-root.sh" "$PLUGIN_ROOT"; then
   echo "[claude-smart] WARNING: failed to set ~/.reflexio/plugin-root symlink — slash commands may not resolve" >&2
 fi
 
+write_success_marker
 echo "[claude-smart] install complete. Backend and dashboard auto-start on session start." >&2
 echo '{"continue":true,"suppressOutput":true}'

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -69,6 +69,8 @@ _DASHBOARD_DIR = _PLUGIN_ROOT / "dashboard"
 _BACKEND_SCRIPT = _SCRIPTS_DIR / "backend-service.sh"
 _DASHBOARD_SCRIPT = _SCRIPTS_DIR / "dashboard-service.sh"
 _REFLEXIO_DIR = Path.home() / ".reflexio"
+_STATE_DIR = Path.home() / ".claude-smart"
+_INSTALL_FAILURE_MARKER = _STATE_DIR / "install-failed"
 _DEFAULT_STORAGE_ROOT = _REFLEXIO_DIR / "data"
 _REFLEXIO_CONFIG_PATH = _REFLEXIO_DIR / "configs" / "config_self-host-org.json"
 _LOCAL_STORAGE_ENV = "LOCAL_STORAGE_PATH"
@@ -126,6 +128,86 @@ def _seed_reflexio_env() -> list[str]:
     with _REFLEXIO_ENV_PATH.open("a") as fh:
         fh.write(prefix + "\n".join(f"{f}=1" for f in missing) + "\n")
     return missing
+
+
+def _find_claude_code_plugin_root() -> Path | None:
+    """Locate the installed Claude Code plugin root after native install."""
+    cache_root = (
+        Path.home()
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / _CODEX_MARKETPLACE_NAME
+        / "claude-smart"
+    )
+    candidates: list[Path] = []
+    if cache_root.is_dir():
+        for child in cache_root.iterdir():
+            if (
+                child.is_dir()
+                and (child / "pyproject.toml").is_file()
+                and (child / "scripts" / "smart-install.sh").is_file()
+            ):
+                candidates.append(child)
+    candidates.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    candidates.extend(
+        [
+            Path.home()
+            / ".claude"
+            / "plugins"
+            / "marketplaces"
+            / _CODEX_MARKETPLACE_NAME
+            / "plugin",
+            _PLUGIN_ROOT,
+        ]
+    )
+    for candidate in candidates:
+        if (
+            (candidate / "pyproject.toml").is_file()
+            and (candidate / "scripts" / "smart-install.sh").is_file()
+        ):
+            return candidate
+    return None
+
+
+def _force_plugin_root(plugin_root: Path) -> None:
+    """Point ~/.reflexio/plugin-root at the installed plugin root."""
+    _REFLEXIO_DIR.mkdir(parents=True, exist_ok=True)
+    link = _REFLEXIO_DIR / "plugin-root"
+    if link.is_symlink() or link.is_file():
+        link.unlink()
+    elif link.exists():
+        raise OSError(f"refusing to replace non-symlink plugin-root at {link}")
+    try:
+        link.symlink_to(plugin_root, target_is_directory=True)
+    except OSError:
+        if link.exists():
+            raise
+        (_REFLEXIO_DIR / "plugin-root.txt").write_text(f"{plugin_root}\n")
+
+
+def _bootstrap_claude_code_install() -> tuple[bool, str]:
+    """Run smart-install immediately for the installed Claude Code plugin."""
+    plugin_root = _find_claude_code_plugin_root()
+    if plugin_root is None:
+        return False, "could not locate installed Claude Code plugin root after install"
+    try:
+        _force_plugin_root(plugin_root)
+    except OSError as exc:
+        return False, str(exc)
+    bash = shutil.which("bash")
+    if not bash:
+        return False, "bash is required to bootstrap claude-smart dependencies"
+    result = subprocess.run(
+        [bash, str(plugin_root / "scripts" / "smart-install.sh")],
+        cwd=plugin_root,
+    )
+    if result.returncode != 0:
+        return False, f"smart-install.sh failed in {plugin_root}"
+    if _INSTALL_FAILURE_MARKER.is_file():
+        reason = _INSTALL_FAILURE_MARKER.read_text().strip() or "unknown error"
+        return False, reason
+    return True, str(plugin_root)
 
 
 def _missing_codex_marketplace_files(root: Path) -> list[Path]:
@@ -792,7 +874,21 @@ def cmd_install(args: argparse.Namespace) -> int:
     if added:
         sys.stdout.write(f"Seeded {_REFLEXIO_ENV_PATH} with {', '.join(added)}.\n")
 
-    sys.stdout.write("\nclaude-smart installed. Restart Claude Code in your project.\n")
+    bootstrapped, message = _bootstrap_claude_code_install()
+    if not bootstrapped:
+        sys.stderr.write(
+            f"error: claude-smart installed, but dependency bootstrap failed: {message}\n"
+        )
+        sys.stderr.write(
+            "Fix the issue above, then run /claude-smart:restart or restart Claude Code to retry.\n"
+        )
+        return 1
+    sys.stdout.write(f"Prepared claude-smart runtime at {message}.\n")
+
+    sys.stdout.write(
+        "\nclaude-smart installed and dependencies are prepared. "
+        "Restart Claude Code in your project.\n"
+    )
     return 0
 
 

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -377,7 +377,7 @@ wheels = [
 
 [[package]]
 name = "chromadb"
-version = "1.5.8"
+version = "1.5.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
@@ -408,18 +408,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/45/39696984553ede2bed1c54550f194111c66ef6ba86c0cd5bd8099d39b2c3/chromadb-1.5.8.tar.gz", hash = "sha256:9f5dfaea989128793c4e1928de6a150d70ae55e44403d85448be94ff32f2c962", size = 2515918, upload-time = "2026-04-16T23:35:11.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/d1/5e33b26985f0c7046a0be1cee2158ada1748ee700d2545057fde1468d74d/chromadb-1.5.9.tar.gz", hash = "sha256:5c20e62a455c28bacac927f26116a73fd8e1799e0d908be8e8a4f02197a54731", size = 2595635, upload-time = "2026-05-05T05:54:51.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/20/5c0218014f1dd8f39e48e9e7d4dc15bd36039510747a167a29e5999d1d68/chromadb-1.5.8-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:397331d749aefc95222733509172b4598688d7306659459a59421f8763ba83b7", size = 22482099, upload-time = "2026-04-16T23:35:09.27Z" },
-    { url = "https://files.pythonhosted.org/packages/82/90/4d8ebfc4c168295b2e903dd385f4b76b155980d3c8db69e7383a6770e178/chromadb-1.5.8-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:852aae44eac81d73e9c349e8daa2eaa34873576afeb2604765aeebd01eb03346", size = 21595370, upload-time = "2026-04-16T23:35:06.091Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/de/3c4c0661152cef02b5d0684fa8d0195aa36d3242e56903d211ff2acd3424/chromadb-1.5.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33976c781a9d6e6386a15481a58f5bde88e68fce87925aa5f30bca4f142c8303", size = 22568047, upload-time = "2026-04-16T23:34:59.376Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/45/53556edcbbd273c54b81e07c1b21c79f7209ab4edf9603f94babb4ecf4f6/chromadb-1.5.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9494f0cf734dcfd2976890f9e3a446fdd5ca565375ffebe0de388ce994ac1f5e", size = 23214104, upload-time = "2026-04-16T23:35:02.583Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/ea/d6df4e0718bde638563225c8690be110f53874d5b5fb74f347d9a7747a1f/chromadb-1.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:b7490b26843c9851e1e9bb0333a1d584e5e77b5a49a78713424600af9b3a28e6", size = 23413244, upload-time = "2026-04-16T23:35:14.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5b/3cced915244f43ed14b53fe9f63a37f05f865064f4e4fe7d9448d3f2a352/chromadb-1.5.9-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:60701011b5e6409647fa40d12c7c5a66b2b0bfcf33a52db2ad53a30a2abc4957", size = 22564540, upload-time = "2026-05-05T05:54:48.906Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4c/adcef1f4e82a2ef69ccd3711d55fc289193d54c4c0ff7a0292a3631db46f/chromadb-1.5.9-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:814b9c95617377f6501e5757d63dfddb554a283a7739c87b9fa573850174e6f3", size = 21699698, upload-time = "2026-05-05T05:54:45.078Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4e/937bc4d2e6f8ab9664ec79931fbbd69efff47e513ec2924b071e4b0ff774/chromadb-1.5.9-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9192d111bd662241625867962333d99369a00769a50f8b2f58cb388731274d7e", size = 22680924, upload-time = "2026-05-05T05:54:36.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ec/0c42039e80b9acc534f67b73b7a42471948042859b3a64867b50a4a77fa3/chromadb-1.5.9-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc09b3df76e5a5cb386aed2715a2eea152e3949f9e1ba93c7119505377749929", size = 23316203, upload-time = "2026-05-05T05:54:41.157Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ce/0f7be6e5d0feafa2cda54b12e6542afeea7dea89d2d411e14da90f8abb96/chromadb-1.5.9-cp39-abi3-win_amd64.whl", hash = "sha256:4fd0b560e56761b7f3cb4d5c6205fd5f20814484b4a3e4e9af9038c2b428fc6c", size = 23542454, upload-time = "2026-05-05T05:54:54.942Z" },
 ]
 
 [[package]]
 name = "claude-smart"
-version = "0.2.28"
+version = "0.2.29"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
@@ -510,9 +510,6 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
 cudart = [
     { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -1750,14 +1747,14 @@ wheels = [
 
 [[package]]
 name = "nvidia-cudnn-cu13"
-version = "9.19.0.56"
+version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
 ]
 
 [[package]]
@@ -1818,20 +1815,20 @@ wheels = [
 
 [[package]]
 name = "nvidia-cusparselt-cu13"
-version = "0.8.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
 ]
 
 [[package]]
 name = "nvidia-nccl-cu13"
-version = "2.28.9"
+version = "2.29.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
 ]
 
 [[package]]
@@ -1872,35 +1869,34 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.24.4"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "protobuf" },
-    { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/60/c4d1c8043eb42f8a9aa9e931c8c293d289c48ff463267130eca97d13357f/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a5c5a544b22f90859c88617ecb30e161ee3349fcc73878854f43d77f00558b5", size = 15172485, upload-time = "2026-03-17T22:03:32.182Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
-    { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f0/8a21ec0a97e40abb7d8da1e8b20fb9e1af509cc6d191f6faa75f73622fb2/onnxruntime-1.24.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e99a48078baaefa2b50fe5836c319499f71f13f76ed32d0211f39109147a49e0", size = 17341922, upload-time = "2026-03-17T22:03:56.364Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/25/d7908de8e08cee9abfa15b8aa82349b79733ae5865162a3609c11598805d/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4aaed1e5e1aaacf2343c838a30a7c3ade78f13eeb16817411f929d04040a13", size = 15172290, upload-time = "2026-03-17T22:03:37.124Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/72/105ec27a78c5aa0154a7c0cd8c41c19a97799c3b12fc30392928997e3be3/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e30c972bc02e072911aabb6891453ec73795386c0af2b761b65444b8a4c4745f", size = 17244738, upload-time = "2026-03-17T22:04:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/05/fb/a592736d968c2f58e12de4d52088dda8e0e724b26ad5c0487263adb45875/onnxruntime-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:3b6ba8b0181a3aa88edab00eb01424ffc06f42e71095a91186c2249415fcff93", size = 12597435, upload-time = "2026-03-17T22:05:43.826Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/04/ae2479e9841b64bd2eb44f8a64756c62593f896514369a11243b1b86ca5c/onnxruntime-1.24.4-cp313-cp313-win_arm64.whl", hash = "sha256:71d6a5c1821d6e8586a024000ece458db8f2fc0ecd050435d45794827ce81e19", size = 12269852, upload-time = "2026-03-17T22:05:33.353Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/af/a479a536c4398ffaf49fbbe755f45d5b8726bdb4335ab31b537f3d7149b8/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1700f559c8086d06b2a4d5de51e62cb4ff5e2631822f71a36db8c72383db71ee", size = 15176861, upload-time = "2026-03-17T22:03:40.143Z" },
-    { url = "https://files.pythonhosted.org/packages/be/13/19f5da70c346a76037da2c2851ecbf1266e61d7f0dcdb887c667210d4608/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c74e268dc808e61e63784d43f9ddcdaf50a776c2819e8bd1d1b11ef64bf7e36", size = 17247454, upload-time = "2026-03-17T22:04:46.643Z" },
-    { url = "https://files.pythonhosted.org/packages/89/db/b30dbbd6037847b205ab75d962bc349bf1e46d02a65b30d7047a6893ffd6/onnxruntime-1.24.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:fbff2a248940e3398ae78374c5a839e49a2f39079b488bc64439fa0ec327a3e4", size = 17343300, upload-time = "2026-03-17T22:03:59.223Z" },
-    { url = "https://files.pythonhosted.org/packages/61/88/1746c0e7959961475b84c776d35601a21d445f463c93b1433a409ec3e188/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2b7969e72d8cb53ffc88ab6d49dd5e75c1c663bda7be7eb0ece192f127343d1", size = 15175936, upload-time = "2026-03-17T22:03:43.671Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/ba/4699cde04a52cece66cbebc85bd8335a0d3b9ad485abc9a2e15946a1349d/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14ed1f197fab812b695a5eaddb536c635e58a2fbbe50a517c78f082cc6ce9177", size = 17246432, upload-time = "2026-03-17T22:04:49.58Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/60/4590910841bb28bd3b4b388a9efbedf4e2d2cca99ddf0c863642b4e87814/onnxruntime-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:311e309f573bf3c12aa5723e23823077f83d5e412a18499d4485c7eb41040858", size = 12903276, upload-time = "2026-03-17T22:05:46.349Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/6f/60e2c0acea1e1ac09b3e794b5a19c166eebf91c0b860b3e6db8e74983fda/onnxruntime-1.24.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f0b910e86b759a4732663ec61fd57ac42ee1b0066f68299de164220b660546d", size = 12594365, upload-time = "2026-03-17T22:05:35.795Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/0c05d10f8f6c40fe0912ebec0d5a33884aaa2af2053507e864dab0883208/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa12ddc54c9c4594073abcaa265cd9681e95fb89dae982a6f508a794ca42e661", size = 15176889, upload-time = "2026-03-17T22:03:48.021Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/1d/1666dc64e78d8587d168fec4e3b7922b92eb286a2ddeebcf6acb55c7dc82/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1cc6a518255f012134bc791975a6294806be9a3b20c4a54cca25194c90cf731", size = 17247021, upload-time = "2026-03-17T22:04:52.377Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b1/d111b1df656761f980d9e298a60039a9cb66036b1d039e777537743d0ac3/onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac", size = 18016624, upload-time = "2026-05-12T00:41:01.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a0/3f9d896a0385a36bd04345d6d0b802821a5782adde562e7e135f6bb71c73/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0", size = 16052692, upload-time = "2026-05-08T19:07:13.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6", size = 18185439, upload-time = "2026-05-08T19:07:36.299Z" },
+    { url = "https://files.pythonhosted.org/packages/44/fc/026d0a7162b9c2153dac292baea9e027c42304dc1d9dc6f8ff5b4cfbaedd/onnxruntime-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:a26374dc7fbcaae593601086b242120e13f2310558df0991da6dd8b8fac00414", size = 13026427, upload-time = "2026-05-08T19:08:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/27/1dcf88e45e4c69db5f7b106f2dacc3801ba98994e082ca03e1dfdf7bfe57/onnxruntime-1.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:54a8053410fd31fd66469bd754fcfe8a4df9f7eb44756b4b5479bf50c842d948", size = 12796647, upload-time = "2026-05-08T19:07:52.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a2/c801242685e0ce48a4ca51dfafbb588765e0446397e123be53ba5598f3f5/onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0", size = 18016563, upload-time = "2026-05-08T19:07:28.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/64/0492c0b1db04e29b2630c87cfa36f9d6872b1ca8614b90c5cad58fac7d76/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdbed8cf3b672b66acb032f33a253bc27f42bce6ece48ae3fab4fa483a5e96e0", size = 16052634, upload-time = "2026-05-08T19:07:16.885Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/26/4d09ddc755a84fc8d5e192991626b0e0680e8f6c5d58f4f1d05c42bc48cf/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c07af6fc6d5557835f2b6ee7a96d8b3235d0c57a8e230efdedaee106a8a3cbc6", size = 18185632, upload-time = "2026-05-08T19:07:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/77/89/3e52249aa08fa301e217ecba07b5246a8338fa2b401e109326e3fc5be0f9/onnxruntime-1.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:61bec80655efa460591c2bc655392d57d2650ce85533a6b9b3b7a790d7ea7916", size = 13026751, upload-time = "2026-05-08T19:08:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/c1c8782b14af6797c303de132d6eef26a9fb80dfacd3750ce57911d11c6b/onnxruntime-1.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a6677545ff451e3539a02746d2f207d8c5baa4a0a818886bb9d6a6eb9511ee89", size = 12796807, upload-time = "2026-05-08T19:07:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f5/47b0676408abec652c14b84d7173e389837832d850c24f87184277313e8d/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e016edc15d3c19f36807e1c6b10be5b27807688c32720f91b5ae480a95215d0", size = 16057265, upload-time = "2026-05-08T19:07:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/45/33ab6deeef010ca844c877dd618cebc079590bbe52d2a3678e7223b1b908/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5fc48a91a046a6a5c9b147f83fb41d65d24d24923373b222cdd248f0f4f4aac", size = 18197590, upload-time = "2026-05-08T19:07:41.422Z" },
+    { url = "https://files.pythonhosted.org/packages/40/89/17546c1c20f6bfc3ae41c22152378a26edfea918af3129e2139dcd7c99f3/onnxruntime-1.26.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:33a791f31432a3af1a96db5e54818b37aba5e5eefc2e6af5794c10a9118a9993", size = 18019724, upload-time = "2026-05-08T19:07:30.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/24/89457a35f6af29538a76647f2c18c3a28277e6c19234c847e7b4b7c19860/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e90c00732c4553618103149d93f688e8c3063017938f8983e21a71d9f3b6d22e", size = 16054821, upload-time = "2026-05-08T19:07:22.348Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f9/15b2e1815cf570d238e0135529f80d2dce64e8e8818a1489cae83823c5c6/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01498e80ba8988428d08c2d51b1338f89e3de2a93e6ffe555f79c68f26a5c06b", size = 18185815, upload-time = "2026-05-08T19:07:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/65/2e11055faf015e4b07f45b513fa49b391baf2e19d92d77d73ebee13c1004/onnxruntime-1.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:7ead61450d8405167c87dd3a31d8da1d576b490a57dab1aa8b82a7da6825f5aa", size = 13349887, upload-time = "2026-05-08T19:08:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e4/0f9d1a5718b1781c610c1e354765a3820597081754277a6a9a2b50705702/onnxruntime-1.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:31d71a53490e46910877d0902b5ad99c69a5955e5c7ea6c82863519410e1ba7c", size = 13140121, upload-time = "2026-05-08T19:07:57.804Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/42/3b8e635f067d06d9f45bede470b8d539d101a4166c272213158dfd08b6ce/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b6d258fb78fdfcf049795bcfaa74dcb90ae7baa277afd21e6fd28b83f2c496", size = 16057240, upload-time = "2026-05-08T19:07:25.163Z" },
+    { url = "https://files.pythonhosted.org/packages/93/99/f2be40a31b908d96b861ae0ce98582fa376c18a7f816b9d5eb4cd6aa0a4c/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eefd386a45202aefb7a5132b94f32df9d506c9edcc7faf2fc60d65183f4b183", size = 18197382, upload-time = "2026-05-08T19:07:46.965Z" },
 ]
 
 [[package]]
@@ -3229,15 +3225,16 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.11.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
@@ -3248,26 +3245,26 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
-    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
-    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
-    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
-    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
-    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
-    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/86/7cd7c66cb9cec6be330fff36db5bd0eef386d80c031b581ec81be1d4b26c/torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7", size = 419749385, upload-time = "2026-03-23T18:07:33.77Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e8/b98ca2d39b2e0e4730c0ee52537e488e7008025bc77ca89552ff91021f7c/torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60", size = 530716756, upload-time = "2026-03-23T18:07:50.02Z" },
-    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835, upload-time = "2026-03-23T18:07:18.974Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405, upload-time = "2026-03-23T18:08:07.014Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
+    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
+    { url = "https://files.pythonhosted.org/packages/67/dc/ac069f8d6e8be701535921141055293b0d4819d3d7f224a4612cf157c7f9/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7dfae4a519197dfa050e98d8e36378a0fb5899625a875c2b54445005a2e404e", size = 88027282, upload-time = "2026-05-13T14:53:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c3/1c1eb00e34555b536dddf792676026a988d710ed36981aa00499b36b0620/torch-2.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:891c769072637c74e9a5a77a3bc782894696d8ffec83b938df8536dee7f0ba78", size = 426386961, upload-time = "2026-05-13T14:51:28.406Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d4/7e730dba0c7032a4154dc9056b76cf9625515e030e269cfbf8098fcfee7d/torch-2.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e2ad3eb85d39c3cab62dfa93ed5a73516e6a53c6713cb97d004004fe089f0f1f", size = 532272265, upload-time = "2026-05-13T14:51:59.308Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b4/92c80d1bbfee1c0036c06d1d2155a3065bd2423134c83bf8a47e65cd6b9b/torch-2.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:c66696857e987efb8bc1777a37357ec4f60ab5e8af6250b83d6034437fa2d8f3", size = 122987138, upload-time = "2026-05-13T14:51:45.942Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/78/2e12b37ce50a19a037d7bc62d652a5a8f27385a7b05859d6bc9204f20cfe/torch-2.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b4556715c8572758625d62b6e0ae3b1f76c440221913a6fb5e100f321fb4fb02", size = 88320100, upload-time = "2026-05-13T14:51:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/83c450ec7b0bb40a7b74611c1b5440f9260e33c54c90d556fd4a1f0fd955/torch-2.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a43ac605a5e13116c72b64c359644cce0229f213dde48d2ae0ae5eb5becf7feb", size = 426391871, upload-time = "2026-05-13T14:52:14.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e9/1a0b575d98d0afedd8f157d23fa3d2759421483660448e60d0a4b10b6daa/torch-2.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a7512adfdd7f6732e40de1c620831e3c75b39b98cef60b11d0c5f0a76473ec5", size = 532192241, upload-time = "2026-05-13T14:51:07.795Z" },
+    { url = "https://files.pythonhosted.org/packages/88/21/afadd25ecd81b3cea1e11c73cf1ab41a983a50271548c3ec7ec3b9efc3e9/torch-2.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f96b63f8287f66a005dd1b5a6abba2920f11156c5e5c4d815f3e2050fd1aa16", size = 123231092, upload-time = "2026-05-13T14:51:18.854Z" },
 ]
 
 [[package]]
@@ -3304,19 +3301,19 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.6.0"
+version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fb/82a802dac4689f2a2fb2e69302e6a138eecc3e175bbe976ba3cfc717683a/triton-3.7.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a44a8476d0d3571eac4e4d1048e1ff75aad81a09ff4602ccfc56c6dea1672e", size = 188507879, upload-time = "2026-05-07T19:05:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/af/9904ec6d3c93d9b24e5ec360445bbdf758b7f00bfbeedb89cb0eb64eb8bb/triton-3.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b85e72968a9d8bba5ddb24e9b64aaabaf48affb042f2755cb7cfa92b7531ce", size = 201460637, upload-time = "2026-05-07T18:46:34.749Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f9/4835a8ea746b88727d8899f4e3ccce4f9cacb38abfc3bb0a638266c53111/triton-3.7.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a160de426fd99f92b0baf509045360afbd3bfaa0b4a5171dde800ec9f09684", size = 188608706, upload-time = "2026-05-07T19:05:39.218Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/68/fa86e5a39608000f645535b2c124920126327ab731f8c4fafd5b07ff8d4b/triton-3.7.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce061073102714b725f3660ec6939d94a1da7984b3aa99c921417cae273672f5", size = 201546766, upload-time = "2026-05-07T18:46:42.088Z" },
 ]
 
 [[package]]

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,0 +1,101 @@
+"""Tests for Claude Code install bootstrap recovery paths."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+from pathlib import Path
+
+from claude_smart import cli
+
+
+def _installed_plugin(tmp_path: Path, version: str = "9.8.7") -> Path:
+    root = (
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / version
+    )
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    (root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    install = scripts / "smart-install.sh"
+    install.write_text("#!/usr/bin/env bash\nprintf '%s\\n' \"$PWD\" > \"$HOME/bootstrap-ran\"\n")
+    install.chmod(install.stat().st_mode | stat.S_IXUSR)
+    return root
+
+
+def _isolate_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(cli, "_REFLEXIO_DIR", tmp_path / ".reflexio")
+    monkeypatch.setattr(cli, "_INSTALL_FAILURE_MARKER", tmp_path / ".claude-smart" / "install-failed")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+def test_bootstrap_claude_code_install_runs_installed_smart_install(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plugin_root = _installed_plugin(tmp_path)
+    _isolate_home(monkeypatch, tmp_path)
+
+    ok, message = cli._bootstrap_claude_code_install()
+
+    assert ok, message
+    assert message == str(plugin_root)
+    assert (tmp_path / "bootstrap-ran").read_text().strip() == str(plugin_root)
+    assert (tmp_path / ".reflexio" / "plugin-root").resolve() == plugin_root
+
+
+def test_bootstrap_claude_code_install_reports_failure_marker(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plugin_root = _installed_plugin(tmp_path)
+    install = plugin_root / "scripts" / "smart-install.sh"
+    install.write_text(
+        "#!/usr/bin/env bash\n"
+        "mkdir -p \"$HOME/.claude-smart\"\n"
+        "printf 'network unavailable\\n' > \"$HOME/.claude-smart/install-failed\"\n"
+    )
+    install.chmod(install.stat().st_mode | stat.S_IXUSR)
+    _isolate_home(monkeypatch, tmp_path)
+
+    ok, message = cli._bootstrap_claude_code_install()
+
+    assert not ok
+    assert message == "network unavailable"
+
+
+def test_bootstrap_claude_code_install_refuses_real_plugin_root_directory(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _installed_plugin(tmp_path)
+    _isolate_home(monkeypatch, tmp_path)
+    real_dir = tmp_path / ".reflexio" / "plugin-root"
+    real_dir.mkdir(parents=True)
+    sentinel = real_dir / "keep.txt"
+    sentinel.write_text("do not delete")
+
+    ok, message = cli._bootstrap_claude_code_install()
+
+    assert not ok
+    assert "refusing to replace non-symlink plugin-root" in message
+    assert sentinel.read_text() == "do not delete"
+
+
+def test_cmd_install_fails_when_dependency_bootstrap_fails(monkeypatch, tmp_path: Path) -> None:
+    _installed_plugin(tmp_path)
+    _isolate_home(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: argparse.Namespace(returncode=0))
+    monkeypatch.setattr(cli, "_bootstrap_claude_code_install", lambda: (False, "uv failed"))
+
+    rc = cli.cmd_install(argparse.Namespace(host="claude-code", source="unused"))
+
+    assert rc == 1

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -20,6 +20,7 @@ SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
 CODEX_COMPAT = REPO_ROOT / "plugin" / "scripts" / "codex-claude-compat"
 CODEX_HOOK = REPO_ROOT / "plugin" / "scripts" / "codex-hook.js"
 BACKEND_LOG_RUNNER = REPO_ROOT / "plugin" / "scripts" / "backend-log-runner.sh"
+NODE_INSTALLER = REPO_ROOT / "bin" / "claude-smart.js"
 
 
 def _minimal_path(tmp_path: Path, *names: str) -> str:
@@ -225,6 +226,196 @@ def test_backend_service_uses_capped_logging() -> None:
     assert "claude_smart_append_capped_log" in service
     assert '>>"$LOG_FILE" 2>&1' not in service
     assert '>>"$LOG_FILE"' not in service
+
+
+def test_smart_install_waits_on_existing_lock() -> None:
+    script = SMART_INSTALL.read_text()
+
+    assert "flock -n" not in script
+    assert "flock 9" in script
+
+
+def test_claude_code_install_hook_matches_session_start_modes() -> None:
+    hooks = json.loads((REPO_ROOT / "plugin" / "hooks" / "hooks.json").read_text())
+    install_block = hooks["hooks"]["SessionStart"][0]
+    runtime_block = hooks["hooks"]["SessionStart"][1]
+
+    assert install_block["matcher"] == runtime_block["matcher"]
+    assert install_block["matcher"] == "startup|clear|compact|resume"
+    assert "smart-install.sh" in install_block["hooks"][0]["command"]
+
+
+def test_node_installer_platform_preflight_messages() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for installer wrapper tests")
+
+    script = (
+        f"const installer = require({json.dumps(str(NODE_INSTALLER))});"
+        "console.log(installer.platformSupportError() || 'ok');"
+    )
+    cases = [
+        ({"CLAUDE_SMART_TEST_PLATFORM": "darwin", "CLAUDE_SMART_TEST_ARCH": "arm64", "CLAUDE_SMART_TEST_RELEASE": "23.0.0"}, "ok"),
+        ({"CLAUDE_SMART_TEST_PLATFORM": "darwin", "CLAUDE_SMART_TEST_ARCH": "x64", "CLAUDE_SMART_TEST_RELEASE": "23.0.0"}, "Intel Mac is not supported"),
+        ({"CLAUDE_SMART_TEST_PLATFORM": "darwin", "CLAUDE_SMART_TEST_ARCH": "arm64", "CLAUDE_SMART_TEST_RELEASE": "22.6.0"}, "macOS 13 and older are not supported"),
+        ({"CLAUDE_SMART_TEST_PLATFORM": "win32", "CLAUDE_SMART_TEST_ARCH": "arm64"}, "Windows ARM is not supported"),
+        ({"CLAUDE_SMART_TEST_PLATFORM": "win32", "CLAUDE_SMART_TEST_ARCH": "x64"}, "ok"),
+    ]
+    for overrides, expected in cases:
+        env = os.environ.copy()
+        env.update(overrides)
+        result = subprocess.run(
+            [node, "-e", script],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert expected in result.stdout.strip()
+
+
+def test_node_installer_does_not_treat_global_node_as_private_runtime(
+    tmp_path: Path,
+) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for installer wrapper tests")
+
+    home = tmp_path / "home"
+    global_bin = tmp_path / "global-bin"
+    global_bin.mkdir(parents=True)
+    for name in ("node", "npm"):
+        executable = global_bin / name
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+    script = (
+        f"const installer = require({json.dumps(str(NODE_INSTALLER))});"
+        "installer.ensurePrivateNode()"
+        ".then(() => { console.error('unexpected success'); process.exit(1); })"
+        ".catch((err) => { console.log(err.message); });"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": str(global_bin),
+            "CLAUDE_SMART_TEST_PLATFORM": "darwin",
+            "CLAUDE_SMART_TEST_ARCH": "x64",
+            "CLAUDE_SMART_TEST_RELEASE": "23.0.0",
+        }
+    )
+    result = subprocess.run(
+        [node, "-e", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Intel Mac is not supported" in result.stdout
+
+
+def test_node_installer_bootstraps_runtime_with_private_node_and_uv(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for installer wrapper tests")
+
+    home = tmp_path / "home"
+    plugin_root = tmp_path / "plugin"
+    dashboard = plugin_root / "dashboard"
+    hooks = plugin_root / "hooks"
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    dashboard.mkdir(parents=True)
+    hooks.mkdir(parents=True)
+    private_node.mkdir(parents=True)
+    uv_bin.mkdir(parents=True)
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    # Use realistic command fixtures so the content-based patcher in
+    # patchCodexHooksForNode can dispatch by script name. The install hook
+    # at index 0 must survive patching because it has to run as bash.
+    (hooks / "codex-hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "hooks": [
+                                {"command": 'bash "$_R/scripts/smart-install.sh"'},
+                                {"command": 'bash "$_R/scripts/ensure-plugin-root.sh" "$_R"'},
+                                {"command": 'bash "$_R/scripts/backend-service.sh" start'},
+                                {"command": 'bash "$_R/scripts/dashboard-service.sh" start'},
+                                {"command": 'bash "$_R/scripts/hook_entry.sh" codex session-start'},
+                            ]
+                        }
+                    ],
+                    "UserPromptSubmit": [{"hooks": [{"command": 'bash "$_R/scripts/hook_entry.sh" codex user-prompt'}]}],
+                    "PostToolUse": [{"hooks": [{"command": 'bash "$_R/scripts/hook_entry.sh" codex post-tool'}]}],
+                    "Stop": [{"hooks": [{"command": 'bash "$_R/scripts/hook_entry.sh" codex stop'}]}],
+                }
+            }
+        )
+        + "\n"
+    )
+    (private_node / "node").write_text("#!/bin/sh\nexit 0\n")
+    (private_node / "npm").write_text(
+        "#!/bin/sh\nprintf 'npm %s\\n' \"$*\" >> \"$HOME/npm.log\"\nexit 0\n"
+    )
+    (uv_bin / "uv").write_text(
+        "#!/bin/sh\nprintf 'uv %s\\n' \"$*\" >> \"$HOME/uv.log\"\nexit 0\n"
+    )
+    for executable in [private_node / "node", private_node / "npm", uv_bin / "uv"]:
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+    script = (
+        f"const installer = require({json.dumps(str(NODE_INSTALLER))});"
+        f"installer.bootstrapPluginRuntime({json.dumps(str(plugin_root))})"
+        ".then(() => console.log('done')).catch((err) => { console.error(err.message); process.exit(1); });"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "CLAUDE_SMART_TEST_PLATFORM": "darwin",
+            "CLAUDE_SMART_TEST_ARCH": "arm64",
+            "CLAUDE_SMART_TEST_RELEASE": "23.0.0",
+        }
+    )
+    result = subprocess.run(
+        [node, "-e", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "done" in result.stdout
+    assert "uv sync --locked --python 3.12 --quiet" in (home / "uv.log").read_text()
+    npm_log = (home / "npm.log").read_text()
+    assert "npm ci" in npm_log
+    assert "npm run build" in npm_log
+    parsed = json.loads((hooks / "codex-hooks.json").read_text())
+    session_hooks = parsed["hooks"]["SessionStart"][0]["hooks"]
+    # Index 0 is smart-install.sh — must run as bash, not through node.
+    install_cmd = session_hooks[0]["command"]
+    assert "smart-install.sh" in install_cmd
+    assert "codex-hook.js" not in install_cmd
+    # Indices 1-4 dispatch to node by command content. Verify each maps to
+    # the right codex-hook.js subcommand and references the private node.
+    # Each arg is independently shell-quoted, so the sub-event appears as
+    # `"hook" "session-start"` rather than `hook session-start`.
+    expected_subs = [["ensure-root"], ["backend"], ["dashboard"], ["hook", "session-start"]]
+    for idx, sub_tokens in enumerate(expected_subs, start=1):
+        cmd = session_hooks[idx]["command"]
+        assert str(private_node / "node") in cmd, f"index {idx}: {cmd}"
+        assert "codex-hook.js" in cmd, f"index {idx}: {cmd}"
+        for token in sub_tokens:
+            assert f'"{token}"' in cmd, f"index {idx} expected token {token!r}: {cmd}"
+    user_prompt_cmd = parsed["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+    assert '"hook"' in user_prompt_cmd and '"user-prompt"' in user_prompt_cmd
 
 
 def test_resolve_npm_accepts_windows_cmd_shim(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- bootstrap Claude Code installs immediately by resolving the installed cache root, setting plugin-root, and running smart-install.sh
- make smart-install.sh idempotent with an install-complete fingerprint and serialized lock handling
- extend Codex/macOS runtime bootstrap to install private Node/npm, uv, Python deps, and dashboard deps, with platform preflight and docs updates

## Why
Fresh installs could reach `/claude-smart:restart` before the Setup hook had installed `uv`, producing a missing-uv error on vanilla systems. This makes installer, SessionStart, and slash-command recovery paths converge on the same bootstrap behavior.

## Validation
- node --check bin/claude-smart.js
- python -m py_compile plugin/src/claude_smart/cli.py
- bash -n plugin/scripts/smart-install.sh plugin/scripts/cli.sh
- hook JSON parse check
- uv run --project plugin pytest tests/test_cli_install.py tests/test_install_scripts.py -q
- uv run --project plugin pytest tests/ -q
- pre-commit pytest during commit: 271 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.2.29

* **New Features**
  * Smart installation bootstrapping system that verifies and manages private Node.js/npm and Python runtime dependencies.
  * Enhanced hook integration for dependency bootstrap on session start.

* **Bug Fixes**
  * Improved error recovery during installation with clearer failure messages.
  * Installation caching to skip redundant dependency setup.

* **Documentation**
  * Updated platform compatibility table (Apple Silicon macOS 14+, Windows x64 supported).
  * Clarified runtime environment structure and data storage locations.
  * Added Windows Git Bash requirement for hook execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->