### PR TITLE
docs: remove Discord badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@
   <a href="#quick-start">
     <img src="https://img.shields.io/badge/hosts-Claude%20Code%20%2B%20Codex-purple.svg" alt="Hosts">
   </a>
-  <a href="https://discord.gg/Jbft3jPn">
-    <img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&logoColor=white" alt="Discord">
-  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Remove the Discord badge from the README header.

## Changes
- `README.md`: drop the `discord.gg/Jbft3jPn` shield link from the badge row.

## Test Plan
- Visual inspection of the rendered README header (no remaining Discord badge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Discord community badge from the README header.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->