### PR TITLE
feat(cli): add 'clear-user <user_id>' for per-user_id row clearing

### DIFF
--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -1561,6 +1561,104 @@ def cmd_clear_all(args: argparse.Namespace) -> int:
     return start_rc or 0
 
 
+def _resolve_reflexio_url() -> str:
+    """Return the URL endpoint for the local claude-smart reflexio backend.
+
+    Mirrors ``claude_smart.reflexio_adapter`` so the CLI's one-shot
+    ReflexioClient calls hit the same server as the long-lived adapter
+    used by hook handlers.
+
+    Returns:
+        str: The ``REFLEXIO_URL`` env var if set, otherwise the default
+            local backend endpoint.
+    """
+    return os.environ.get("REFLEXIO_URL", "http://localhost:8071/")
+
+
+def _format_deleted_counts(deleted_counts: object) -> str:
+    """Render ``deleted_counts`` from a ``clear_user_data`` response as a summary.
+
+    The backend returns one count per affected table. We surface the
+    total in the headline string (``"removed N row(s)"``) and append a
+    per-table breakdown when at least one bucket is populated, so the
+    operator can tell *what* got cleared at a glance.
+
+    Args:
+        deleted_counts (object): The ``deleted_counts`` field from the
+            backend response. Expected to be a mapping of
+            ``str -> int``; anything else is rendered as ``"unknown"``.
+
+    Returns:
+        str: A short human-readable summary suitable for echoing to
+            stdout (e.g. ``"3 row(s) (interactions=3)"``).
+    """
+    if not isinstance(deleted_counts, dict):
+        return "unknown row(s)"
+    pairs: list[tuple[str, int]] = []
+    for key, value in deleted_counts.items():
+        if isinstance(key, str) and isinstance(value, int):
+            pairs.append((key, value))
+    total = sum(value for _, value in pairs)
+    if not pairs:
+        return f"{total} row(s)"
+    breakdown = ", ".join(f"{name}={count}" for name, count in sorted(pairs))
+    return f"{total} row(s) ({breakdown})"
+
+
+def cmd_clear_user(args: argparse.Namespace) -> int:
+    """Delete one user_id's playbooks, profiles, and interactions via the backend.
+
+    Per-user-scoped counterpart of ``clear-all``. Where ``clear-all`` does
+    a filesystem-level wipe of the entire local storage root, ``clear-user``
+    routes through the running reflexio backend's ``clear_user_data``
+    endpoint so it can scope the deletion to a single ``user_id`` —
+    leaving other users' data and globally-shared ``agent_playbooks``
+    untouched. This is the primitive SWE-bench-style benchmark harnesses
+    need when running many parallel evaluations under distinct synthetic
+    user ids against one shared backend.
+
+    Args:
+        args (argparse.Namespace): Parsed CLI args. Requires
+            ``args.user_id`` (positional) and ``args.yes`` (the
+            destructive-action confirmation flag, matching ``clear-all``).
+
+    Returns:
+        int: 0 on success, 1 if confirmation is missing or the backend
+            call fails.
+    """
+    user_id = args.user_id
+    if not args.yes:
+        sys.stdout.write(
+            f"This will permanently delete all reflexio rows for user '{user_id}' "
+            "(playbooks, profiles, interactions). Other users' data and "
+            "agent_playbooks are not affected.\n"
+            "Re-run with --yes to confirm.\n"
+        )
+        return 1
+
+    try:
+        from reflexio import ReflexioClient  # type: ignore[import-not-found]
+    except ImportError as exc:
+        sys.stderr.write(f"error: reflexio is not installed: {exc}\n")
+        return 1
+
+    try:
+        client = ReflexioClient(url_endpoint=_resolve_reflexio_url())
+        # The companion reflexio PR adds ``clear_user_data``; keep the
+        # CLI buildable until both sides ship together.
+        response = client.clear_user_data(user_id)  # pyright: ignore[reportAttributeAccessIssue]
+    except Exception as exc:  # noqa: BLE001 — surface backend failure verbatim.
+        sys.stderr.write(f"error: clear-user failed: {exc}\n")
+        return 1
+
+    deleted_counts = (
+        response.get("deleted_counts") if isinstance(response, dict) else None
+    )
+    summary = _format_deleted_counts(deleted_counts)
+    sys.stdout.write(f"Cleared user '{user_id}': removed {summary}.\n")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="claude-smart")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1624,6 +1722,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Confirm the destructive clear without prompting",
     )
     ca.set_defaults(func=cmd_clear_all)
