### PR TITLE
fix: auto-recover install-failed marker and fix dispatcher double-emit

### DIFF
--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -206,6 +206,61 @@ PY
   return 1
 }
 
+# Print a short fingerprint line for a file ("<cksum>:<size>" or "missing").
+claude_smart_fingerprint_file() {
+  local path
+  path="$1"
+  if [ -f "$path" ]; then
+    cksum "$path" 2>/dev/null | awk '{print $1 ":" $2}'
+  else
+    printf 'missing\n'
+  fi
+}
+
+# Print a multi-line fingerprint covering every input that determines
+# whether smart-install.sh can succeed. Order is stable so the hash is
+# reproducible. Args: $1 = plugin_root, $2 = scripts_dir.
+claude_smart_install_fingerprint() {
+  local plugin_root script_dir
+  plugin_root="$1"
+  script_dir="$2"
+  printf 'plugin_root=%s\n' "$plugin_root"
+  printf 'smart_install=%s\n' "$(claude_smart_fingerprint_file "$script_dir/smart-install.sh")"
+  printf 'lib=%s\n' "$(claude_smart_fingerprint_file "$script_dir/_lib.sh")"
+  printf 'pyproject=%s\n' "$(claude_smart_fingerprint_file "$plugin_root/pyproject.toml")"
+  printf 'uv_lock=%s\n' "$(claude_smart_fingerprint_file "$plugin_root/uv.lock")"
+  # Resolved python interpreter — catches a system upgrade (3.12.4 → 3.12.5)
+  # that would otherwise let install_complete return true against a venv
+  # built against a now-deleted interpreter.
+  if command -v uv >/dev/null 2>&1; then
+    printf 'python=%s\n' "$(uv python find 3.12 2>/dev/null || echo missing)"
+  else
+    printf 'python=no-uv\n'
+  fi
+  if [ -d "$plugin_root/dashboard" ]; then
+    printf 'dashboard_pkg=%s\n' "$(claude_smart_fingerprint_file "$plugin_root/dashboard/package.json")"
+    printf 'dashboard_lock=%s\n' "$(claude_smart_fingerprint_file "$plugin_root/dashboard/package-lock.json")"
+  else
+    printf 'dashboard_pkg=none\n'
+    printf 'dashboard_lock=none\n'
+  fi
+}
+
+# Hash the install fingerprint to a single short hex string. Used by the
+# install-failed marker so hook_entry.sh can detect when inputs change and
+# auto-clear a stale marker. Args: $1 = plugin_root, $2 = scripts_dir.
+claude_smart_install_fingerprint_hash() {
+  local plugin_root script_dir tmp rc
+  plugin_root="$1"
+  script_dir="$2"
+  tmp=$(mktemp 2>/dev/null) || return 1
+  claude_smart_install_fingerprint "$plugin_root" "$script_dir" > "$tmp"
+  claude_smart_sha256_file "$tmp"
+  rc=$?
+  rm -f "$tmp"
+  return $rc
+}
+
 # Return 0 if `node` exists and satisfies the minimum major/minor pair.
 # Patch versions are intentionally ignored because our requirement is a
 # floor, not an exact runtime pin.

--- a/plugin/scripts/cli.sh
+++ b/plugin/scripts/cli.sh
@@ -24,7 +24,7 @@ PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 # on a broken install.
 FAILURE_MARKER="$HOME/.claude-smart/install-failed"
 if [ -f "$FAILURE_MARKER" ]; then
-  msg="$(cat "$FAILURE_MARKER" 2>/dev/null || echo "")"
+  msg="$(head -n 1 "$FAILURE_MARKER" 2>/dev/null || echo "")"
   [ -n "$msg" ] || msg="unknown error"
   echo "claude-smart is not installed correctly: $msg" >&2
   echo "Re-run the plugin's Setup (restart Claude Code) or fix the underlying issue and delete $FAILURE_MARKER to retry." >&2
@@ -50,7 +50,8 @@ if ! command -v uv >/dev/null 2>&1; then
   fi
   if ! command -v uv >/dev/null 2>&1; then
     if [ -f "$FAILURE_MARKER" ]; then
-      msg="$(cat "$FAILURE_MARKER" 2>/dev/null || echo "unknown error")"
+      msg="$(head -n 1 "$FAILURE_MARKER" 2>/dev/null || echo "")"
+      [ -n "$msg" ] || msg="unknown error"
       echo "claude-smart: install failed: $msg" >&2
       echo "Fix the underlying issue and delete $FAILURE_MARKER to retry." >&2
     else

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -43,10 +43,20 @@ PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 FAILURE_MARKER="$HOME/.claude-smart/install-failed"
 STATE_DIR="$HOME/.claude-smart"
 if [ -f "$FAILURE_MARKER" ]; then
