### PR TITLE
fix: guard hook service autostart

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -25,7 +25,10 @@ Tunables read by the plugin at runtime. Most users don't need to touch these —
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `CLAUDE_SMART_USE_LOCAL_CLI` | `0` (installer sets `1`) | Route generation through the active host CLI (`claude` for Claude Code, `codex` for Codex). Written to `~/.reflexio/.env` by `claude-smart install`. |
-| `CLAUDE_SMART_USE_LOCAL_EMBEDDING` | `0` (installer sets `1`) | Use the in-process ONNX embedder (requires `chromadb`). Written to `~/.reflexio/.env` by `claude-smart install`. |
+| `CLAUDE_SMART_USE_LOCAL_EMBEDDING` | `0` (installer sets `1`) | Route embeddings to the shared local embedding daemon on `localhost:8072`. Written to `~/.reflexio/.env` by `claude-smart install`. |
+| `REFLEXIO_EMBEDDING_PROVIDER` | `local_service` when local embedding is enabled | Embedding provider mode: `cloud`, `local_service`, `internal_service`, `inprocess`, or `off`. |
+| `REFLEXIO_EMBEDDING_SERVICE_URL` | `http://127.0.0.1:$EMBEDDING_PORT` | OpenAI-compatible embedding endpoint used by `local_service` and `internal_service`. |
+| `EMBEDDING_PORT` | `8072` | Local embedding daemon port. Shared by Claude Code and Codex on the same machine. |
 | `CLAUDE_SMART_ENABLE_OPTIMIZER` | enabled unless set to `0` | Hook-side env var that controls shared skill optimization and rollups during `SessionStart`. Set it in Claude Code settings, not `~/.reflexio/.env`. |
 | `CLAUDE_SMART_CLI_PATH` | `claude` on Claude Code; Codex compatibility wrapper or `codex` on Codex | Override the executable Reflexio calls for local generation. |
 | `CLAUDE_SMART_STATE_DIR` | `~/.claude-smart/sessions/` | Where the per-session JSONL buffer lives. |
@@ -39,9 +42,11 @@ Tunables read by the plugin at runtime. Most users don't need to touch these —
 
 ## Embeddings
 
-claude-smart uses an in-process ONNX embedder (Chroma's `all-MiniLM-L6-v2`, 384-dim, zero-padded to reflexio's 512-dim schema). The model weights are downloaded on first use (~80 MB, cached under `~/.cache/chroma/onnx_models/`) — after that, no network calls for embedding. Runtime cost is a few milliseconds per short document on CPU.
+claude-smart uses one shared local embedding daemon by default. The backend starts `reflexio embeddings serve` on `127.0.0.1:8072` when `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1`, then every backend worker and host process calls its OpenAI-compatible `/v1/embeddings` endpoint instead of loading a model in each process.
 
-If you still want to use a cloud embedding provider (OpenAI, Gemini, etc.), omit `CLAUDE_SMART_USE_LOCAL_EMBEDDING` and set the corresponding API key in `~/.reflexio/.env` — reflexio will fall back to its standard provider-priority chain.
+Supported local models are `local/nomic-embed-v1.5`, `local/nomic-embed-text-v1.5`, and `local/minilm-l6-v2`. The daemon owns exactly one model for its lifetime; start a second daemon on another port if you need to serve a different model concurrently.
+
+If you still want to use a cloud embedding provider (OpenAI, Gemini, etc.), omit `CLAUDE_SMART_USE_LOCAL_EMBEDDING` and set the corresponding API key in `~/.reflexio/.env` — reflexio will fall back to its standard provider-priority chain. For hosted Reflexio, prefer a managed embedding provider or a scalable `REFLEXIO_EMBEDDING_PROVIDER=internal_service` endpoint instead of a single-machine daemon.
 
 ## Install dependency policy
 
@@ -482,10 +487,10 @@ grep -q '^CLAUDE_SMART_USE_LOCAL_CLI=' ~/.reflexio/.env 2>/dev/null \
   || echo 'CLAUDE_SMART_USE_LOCAL_CLI=1' >> ~/.reflexio/.env
 grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' ~/.reflexio/.env 2>/dev/null \
   || echo 'CLAUDE_SMART_USE_LOCAL_EMBEDDING=1' >> ~/.reflexio/.env
-# On first use the embedder downloads ~80 MB ONNX weights to ~/.cache/chroma/onnx_models/.
+# The backend starts one shared embedding daemon on 127.0.0.1:8072.
 
 # 4. (Optional) start the backend manually instead of letting SessionStart spawn it