+
+    cu = sub.add_parser(
+        "clear-user",
+        help=(
+            "Delete one user_id's playbooks, profiles, and interactions via "
+            "the backend (leaves other users and agent_playbooks intact)"
+        ),
+    )
+    cu.add_argument(
+        "user_id",
+        help="User id whose reflexio rows should be cleared",
+    )
+    cu.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Confirm the destructive clear without prompting",
+    )
+    cu.set_defaults(func=cmd_clear_user)
 
     rs = sub.add_parser(
         "restart",

--- a/tests/test_cli_clear_user.py
+++ b/tests/test_cli_clear_user.py
@@ -1,0 +1,140 @@
+"""Tests for ``claude_smart.cli.cmd_clear_user``.
+
+These tests exercise the per-user-scoped clear command in isolation
+from any real reflexio server. The companion ``ReflexioClient.clear_user_data``
+method ships in a separate reflexio PR, so we inject a fake ``reflexio``
+module into ``sys.modules`` to keep the CLI's late import resolvable
+while remaining fully under the test's control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from claude_smart import cli
+
+
+def _args(*, user_id: str = "alice", yes: bool = True) -> argparse.Namespace:
+    """Build a Namespace shaped like ``_build_parser()`` produces for ``clear-user``.
+
+    Args:
+        user_id (str): Positional ``user_id`` value.
+        yes (bool): Value of the ``--yes`` flag.
+
+    Returns:
+        argparse.Namespace: Namespace ready to feed into ``cmd_clear_user``.
+    """
+    return argparse.Namespace(user_id=user_id, yes=yes)
+
+
+def _install_fake_reflexio(monkeypatch: pytest.MonkeyPatch, client_factory: Any) -> Any:
+    """Insert a synthetic ``reflexio`` module exposing ``ReflexioClient``.
+
+    Mirrors the inline ``from reflexio import ReflexioClient`` import that
+    ``cmd_clear_user`` performs. The factory is invoked with the same
+    ``url_endpoint=...`` kwarg the CLI passes, so tests can intercept and
+    assert on construction arguments if desired.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Active monkeypatch fixture.
+        client_factory (Any): Callable returning the per-construction
+            fake client (typically a ``MagicMock``).
+
+    Returns:
+        Any: The factory callable (returned for chaining/assertion).
+    """
+    module = types.ModuleType("reflexio")
+    module.ReflexioClient = client_factory  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "reflexio", module)
+    return client_factory
+
+
+def test_clear_user_invokes_client_method_with_user_id(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``cmd_clear_user`` constructs ``ReflexioClient`` and calls ``clear_user_data``."""
+    fake_client = MagicMock()
+    fake_client.clear_user_data.return_value = {"deleted_counts": {}}
+    factory = MagicMock(return_value=fake_client)
+    _install_fake_reflexio(monkeypatch, factory)
+    monkeypatch.setenv("REFLEXIO_URL", "http://localhost:8071/")
+
+    rc = cli.cmd_clear_user(_args(user_id="bob", yes=True))
+
+    assert rc == 0
+    factory.assert_called_once_with(url_endpoint="http://localhost:8071/")
+    fake_client.clear_user_data.assert_called_once_with("bob")
+    assert "Cleared user 'bob'" in capsys.readouterr().out
+
+
+def test_clear_user_requires_yes_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """Omitting ``--yes`` must short-circuit before any client construction.
+
+    Two surfaces are checked:
+      1. argparse-level: invoking the full parser without ``--yes`` is
+         allowed (``--yes`` is a flag, not required by argparse), so the
+         flag is enforced by ``cmd_clear_user`` itself with a clear
+         confirmation message and a non-zero exit.
+      2. argparse-level: invoking with no ``user_id`` at all *is* an
+         argparse error and exits with the expected SystemExit.
+    """
+    parser = cli._build_parser()
+
+    # No user_id -> argparse error.
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["clear-user"])
+    assert excinfo.value.code == 2
+    assert "user_id" in capsys.readouterr().err
+
+    # user_id present, --yes absent -> CLI safety guard fires.
+    args = parser.parse_args(["clear-user", "alice"])
+    assert args.yes is False
+    rc = cli.cmd_clear_user(args)
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Re-run with --yes" in captured.out
+
+
+def test_clear_user_propagates_backend_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A failing ``clear_user_data`` call exits non-zero with the error on stderr."""
+    fake_client = MagicMock()
+    fake_client.clear_user_data.side_effect = RuntimeError("boom: reflexio unreachable")
+    factory = MagicMock(return_value=fake_client)
+    _install_fake_reflexio(monkeypatch, factory)
+
+    rc = cli.cmd_clear_user(_args(user_id="carol", yes=True))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "boom: reflexio unreachable" in captured.err
+    assert captured.out == ""
+
+
+def test_clear_user_prints_deleted_counts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The success line surfaces the per-table breakdown from ``deleted_counts``."""
+    fake_client = MagicMock()
+    fake_client.clear_user_data.return_value = {
+        "deleted_counts": {"interactions": 3, "profiles": 2, "user_playbooks": 5},
+    }
+    factory = MagicMock(return_value=fake_client)
+    _install_fake_reflexio(monkeypatch, factory)
+
+    rc = cli.cmd_clear_user(_args(user_id="dave", yes=True))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Cleared user 'dave'" in out
+    assert "10 row(s)" in out
+    assert "interactions=3" in out
+    assert "profiles=2" in out
+    assert "user_playbooks=5" in out