-  if [ "$EVENT" = "session-start" ] && command -v python3 >/dev/null 2>&1; then
-    python3 - "$FAILURE_MARKER" <<'PY'
+  # Auto-clear the marker when install inputs have changed since the
+  # failure was recorded (pyproject.toml / uv.lock / smart-install.sh /
+  # python interpreter etc.). Without this the plugin stays muted forever
+  # after a transient sync failure even when the user has fixed it.
+  stored_fp="$(awk -F= '$1=="fingerprint"{print $2; exit}' "$FAILURE_MARKER" 2>/dev/null || true)"
+  current_fp="$(claude_smart_install_fingerprint_hash "$PLUGIN_ROOT" "$HERE" 2>/dev/null || true)"
+  if [ -z "$stored_fp" ] || [ "$stored_fp" != "$current_fp" ]; then
+    rm -f "$FAILURE_MARKER"
+  else
+    if [ "$EVENT" = "session-start" ] && command -v python3 >/dev/null 2>&1; then
+      python3 - "$FAILURE_MARKER" <<'PY'
 import json, pathlib, sys
-msg = pathlib.Path(sys.argv[1]).read_text().strip() or "unknown error"
+first = pathlib.Path(sys.argv[1]).read_text().splitlines()
+msg = (first[0].strip() if first else "") or "unknown error"
 print(json.dumps({
     "hookSpecificOutput": {
         "hookEventName": "SessionStart",
@@ -59,10 +69,11 @@ print(json.dumps({
     }
 }))
 PY
-  else
-    echo '{"continue":true,"suppressOutput":true}'
+    else
+      echo '{"continue":true,"suppressOutput":true}'
+    fi
+    exit 0
   fi
-  exit 0
 fi
 
 if ! command -v uv >/dev/null 2>&1; then

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -80,45 +80,23 @@ acquire_install_lock
 rm -f "$FAILURE_MARKER"
 
 write_failure() {
-  local reason
+  local reason fp_hash
   reason="$1"
-  printf '%s\n' "$reason" > "$FAILURE_MARKER"
+  fp_hash="$(claude_smart_install_fingerprint_hash "$PLUGIN_ROOT" "$HERE" 2>/dev/null || true)"
+  {
+    printf '%s\n' "$reason"
+    if [ -n "$fp_hash" ]; then
+      printf 'fingerprint=%s\n' "$fp_hash"
+    fi
+  } > "$FAILURE_MARKER"
   rm -f "$SUCCESS_MARKER"
   echo "[claude-smart] install failed: $reason" >&2
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 }
 
-fingerprint_file() {
-  local path
-  path="$1"
-  if [ -f "$path" ]; then
-    cksum "$path" 2>/dev/null | awk '{print $1 ":" $2}'
-  else
-    printf 'missing\n'
-  fi
-}
-
 install_fingerprint() {
-  printf 'plugin_root=%s\n' "$PLUGIN_ROOT"
-  printf 'smart_install=%s\n' "$(fingerprint_file "$HERE/smart-install.sh")"
-  printf 'pyproject=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/pyproject.toml")"
-  printf 'uv_lock=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/uv.lock")"
-  # Resolved python interpreter — catches a system upgrade (3.12.4 → 3.12.5)
-  # that would otherwise let install_complete return true against a venv
-  # built against a now-deleted interpreter.
-  if command -v uv >/dev/null 2>&1; then
-    printf 'python=%s\n' "$(uv python find 3.12 2>/dev/null || echo missing)"
-  else
-    printf 'python=no-uv\n'
-  fi
-  if [ -d "$PLUGIN_ROOT/dashboard" ]; then
-    printf 'dashboard_pkg=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/dashboard/package.json")"
-    printf 'dashboard_lock=%s\n' "$(fingerprint_file "$PLUGIN_ROOT/dashboard/package-lock.json")"
-  else
-    printf 'dashboard_pkg=none\n'
-    printf 'dashboard_lock=none\n'
-  fi
+  claude_smart_install_fingerprint "$PLUGIN_ROOT" "$HERE"
 }
 
 install_complete() {

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -205,7 +205,8 @@ def _bootstrap_claude_code_install() -> tuple[bool, str]:
     if result.returncode != 0:
         return False, f"smart-install.sh failed in {plugin_root}"
     if _INSTALL_FAILURE_MARKER.is_file():
-        reason = _INSTALL_FAILURE_MARKER.read_text().strip() or "unknown error"
+        first_line = _INSTALL_FAILURE_MARKER.read_text().splitlines()
+        reason = (first_line[0].strip() if first_line else "") or "unknown error"
         return False, reason
     return True, str(plugin_root)
 

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -20,6 +20,8 @@ import json
 import logging
 import sys
 from collections.abc import Callable
+from contextlib import redirect_stdout
+from io import StringIO
 from typing import Any
 
 from claude_smart import hook_log, ids, runtime
@@ -134,18 +136,25 @@ def main(argv: list[str] | None = None) -> int:
     handler_status = "ok"
     publish_status: str | None = None
     publish_count: int | None = None
+    handler_stdout = StringIO()
     try:
-        result = handler(payload)
+        with redirect_stdout(handler_stdout):
+            result = handler(payload)
         if isinstance(result, tuple) and len(result) == 2:
             publish_status, publish_count = result
     except Exception as exc:  # noqa: BLE001 — hooks must never crash the session.
         _LOGGER.exception("hook handler %s raised: %s", event, exc)
         handler_status = f"raised:{type(exc).__name__}: {exc}"
-    # Always emit the JSON continue response — Claude Code's hook contract
-    # expects one on stdout regardless of whether the handler succeeded or
-    # raised. Skipping it on the success path would leave the hook silent
-    # and the session would block waiting for a reply.
-    emit_continue()
+        emit_continue()
+    else:
+        # Handlers that inject context already emit the full hook JSON. Silent
+        # handlers still need the continue response so the parent session does
+        # not wait on an empty stdout payload.
+        captured = handler_stdout.getvalue()
+        if captured.strip():
+            sys.stdout.write(captured)
+        else:
+            emit_continue()
     hook_log.log_event(
         event=event,
         host=host,

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -217,6 +217,39 @@ def test_dispatcher_emits_continue_on_handler_success(
     assert '"continue": true' in out
 
 
+def test_dispatcher_does_not_append_continue_after_handler_json(
+    hook_log_path, stdin_payload, monkeypatch, capsys
+) -> None:
+    """Context-injection handlers already emit hook JSON; don't append another."""
+
+    def inject_context(_payload: dict[str, Any]) -> None:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                        "additionalContext": "matched context",
+                    }
+                }
+            )
+        )
+        sys.stdout.write("\n")
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"user-prompt": inject_context})
+    stdin_payload({"session_id": "s-inject", "cwd": "/tmp"})
+    hook.main(["claude-code", "user-prompt"])
+    out = capsys.readouterr().out
+    lines = [json.loads(line) for line in out.splitlines()]
+    assert lines == [
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": "matched context",
+            }
+        }
+    ]
+
+
 def test_dispatcher_emits_continue_on_handler_exception(
     hook_log_path, stdin_payload, monkeypatch, capsys
 ) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -773,6 +773,56 @@ def test_codex_hook_caps_backend_log_appends(tmp_path: Path) -> None:
     assert log.stat().st_size <= 10_000_000
 
 