-cd plugin && BACKEND_PORT=8071 uv run reflexio services start --only backend --no-reload
+cd plugin && BACKEND_PORT=8071 EMBEDDING_PORT=8072 uv run reflexio services start --only backend --no-reload
 # Health check: curl http://localhost:8071/health  →  {"status":"healthy"}
 # Stop:         uv run reflexio services stop
 ```

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,7 +4,7 @@
 Extraction is async by default. Run `/learn` to flag the previous turn as a correction and force extraction, wait ~20–30s, then run `/show` — no new session needed. `/show` shows whether the rule was actually extracted.
 
 **Reflexio refuses to boot with "no embedding-capable provider".**
-Check that `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` is in `~/.reflexio/.env` *and* that `chromadb` is installed in the venv (`uv run --project plugin python -c "import chromadb"` should print nothing). If you'd rather use a cloud embedder instead, drop the env flag and set `OPENAI_API_KEY` or `GEMINI_API_KEY` in the same file.
+Check that `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` is in `~/.reflexio/.env`. With the default shared daemon, `reflexio services start --only backend` also starts `reflexio embeddings serve` on `127.0.0.1:8072`; check `~/.claude-smart/backend.log` for the `embedding` service if semantic search is unavailable. If you'd rather use a cloud embedder instead, drop the env flag and set `OPENAI_API_KEY` or `GEMINI_API_KEY` in the same file.
 
 **`claude-smart` doesn't see my interactions.**
 Check `~/.claude-smart/sessions/`. If your current session's JSONL has no `User`/`Assistant` rows, the plugin isn't receiving hook events — verify `.claude/settings.local.json` has the right path and that `enabledPlugins` is `true`.

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -32,6 +32,16 @@ claude_smart_prepend_node_bins() {
   export PATH="$_CS_NODE_ROOT/bin:$_CS_NODE_ROOT:$PATH"
 }
 
+claude_smart_is_internal_invocation_env() {
+  if [ "${CLAUDE_SMART_INTERNAL:-}" = "1" ]; then
+    return 0
+  fi
+  if [ -n "${CLAUDE_CODE_ENTRYPOINT:-}" ] && [ "${CLAUDE_CODE_ENTRYPOINT:-}" != "cli" ]; then
+    return 0
+  fi
+  return 1
+}
+
 claude_smart_dashboard_unavailable_marker() {
   printf '%s\n' "$HOME/.claude-smart/dashboard-unavailable"
 }

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -25,15 +25,23 @@ claude_smart_prepend_astral_bins
 
 CMD="${1:-start}"
 PORT=8071
+EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"
 # Pass through to `reflexio services start/stop` so the spawned backend
 # binds to PORT instead of reflexio's library default (8081).
 export BACKEND_PORT="$PORT"
+export EMBEDDING_PORT
 
 # Default: route extraction through the active host CLI + ONNX embedder
 # so claude-smart works without any LLM API key. Users can opt out by
 # pre-exporting these to 0.
 export CLAUDE_SMART_USE_LOCAL_CLI="${CLAUDE_SMART_USE_LOCAL_CLI:-1}"
 export CLAUDE_SMART_USE_LOCAL_EMBEDDING="${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}"
+case "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" in
+  1|true|True|yes|YES|on|ON)
+    export REFLEXIO_EMBEDDING_PROVIDER="${REFLEXIO_EMBEDDING_PROVIDER:-local_service}"
+    export REFLEXIO_EMBEDDING_SERVICE_URL="${REFLEXIO_EMBEDDING_SERVICE_URL:-http://127.0.0.1:$EMBEDDING_PORT}"
+    ;;
+esac
 # The backend can be spawned from contexts whose PATH lacks the host
 # CLI dir (commonly ~/.local/bin or /opt/homebrew/bin). Pin the CLI
 # explicitly if we can resolve it from our own (post-login-path) PATH.
@@ -173,6 +181,9 @@ full_stop() {
 
 case "$CMD" in
   start)
+    if claude_smart_is_internal_invocation_env; then
+      emit_ok; exit 0
+    fi
     # Opt-out: users who don't want the backend managed by the hook can
     # set CLAUDE_SMART_BACKEND_AUTOSTART=0.
     if [ "${CLAUDE_SMART_BACKEND_AUTOSTART:-1}" = "0" ]; then

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -36,12 +36,10 @@ export EMBEDDING_PORT
 # pre-exporting these to 0.
 export CLAUDE_SMART_USE_LOCAL_CLI="${CLAUDE_SMART_USE_LOCAL_CLI:-1}"
 export CLAUDE_SMART_USE_LOCAL_EMBEDDING="${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}"
-case "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" in
-  1|true|True|yes|YES|on|ON)
-    export REFLEXIO_EMBEDDING_PROVIDER="${REFLEXIO_EMBEDDING_PROVIDER:-local_service}"
-    export REFLEXIO_EMBEDDING_SERVICE_URL="${REFLEXIO_EMBEDDING_SERVICE_URL:-http://127.0.0.1:$EMBEDDING_PORT}"
-    ;;
-esac
+if [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ]; then
+  export REFLEXIO_EMBEDDING_PROVIDER="${REFLEXIO_EMBEDDING_PROVIDER:-local_service}"
+  export REFLEXIO_EMBEDDING_SERVICE_URL="${REFLEXIO_EMBEDDING_SERVICE_URL:-http://127.0.0.1:$EMBEDDING_PORT}"
+fi
 # The backend can be spawned from contexts whose PATH lacks the host
 # CLI dir (commonly ~/.local/bin or /opt/homebrew/bin). Pin the CLI
 # explicitly if we can resolve it from our own (post-login-path) PATH.

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -87,6 +87,9 @@ port_occupied() {
 
 case "$CMD" in
   start)
+    if claude_smart_is_internal_invocation_env; then
+      emit_ok; exit 0
+    fi
     # Opt-out: users who don't want the dashboard long-lived can set
     # CLAUDE_SMART_DASHBOARD_AUTOSTART=0 in their environment.
     if [ "${CLAUDE_SMART_DASHBOARD_AUTOSTART:-1}" = "0" ]; then

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -26,6 +26,10 @@ fi
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
+if claude_smart_is_internal_invocation_env; then
+  echo '{"continue":true,"suppressOutput":true}'
+  exit 0
+fi
 # Pick up uv from the user's login-shell PATH (covers ~/.local/bin populated
 # by the astral.sh installer) so a fresh install works before the user
 # restarts their terminal. Matches the pattern used by smart-install.sh.

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -242,6 +242,27 @@ def test_service_start_scripts_recover_missing_dependencies_without_cli_command(
     assert "npm is not on PATH after installer; dashboard cannot start" in dashboard
 
 
+def test_service_start_scripts_guard_internal_invocations() -> None:
+    lib = (REPO_ROOT / "plugin" / "scripts" / "_lib.sh").read_text()
+    hook_entry = HOOK_ENTRY.read_text()
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+    dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
+
+    assert "claude_smart_is_internal_invocation_env()" in lib
+    assert "CLAUDE_CODE_ENTRYPOINT" in lib
+    assert "if claude_smart_is_internal_invocation_env; then" in hook_entry
+    assert "if claude_smart_is_internal_invocation_env; then" in backend
+    assert "if claude_smart_is_internal_invocation_env; then" in dashboard
+
+
+def test_backend_service_configures_shared_embedding_daemon() -> None:
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+
+    assert 'EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"' in backend
+    assert 'REFLEXIO_EMBEDDING_PROVIDER:-local_service' in backend
+    assert "REFLEXIO_EMBEDDING_SERVICE_URL" in backend
+
+
 def test_codex_hook_recovers_missing_dependencies_without_cli_command() -> None:
     script = CODEX_HOOK.read_text()
 


### PR DESCRIPTION
## Summary
- Hardens claude-smart shell entrypoints so internal/headless assistant calls cannot start backend or dashboard services.
- Configures backend startup to use the shared Reflexio embedding daemon on `localhost:8072`.
- Documents the shared daemon behavior and troubleshooting path for local embeddings.

## Changes
- Added a shared shell guard for `CLAUDE_SMART_INTERNAL=1` and non-interactive `CLAUDE_CODE_ENTRYPOINT` values.
- Applied the guard before `hook_entry.sh`, `backend-service.sh`, and `dashboard-service.sh` can self-heal or start services.
- Exported `REFLEXIO_EMBEDDING_PROVIDER=local_service`, `REFLEXIO_EMBEDDING_SERVICE_URL`, and `EMBEDDING_PORT` when local embeddings are enabled.
- Updated install-script tests for guard coverage and daemon configuration.

## Test Plan
- `uv run --project plugin pytest -o addopts='' tests/test_install_scripts.py::test_service_start_scripts_guard_internal_invocations tests/test_install_scripts.py::test_backend_service_configures_shared_embedding_daemon`