### PR DESCRIPTION
## Summary

Add `claude-smart clear-user <user_id> --yes` — the per-`user_id`-scoped sibling of `clear-all`. Calls reflexio's new `POST /api/clear_user_data` endpoint to wipe one user's interactions / requests / user_playbooks / profiles without touching anyone else's data or `agent_playbooks`.

## Why

To unlock parallel SWE-bench paired runs against a single shared backend. Each task's per-arm cleanup needs to delete only that task's data, otherwise concurrent runs nuke each other's playbooks mid-protocol. `clear-all` (filesystem-level wipe of `~/.reflexio/data/`) is too blunt for that — and too slow (~15-30s with backend restart) anyway.

## Difference from `clear-all`

| | `clear-all` | `clear-user <X>` |
|--|--|--|
| Scope | Everything (all users, all rows, the DB file itself) | One user_id's rows |
| Mechanism | `rm -rf ~/.reflexio/data/` + restart backend | SQL `DELETE WHERE user_id=?` via `/api/clear_user_data` |
| Timing | 15-30s | sub-second |
| `agent_playbooks` | Wiped | **Untouched** (intentionally shared cross-project) |
| Backend uptime | Restart needed | Stays running |

## Companion PR

Reflexio side: [feat/clear-user-data](https://github.com/ReflexioAI/reflexio/pull/74) — adds the `/api/clear_user_data` endpoint and `ReflexioClient.clear_user_data(user_id)` method.

Stacked on top of [#30](https://github.com/ReflexioAI/claude-smart/pull/30) so it inherits the full session-end + hook-log + backend-tuning stack.

## Test plan

- [x] 4 new tests in `tests/test_cli_clear_user.py`: happy path (client called with right user_id), missing `--yes` flag (safety guard short-circuits + argparse error on missing positional), backend error propagation (CLI exits 1 with stderr), deleted_counts rendering in the success message.
- [x] Existing CLI tests still pass (25 in `test_cli_clear_all.py`, `test_cli_learn.py`, `test_cli_restart.py`).
- [x] Ruff + pyright clean on the new code.

## Usage

```bash
# Wipe one project's data
claude-smart clear-user pallets__flask-5014 --yes
# → Cleared user 'pallets__flask-5014': removed 10 row(s) (interactions=3, profiles=2, user_playbooks=5).
```

CLI errors:

```bash
$ claude-smart clear-user --yes
error: the following arguments are required: user_id

$ claude-smart clear-user pallets__flask-5014
# → exits 1 with "Re-run with --yes to confirm"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `clear-user` CLI command to permanently delete all stored data for a specified user. Requires explicit confirmation to proceed. Displays a summary of deleted records.

* **Tests**
  * Added comprehensive test coverage for user data deletion, including success scenarios, error handling, and confirmation validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->