+def test_install_fingerprint_hash_tracks_lib_changes(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    scripts = plugin_root / "scripts"
+    dashboard = plugin_root / "dashboard"
+    scripts.mkdir(parents=True)
+    dashboard.mkdir()
+    (scripts / "smart-install.sh").write_text("#!/bin/sh\n")
+    (scripts / "_lib.sh").write_text("helper=v1\n")
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    (plugin_root / "uv.lock").write_text("version = 1\n")
+    (dashboard / "package.json").write_text("{}\n")
+    (dashboard / "package-lock.json").write_text("{}\n")
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = _minimal_path(
+        tmp_path,
+        "awk",
+        "cksum",
+        "mktemp",
+        "rm",
+        "sha256sum",
+        "shasum",
+        "openssl",
+    )
+    command = (
+        f'. "{LIB}"; '
+        f'claude_smart_install_fingerprint_hash "{plugin_root}" "{scripts}"'
+    )
+    before = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", "-c", command],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    (scripts / "_lib.sh").write_text("helper=v2\n")
+    after = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", "-c", command],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert before.returncode == 0, before.stderr
+    assert after.returncode == 0, after.stderr
+    assert before.stdout.strip()
+    assert before.stdout != after.stdout
+
+
 def test_install_private_node_installs_from_verified_archive(tmp_path: Path) -> None:
     dist = _fake_node_dist(tmp_path)
     result = _run_private_node_install(tmp_path, f"file://{dist}")


### PR DESCRIPTION
## Summary
Two related hook-system reliability fixes that together explain why claude-smart was silently muted in real sessions: a permanent install-failed marker that never auto-recovered, and a dispatcher bug that silently dropped every UserPromptSubmit injection.

- A single transient `uv sync` failure (network blip, stale lockfile, edited `pyproject.toml`) wrote `~/.claude-smart/install-failed`, and `hook_entry.sh` then short-circuited *every* hook event until the user manually deleted the marker — permanently muting the plugin with no auto-recovery path.
- Even when the marker was absent, the hook dispatcher emitted `emit_continue()` *after* every successful handler, including UserPromptSubmit handlers that had already written a `hookSpecificOutput` envelope to stdout. Claude Code rejects multi-object stdout as invalid hook output, so the injected `additionalContext` was silently dropped on every prompt.
- This PR fixes both without behavior changes in the happy or same-failure-recurring paths.

## Changes

### 1. Auto-clear stale `install-failed` markers

**`plugin/scripts/_lib.sh`** — add three helpers:
- `claude_smart_fingerprint_file` — `<cksum>:<size>` line per file (or `missing`)
- `claude_smart_install_fingerprint` — canonical multi-line fingerprint over `smart-install.sh`, `_lib.sh`, `pyproject.toml`, `uv.lock`, the resolved Python interpreter, and dashboard manifests
- `claude_smart_install_fingerprint_hash` — sha256 of the fingerprint

**`plugin/scripts/smart-install.sh`** — `write_failure` now writes two lines: reason on line 1, `fingerprint=<sha256>` on line 2. Local `install_fingerprint` reduces to a one-line wrapper around the lib function so `install_complete` stays identical.

**`plugin/scripts/hook_entry.sh`** — when the marker exists, parse `fingerprint=` from line 2, recompute the hash with the same lib function, and `rm -f` the marker when they differ (or the line is absent). Sticky behavior unchanged otherwise. The SessionStart banner now reads only line 1 so the fingerprint never leaks into user-visible text.

**`plugin/scripts/cli.sh`** + **`plugin/src/claude_smart/cli.py`** — both marker readers take only line 1 (`head -n 1` and `splitlines()[0]`).

### 2. Stop emitting duplicate continue after context-injecting handlers

**`plugin/src/claude_smart/hook.py`** — wrap the handler call in `redirect_stdout`. On success, pass captured stdout through verbatim if non-empty; otherwise `emit_continue()` as before. Exception path still emits the continue envelope.

### 3. Tests

**`tests/test_install_scripts.py`** — `test_install_fingerprint_hash_tracks_lib_changes` locks in that `_lib.sh` is part of the canonical fingerprint.

**`tests/test_hook_log.py`** — `test_dispatcher_does_not_append_continue_after_handler_json` asserts exactly one JSON object on stdout when the handler injects context.

## Diagrams

```mermaid
flowchart TD
    A[Hook fires] --> B{install-failed exists?}
    B -- no --> C[Run handler]
    B -- yes --> D[Parse fingerprint from line 2]
    D --> E[Recompute current fingerprint hash]
    E --> F{stored == current?}
    F -- yes --> G[Short-circuit<br/>continue: suppressOutput]
    F -- no / missing --> H[rm -f marker]
    H --> C
    C --> I{Handler wrote stdout?}
    I -- yes --> J[Pass through verbatim]
    I -- no --> K[emit_continue]
```

## Test Plan
- [x] `uv run --project plugin pytest tests/test_install_scripts.py tests/test_hook_log.py` → 48 passed.
- [x] Pre-commit ran the full plugin suite twice (once per commit) → 311 then 312 passed.
- [x] Manual end-to-end with the literal `UserPromptSubmit` payload:
  - Plant marker with **stale** fingerprint → marker removed, hook ran full retrieval (~9 KB injected).
  - Plant marker with **current** fingerprint (under same PATH setup as `hook_entry.sh`) → marker retained, hook short-circuited with 40 B `{"continue":true,"suppressOutput":true}`.
  - SessionStart with sticky marker → banner shows line-1 reason only.
  - Old-format marker (no fingerprint line) → treated as stale, removed.
- [x] Live verification this very session: project-specific skills now reach the assistant via `additionalContext` instead of being silently dropped.

## Notes
- No backwards-compat path for old markers — cleared on first read. Matches project preference for clean removal over legacy compat.
- The dispatcher fix matches the cs:s5-170 playbook pattern exactly: two separate JSON objects in the same handler chain → Claude Code rejects multi-line stdout as invalid single-object JSON.
