### PR TITLE
feat: refresh claude-smart dashboard theme

### DIFF
--- a/plugin/dashboard/app/configure/env/page.tsx
+++ b/plugin/dashboard/app/configure/env/page.tsx
@@ -111,7 +111,7 @@ export default function ConfigureEnvPage() {
         }
       />
 
-      <div className="p-6 max-w-2xl mx-auto space-y-6">
+      <div className="p-6 max-w-3xl mx-auto space-y-5">
         {error && (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm">
             {error}
@@ -124,7 +124,7 @@ export default function ConfigureEnvPage() {
           </div>
         )}
 
-        <section className="space-y-4">
+        <section className="space-y-4 rounded-lg border border-border bg-card/92 p-5 shadow-sm">
           <div>
             <h2 className="text-sm font-semibold">Dashboard</h2>
             <p className="text-xs text-muted-foreground">
@@ -136,7 +136,7 @@ export default function ConfigureEnvPage() {
             <Input
               value={reflexioUrl}
               onChange={(e) => setReflexioUrl(e.target.value)}
-              className="font-mono text-xs"
+              className="font-mono text-xs bg-background/80"
               placeholder="http://localhost:8071"
             />
           </div>
@@ -144,7 +144,7 @@ export default function ConfigureEnvPage() {
 
         <Separator />
 
-        <section className="space-y-4">
+        <section className="space-y-4 rounded-lg border border-border bg-card/92 p-5 shadow-sm">
           <div>
             <h2 className="text-sm font-semibold">claude-smart environment</h2>
             <p className="text-xs text-muted-foreground">
@@ -162,7 +162,7 @@ export default function ConfigureEnvPage() {
                 <Input
                   value={config.REFLEXIO_URL}
                   onChange={(e) => update("REFLEXIO_URL", e.target.value)}
-                  className="font-mono text-xs"
+                  className="font-mono text-xs bg-background/80"
                   placeholder="http://localhost:8071/"
                 />
               </div>
@@ -206,7 +206,7 @@ export default function ConfigureEnvPage() {
                 <Input
                   value={String(config.CLAUDE_SMART_CLI_PATH ?? "")}
                   onChange={(e) => update("CLAUDE_SMART_CLI_PATH", e.target.value)}
-                  className="font-mono text-xs"
+                  className="font-mono text-xs bg-background/80"
                   placeholder="(empty — auto-detect via $PATH)"
                 />
               </div>
@@ -218,7 +218,7 @@ export default function ConfigureEnvPage() {
                   onChange={(e) =>
                     update("CLAUDE_SMART_CLI_TIMEOUT", e.target.value)
                   }
-                  className="font-mono text-xs"
+                  className="font-mono text-xs bg-background/80"
                   placeholder="120"
                 />
               </div>
@@ -230,7 +230,7 @@ export default function ConfigureEnvPage() {
                   onChange={(e) =>
                     update("CLAUDE_SMART_STATE_DIR", e.target.value)
                   }
-                  className="font-mono text-xs"
+                  className="font-mono text-xs bg-background/80"
                   placeholder="(empty — default ~/.claude-smart/sessions)"
                 />
               </div>
@@ -240,7 +240,7 @@ export default function ConfigureEnvPage() {
 
         <Separator />
 
-        <section className="space-y-4">
+        <section className="space-y-4 rounded-lg border border-border bg-card/92 p-5 shadow-sm">
           <div>
             <h2 className="text-sm font-semibold">Claude Code hook environment</h2>
             <p className="text-xs text-muted-foreground">
@@ -270,7 +270,7 @@ export default function ConfigureEnvPage() {
                   onCheckedChange={updateOptimizer}
                 />
               </div>
-              <div className="rounded-md border border-border bg-muted/20 p-3 text-xs text-muted-foreground space-y-2">
+              <div className="rounded-md border border-border bg-background/60 p-3 text-xs text-muted-foreground space-y-2">
                 <div className="flex items-center justify-between gap-4">
                   <span>Effective value</span>
                   <span className="font-medium text-foreground">

--- a/plugin/dashboard/app/configure/layout.tsx
+++ b/plugin/dashboard/app/configure/layout.tsx
@@ -30,7 +30,7 @@ export default function ConfigureLayout({
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <div className="border-b border-border bg-muted/20 px-6 py-4">
+      <div className="border-b border-border bg-background/72 px-6 py-4 backdrop-blur">
         <PageTabs
           items={tabs}
           activeId={

--- a/plugin/dashboard/app/configure/server/page.tsx
+++ b/plugin/dashboard/app/configure/server/page.tsx
@@ -120,7 +120,7 @@ export default function ConfigureServerPage() {
         }
       />
 
-      <div className="p-6 max-w-2xl mx-auto space-y-6">
+      <div className="p-6 max-w-3xl mx-auto space-y-5">
         {srvError && (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm">
             {srvError}
@@ -136,7 +136,7 @@ export default function ConfigureServerPage() {
         {srvLoading ? (
           <div className="text-sm text-muted-foreground">Loading…</div>
         ) : srvConfig ? (
-          <section className="space-y-5">
+          <section className="space-y-5 rounded-lg border border-border bg-card/92 p-5 shadow-sm">
             <div className="space-y-2">
               <Label>Additional agent description</Label>
               <p className="text-xs text-muted-foreground">
@@ -148,7 +148,7 @@ export default function ConfigureServerPage() {
                 onChange={(e) =>
                   updateSrv("agent_context_prompt", e.target.value || null)
                 }
-                className="w-full font-mono text-xs min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="w-full font-mono text-xs min-h-[80px] rounded-md border border-input bg-background/80 px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 placeholder="(empty)"
               />
             </div>
@@ -170,7 +170,7 @@ export default function ConfigureServerPage() {
                     Number.isFinite(n) && n > 0 ? n : undefined,
                   );
                 }}
-                className="font-mono text-xs"
+                className="font-mono text-xs bg-background/80"
                 placeholder="10"
               />
             </div>
@@ -192,7 +192,7 @@ export default function ConfigureServerPage() {
                     Number.isFinite(n) && n > 0 ? n : undefined,
                   );
                 }}
-                className="font-mono text-xs"
+                className="font-mono text-xs bg-background/80"
                 placeholder="5"
               />
             </div>
@@ -215,7 +215,7 @@ export default function ConfigureServerPage() {
                       e.target.value,
                     )
                   }
-                  className="w-full font-mono text-xs min-h-[120px] rounded-md border border-input bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  className="w-full font-mono text-xs min-h-[120px] rounded-md border border-input bg-background/80 px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 />
               ) : (
                 <div className="text-xs text-muted-foreground italic">
@@ -242,7 +242,7 @@ export default function ConfigureServerPage() {
                       e.target.value,
                     )
                   }
-                  className="w-full font-mono text-xs min-h-[120px] rounded-md border border-input bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  className="w-full font-mono text-xs min-h-[120px] rounded-md border border-input bg-background/80 px-3 py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 />
               ) : (
                 <div className="text-xs text-muted-foreground italic">

--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -177,8 +177,8 @@ export default function DashboardPage() {
           </div>
         )}
 
-        <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
-        <section className="rounded-lg border border-border bg-card/86 p-4 shadow-sm">
+        <div className="grid min-w-0 gap-6 lg:grid-cols-2">
+        <section className="min-w-0 rounded-lg border border-border bg-card/86 p-4 shadow-sm">
           <div className="flex items-center justify-between mb-3">
             <div>
               <h2 className="text-sm font-semibold">Recent sessions</h2>
@@ -226,7 +226,7 @@ export default function DashboardPage() {
           )}
         </section>
 
-        <section className="rounded-lg border border-border bg-card/86 p-4 shadow-sm">
+        <section className="min-w-0 rounded-lg border border-border bg-card/86 p-4 shadow-sm">
           <div className="flex items-center justify-between mb-3">
             <div>
               <h2 className="text-sm font-semibold">Recent learnings</h2>
@@ -255,11 +255,11 @@ export default function DashboardPage() {
                 <Link
                   key={item.id}
                   href={item.href}
-                  className="flex items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-accent/45"
+                  className="flex min-w-0 items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-accent/45"
                 >
-                  <div className="min-w-0 flex items-center gap-3">
+                  <div className="min-w-0 flex flex-1 items-center gap-3">
                     {learningIcon(item.kind)}
-                    <div className="min-w-0">
+                    <div className="min-w-0 flex-1">
                       <p className="text-sm truncate">{item.content}</p>
                       <div className="mt-1 flex items-center gap-2">
                         <Badge variant="outline" className="h-5 text-[10px]">
@@ -286,7 +286,7 @@ export default function DashboardPage() {
           )}
         </section>
 
-        <section>
+        <section className="min-w-0">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold">
@@ -312,9 +312,9 @@ export default function DashboardPage() {
                 const label = appliedRuleLabel(s);
                 const rowBody = (
                   <>
-                    <div className="min-w-0 flex items-center gap-3">
+                    <div className="min-w-0 flex flex-1 items-center gap-3">
                       <Sparkles className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <div className="min-w-0">
+                      <div className="min-w-0 flex-1">
                         <p className="text-sm truncate">
                           {s.title || (
                             <span className="text-muted-foreground italic">
@@ -339,14 +339,14 @@ export default function DashboardPage() {
                   <Link
                     key={`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`}
                     href={href}
-                    className="flex items-center justify-between gap-3 px-4 py-3 hover:bg-accent/40 transition-colors"
+                    className="flex min-w-0 items-center justify-between gap-3 px-4 py-3 hover:bg-accent/40 transition-colors"
                   >
                     {rowBody}
                   </Link>
                 ) : (
                   <div
                     key={`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`}
-                    className="flex items-center justify-between gap-3 px-4 py-3"
+                    className="flex min-w-0 items-center justify-between gap-3 px-4 py-3"
                   >
                     {rowBody}
                   </div>

--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -177,32 +177,40 @@ export default function DashboardPage() {
           </div>
         )}
 
-        <section>
+        <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <section className="rounded-lg border border-border bg-card/86 p-4 shadow-sm">
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-sm font-semibold">Recent sessions</h2>
+            <div>
+              <h2 className="text-sm font-semibold">Recent sessions</h2>
+              <p className="text-xs text-muted-foreground">
+                Latest local buffers and cited learnings.
+              </p>
+            </div>
             <Link
               href="/sessions"
-              className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+              className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
             >
               View all <ExternalLink className="h-3 w-3" />
             </Link>
           </div>
           {sessions && sessions.length > 0 ? (
-            <div className="rounded-xl border border-border divide-y divide-border bg-card">
+            <div className="rounded-lg border border-border divide-y divide-border bg-background/70 overflow-hidden">
               {sessions.slice(0, 5).map((s) => (
                 <Link
                   key={s.session_id}
                   href={`/sessions/${s.session_id}`}
-                  className="flex items-center justify-between px-4 py-3 hover:bg-accent/40 transition-colors"
+                  className="flex flex-col gap-2 px-4 py-3 transition-colors hover:bg-accent/45 sm:flex-row sm:items-center sm:justify-between"
                 >
-                  <div className="min-w-0 flex items-center gap-3">
-                    <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div className="min-w-0 flex w-full items-center gap-3">
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                      <MessageSquare className="h-4 w-4" />
+                    </span>
                     <code className="font-mono text-xs truncate">
                       {truncateId(s.session_id, 10, 6)}
                     </code>
                     <LearningsBadge count={s.learning_interaction_count} />
                   </div>
-                  <div className="flex items-center gap-4 text-xs text-muted-foreground shrink-0">
+                  <div className="flex w-full items-center justify-end gap-4 text-xs text-muted-foreground sm:w-auto sm:shrink-0">
                     <span>{s.turn_count} turns</span>
                     <span>{formatRelative(s.last_activity)}</span>
                   </div>
@@ -218,31 +226,36 @@ export default function DashboardPage() {
           )}
         </section>
 
-        <section>
+        <section className="rounded-lg border border-border bg-card/86 p-4 shadow-sm">
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-sm font-semibold">Recent learnings</h2>
+            <div>
+              <h2 className="text-sm font-semibold">Recent learnings</h2>
+              <p className="text-xs text-muted-foreground">
+                New skills and preferences extracted from recent patterns.
+              </p>
+            </div>
             <div className="flex items-center gap-3">
               <Link
                 href="/skills"
-                className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+                className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
               >
                 Skills <ExternalLink className="h-3 w-3" />
               </Link>
               <Link
                 href="/preferences"
-                className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+                className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
               >
                 Preferences <ExternalLink className="h-3 w-3" />
               </Link>
             </div>
           </div>
           {recentLearnings.length > 0 ? (
-            <div className="rounded-xl border border-border divide-y divide-border bg-card">
+            <div className="rounded-lg border border-border divide-y divide-border bg-background/70 overflow-hidden">
               {recentLearnings.map((item) => (
                 <Link
                   key={item.id}
                   href={item.href}
-                  className="flex items-center justify-between gap-3 px-4 py-3 hover:bg-accent/40 transition-colors"
+                  className="flex items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-accent/45"
                 >
                   <div className="min-w-0 flex items-center gap-3">
                     {learningIcon(item.kind)}
@@ -348,6 +361,7 @@ export default function DashboardPage() {
             />
           )}
         </section>
+        </div>
       </div>
     </div>
   );

--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -286,7 +286,7 @@ export default function DashboardPage() {
           )}
         </section>
 
-        <section className="min-w-0">
+        <section className="min-w-0 lg:col-span-2">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold">

--- a/plugin/dashboard/app/globals.css
+++ b/plugin/dashboard/app/globals.css
@@ -7,8 +7,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--dashboard-font-sans);
+  --font-mono: var(--dashboard-font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -48,6 +48,10 @@
 }
 
 :root {
+  --dashboard-font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --dashboard-font-mono: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono",
+    Menlo, monospace;
   --background: oklch(0.982 0.006 197);
   --foreground: oklch(0.19 0.018 236);
   --card: oklch(0.997 0.003 197);

--- a/plugin/dashboard/app/globals.css
+++ b/plugin/dashboard/app/globals.css
@@ -48,72 +48,72 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: oklch(0.982 0.006 197);
+  --foreground: oklch(0.19 0.018 236);
+  --card: oklch(0.997 0.003 197);
+  --card-foreground: oklch(0.19 0.018 236);
+  --popover: oklch(0.997 0.003 197);
+  --popover-foreground: oklch(0.19 0.018 236);
+  --primary: oklch(0.48 0.142 202);
+  --primary-foreground: oklch(0.99 0.006 197);
+  --secondary: oklch(0.939 0.025 202);
+  --secondary-foreground: oklch(0.245 0.038 218);
+  --muted: oklch(0.949 0.011 218);
+  --muted-foreground: oklch(0.486 0.024 230);
+  --accent: oklch(0.928 0.054 185);
+  --accent-foreground: oklch(0.235 0.052 205);
+  --destructive: oklch(0.58 0.216 27);
+  --border: oklch(0.882 0.018 218);
+  --input: oklch(0.892 0.018 218);
+  --ring: oklch(0.65 0.104 192);
+  --chart-1: oklch(0.68 0.13 188);
+  --chart-2: oklch(0.62 0.15 154);
+  --chart-3: oklch(0.72 0.16 82);
+  --chart-4: oklch(0.64 0.16 24);
+  --chart-5: oklch(0.54 0.13 258);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.964 0.013 213);
+  --sidebar-foreground: oklch(0.22 0.026 236);
+  --sidebar-primary: oklch(0.48 0.142 202);
+  --sidebar-primary-foreground: oklch(0.99 0.006 197);
+  --sidebar-accent: oklch(0.918 0.043 190);
+  --sidebar-accent-foreground: oklch(0.24 0.054 206);
+  --sidebar-border: oklch(0.862 0.02 218);
+  --sidebar-ring: oklch(0.65 0.104 192);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.154 0.022 236);
+  --foreground: oklch(0.938 0.012 202);
+  --card: oklch(0.205 0.027 236);
+  --card-foreground: oklch(0.938 0.012 202);
+  --popover: oklch(0.205 0.027 236);
+  --popover-foreground: oklch(0.938 0.012 202);
+  --primary: oklch(0.72 0.119 188);
+  --primary-foreground: oklch(0.154 0.022 236);
+  --secondary: oklch(0.265 0.029 235);
+  --secondary-foreground: oklch(0.914 0.014 202);
+  --muted: oklch(0.258 0.027 235);
+  --muted-foreground: oklch(0.69 0.026 219);
+  --accent: oklch(0.306 0.054 202);
+  --accent-foreground: oklch(0.9 0.05 183);
+  --destructive: oklch(0.66 0.21 24);
+  --border: oklch(0.332 0.031 236);
+  --input: oklch(0.354 0.034 236);
+  --ring: oklch(0.72 0.119 188);
+  --chart-1: oklch(0.72 0.119 188);
+  --chart-2: oklch(0.72 0.14 148);
+  --chart-3: oklch(0.78 0.15 82);
+  --chart-4: oklch(0.68 0.17 24);
+  --chart-5: oklch(0.69 0.12 258);
+  --sidebar: oklch(0.184 0.027 236);
+  --sidebar-foreground: oklch(0.916 0.014 202);
+  --sidebar-primary: oklch(0.72 0.119 188);
+  --sidebar-primary-foreground: oklch(0.154 0.022 236);
+  --sidebar-accent: oklch(0.29 0.051 202);
+  --sidebar-accent-foreground: oklch(0.9 0.05 183);
+  --sidebar-border: oklch(0.332 0.031 236);
+  --sidebar-ring: oklch(0.72 0.119 188);
 }
 
 @layer base {
@@ -122,8 +122,18 @@
   }
   body {
     @apply bg-background text-foreground;
+    background-image:
+      linear-gradient(to right, oklch(0.88 0.018 218 / 0.45) 1px, transparent 1px),
+      linear-gradient(to bottom, oklch(0.88 0.018 218 / 0.45) 1px, transparent 1px);
+    background-size: 32px 32px;
+    background-position: -1px -1px;
   }
   html {
     @apply font-sans;
+  }
+  .dark body {
+    background-image:
+      linear-gradient(to right, oklch(0.38 0.032 236 / 0.28) 1px, transparent 1px),
+      linear-gradient(to bottom, oklch(0.38 0.032 236 / 0.28) 1px, transparent 1px);
   }
 }

--- a/plugin/dashboard/app/layout.tsx
+++ b/plugin/dashboard/app/layout.tsx
@@ -1,13 +1,19 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import { Sidebar } from "@/components/layout/sidebar";
 import { TopBar } from "@/components/layout/top-bar";
 import { StallBanner } from "@/components/stall-banner";
 
-const inter = Inter({
+const plexSans = IBM_Plex_Sans({
   variable: "--font-sans",
+  weight: ["400", "500", "600", "700"],
+  subsets: ["latin"],
+});
+
+const jetBrainsMono = JetBrains_Mono({
+  variable: "--font-geist-mono",
   subsets: ["latin"],
 });
 
@@ -22,16 +28,25 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} h-full`} suppressHydrationWarning>
-      <body className="h-full flex flex-col antialiased font-sans">
+    <html
+      lang="en"
+      className={`${plexSans.variable} ${jetBrainsMono.variable} h-full`}
+      suppressHydrationWarning
+    >
+      <body
+        className="h-full flex flex-col antialiased font-sans"
+        suppressHydrationWarning
+      >
         <Providers>
           <StallBanner />
           <TopBar />
           <div className="flex flex-1 min-h-0">
-            <aside className="hidden lg:block w-60 border-r border-border shrink-0">
+            <aside className="hidden lg:block w-64 border-r border-sidebar-border bg-sidebar/95 shrink-0">
               <Sidebar />
             </aside>
-            <main className="flex-1 min-w-0 flex flex-col">{children}</main>
+            <main className="flex-1 min-w-0 flex flex-col bg-background/88">
+              {children}
+            </main>
           </div>
         </Providers>
       </body>

--- a/plugin/dashboard/app/layout.tsx
+++ b/plugin/dashboard/app/layout.tsx
@@ -1,21 +1,9 @@
 import type { Metadata } from "next";
-import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import { Sidebar } from "@/components/layout/sidebar";
 import { TopBar } from "@/components/layout/top-bar";
 import { StallBanner } from "@/components/stall-banner";
-
-const plexSans = IBM_Plex_Sans({
-  variable: "--font-sans",
-  weight: ["400", "500", "600", "700"],
-  subsets: ["latin"],
-});
-
-const jetBrainsMono = JetBrains_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Claude-Smart Dashboard",
@@ -30,7 +18,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${plexSans.variable} ${jetBrainsMono.variable} h-full`}
+      className="h-full"
       suppressHydrationWarning
     >
       <body

--- a/plugin/dashboard/app/preferences/[id]/page.tsx
+++ b/plugin/dashboard/app/preferences/[id]/page.tsx
@@ -199,7 +199,7 @@ export default function PreferenceDetailPage({
         <div className="mx-auto max-w-5xl grid gap-6 lg:grid-cols-[1fr_280px]">
           <div className="space-y-6 min-w-0">
             {error && (
-              <div className="rounded-xl border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm flex items-start gap-2">
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm flex items-start gap-2">
                 <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
                 <span>{error}</span>
               </div>
@@ -236,7 +236,7 @@ export default function PreferenceDetailPage({
                   onChange={(e) => setContent(e.target.value)}
                   rows={6}
                   placeholder="e.g. Project bans pytest-asyncio; uses anyio with trio backend for async tests."
-                  className="w-full rounded-xl border border-input bg-transparent px-4 py-3 text-sm leading-relaxed font-sans resize-y outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 placeholder:text-muted-foreground"
+                  className="w-full rounded-lg border border-input bg-transparent px-4 py-3 text-sm leading-relaxed font-sans resize-y outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 placeholder:text-muted-foreground"
                 />
               ) : (
                 <Prose text={profile?.content ?? ""} />
@@ -269,7 +269,7 @@ export default function PreferenceDetailPage({
                 title="Custom features"
                 hint="Structured metadata attached to this preference."
               >
-                <div className="rounded-xl border border-border bg-card overflow-hidden">
+                <div className="rounded-lg border border-border bg-card overflow-hidden">
                   <dl className="divide-y divide-border">
                     {customEntries.map(([k, v]) => (
                       <div
@@ -305,8 +305,8 @@ export default function PreferenceDetailPage({
 
           {profile && (
             <aside className="space-y-3 lg:sticky lg:top-6 lg:self-start">
-              <div className="rounded-xl border border-border bg-card p-4">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <div className="rounded-lg border border-border bg-card p-4">
+                <h3 className="text-xs font-semibold uppercase text-muted-foreground mb-3">
                   Metadata
                 </h3>
                 <dl className="space-y-2.5 text-sm">
@@ -390,7 +390,7 @@ function Prose({ text }: { text: string }) {
     return <p className="text-sm text-muted-foreground italic">—</p>;
   }
   return (
-    <div className="rounded-xl border border-border bg-card px-4 py-3">
+    <div className="rounded-lg border border-border bg-card px-4 py-3">
       <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">
         {text}
       </p>

--- a/plugin/dashboard/app/preferences/page.tsx
+++ b/plugin/dashboard/app/preferences/page.tsx
@@ -54,7 +54,7 @@ export default function PreferencesPage() {
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
               placeholder="Filter"
-              className="h-8 w-56 text-xs"
+              className="h-9 w-56 text-xs bg-background/80"
             />
             <DeleteAllButton
               label={`Delete all${profiles && profiles.length > 0 ? ` (${profiles.length})` : ""}`}
@@ -90,7 +90,7 @@ export default function PreferencesPage() {
               <Link
                 key={p.profile_id}
                 href={`/preferences/project/${encodeURIComponent(p.profile_id)}`}
-                className="group block rounded-xl border border-border bg-card p-4 hover:bg-accent/40 transition-colors"
+                className="group block rounded-lg border border-border bg-card/92 p-4 shadow-sm transition-colors hover:border-primary/35 hover:bg-accent/45"
               >
                 <header className="flex items-center justify-between gap-2 mb-2">
                   <div className="flex items-center gap-2 min-w-0">
@@ -110,7 +110,9 @@ export default function PreferencesPage() {
                     <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/60 group-hover:text-foreground transition-colors" />
                   </div>
                 </header>
-                <p className="text-sm leading-relaxed line-clamp-4">{p.content}</p>
+                <p className="rounded-md border border-border bg-background/60 px-3 py-2 text-sm leading-relaxed line-clamp-4">
+                  {p.content}
+                </p>
                 {p.source && (
                   <p className="text-[11px] text-muted-foreground mt-2 font-mono">
                     source: {p.source}

--- a/plugin/dashboard/app/sessions/[sessionId]/page.tsx
+++ b/plugin/dashboard/app/sessions/[sessionId]/page.tsx
@@ -121,7 +121,7 @@ export default function InteractionDetailPage({
                 <article
                   key={idx}
                   className={cn(
-                    "rounded-xl border px-4 py-3 bg-card",
+                    "rounded-lg border px-4 py-3 bg-card",
                     flagged
                       ? "border-destructive/30 bg-destructive/5"
                       : "border-border",
@@ -177,7 +177,7 @@ export default function InteractionDetailPage({
                                 <div className="mt-1 space-y-1.5">
                                   {hasInput && (
                                     <div>
-                                      <div className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/70 mb-0.5">
+                                      <div className="text-[10px] font-mono uppercase text-muted-foreground/70 mb-0.5">
                                         input
                                       </div>
                                       <pre className="whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 px-2 py-1 text-[10px] font-mono text-muted-foreground">
@@ -187,7 +187,7 @@ export default function InteractionDetailPage({
                                   )}
                                   {hasOutput && (
                                     <div>
-                                      <div className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/70 mb-0.5">
+                                      <div className="text-[10px] font-mono uppercase text-muted-foreground/70 mb-0.5">
                                         output
                                       </div>
                                       <pre className="whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 px-2 py-1 text-[10px] font-mono text-muted-foreground">

--- a/plugin/dashboard/app/sessions/page.tsx
+++ b/plugin/dashboard/app/sessions/page.tsx
@@ -60,12 +60,12 @@ export default function SessionsPage() {
         actions={
           <div className="flex items-center gap-2">
             <div className="relative">
-              <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
                 placeholder="Search sessions…"
-                className="h-8 w-64 pl-7 text-xs"
+                className="h-9 w-64 pl-8 text-xs bg-background/80"
               />
             </div>
             <DeleteAllButton
@@ -108,14 +108,14 @@ export default function SessionsPage() {
             {grouped.map(([label, items]) => (
               <section key={label}>
                 <div className="flex items-center gap-2 mb-2 px-1">
-                  <h2 className="text-[11px] uppercase tracking-wider font-medium text-muted-foreground">
+                  <h2 className="text-[11px] uppercase font-semibold text-muted-foreground">
                     {label}
                   </h2>
                   <span className="text-[11px] text-muted-foreground/70">
                     · {items.length}
                   </span>
                 </div>
-                <div className="rounded-xl border border-border divide-y divide-border bg-card overflow-hidden">
+                <div className="rounded-lg border border-border divide-y divide-border bg-card/90 overflow-hidden shadow-sm">
                   {items.map((s) => (
                     <div
                       key={s.session_id}
@@ -134,11 +134,14 @@ export default function SessionsPage() {
                           );
                         }
                       }}
-                      className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-accent/40 focus:bg-accent/40 focus:outline-none transition-colors"
+                      className="flex cursor-pointer flex-col gap-2 px-4 py-3 transition-colors hover:bg-accent/45 focus:bg-accent/45 focus:outline-none sm:flex-row sm:items-center"
                     >
-                      <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
+                      <div className="flex min-w-0 items-start gap-3">
+                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                          <MessageSquare className="h-4 w-4" />
+                        </span>
+                        <div className="flex-1 min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
                           <p className="text-sm truncate">
                             {s.preview ?? (
                               <span className="text-muted-foreground italic">
@@ -167,10 +170,11 @@ export default function SessionsPage() {
                                   {s.published_up_to} published
                                 </span>
                               </>
-                            )}
+                          )}
+                        </div>
                         </div>
                       </div>
-                      <div className="text-xs text-muted-foreground shrink-0 tabular-nums">
+                      <div className="self-end text-xs text-muted-foreground tabular-nums sm:shrink-0">
                         {formatRelative(s.last_activity)}
                       </div>
                     </div>

--- a/plugin/dashboard/app/skills/page.tsx
+++ b/plugin/dashboard/app/skills/page.tsx
@@ -191,7 +191,7 @@ export default function SkillsPage() {
               value={agentVersion}
               onValueChange={(v) => setAgentVersion(v ?? "__all__")}
             >
-              <SelectTrigger size="sm" className="w-40 text-xs">
+              <SelectTrigger size="sm" className="w-40 text-xs bg-background/80">
                 <SelectValue placeholder="Project" />
               </SelectTrigger>
               <SelectContent>
@@ -207,7 +207,7 @@ export default function SkillsPage() {
               value={statusFilter}
               onValueChange={(v) => setStatusFilter(v ?? "__all__")}
             >
-              <SelectTrigger size="sm" className="w-36 text-xs">
+              <SelectTrigger size="sm" className="w-36 text-xs bg-background/80">
                 <SelectValue placeholder="Status" />
               </SelectTrigger>
               <SelectContent>
@@ -246,7 +246,7 @@ export default function SkillsPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search"
-              className="h-8 w-48 text-xs"
+              className="h-9 w-48 text-xs bg-background/80"
             />
             <DeleteAllButton
               label={`Delete ${activeKind === "project" ? "project" : "shared"}${activeCount > 0 ? ` (${activeCount})` : ""}`}
@@ -320,7 +320,7 @@ export default function SkillsPage() {
               <Link
                 key={`${p.kind}:${p.id}`}
                 href={`/skills/${p.kind}/${p.id}`}
-                className="block rounded-xl border border-border bg-card p-4 hover:bg-accent/40 transition-colors"
+                className="block rounded-lg border border-border bg-card/92 p-4 shadow-sm transition-colors hover:border-primary/35 hover:bg-accent/45"
               >
                 <header className="flex items-center justify-between gap-2 mb-2">
                   <div className="flex items-center gap-2 min-w-0">
@@ -339,7 +339,7 @@ export default function SkillsPage() {
                 </header>
                 <p
                   className={cn(
-                    "text-sm leading-relaxed line-clamp-4",
+                    "rounded-md border border-border bg-background/60 px-3 py-2 text-sm leading-relaxed line-clamp-4",
                     !p.trigger && "text-muted-foreground italic",
                   )}
                 >

--- a/plugin/dashboard/app/skills/project/[id]/page.tsx
+++ b/plugin/dashboard/app/skills/project/[id]/page.tsx
@@ -223,7 +223,7 @@ export default function ProjectSkillDetailPage({
         <div className="mx-auto max-w-5xl grid gap-6 lg:grid-cols-[1fr_280px]">
           <div className="space-y-6 min-w-0">
             {error && (
-              <div className="rounded-xl border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm flex items-start gap-2">
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm flex items-start gap-2">
                 <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
                 <span>{error}</span>
               </div>
@@ -317,8 +317,8 @@ export default function ProjectSkillDetailPage({
 
           {playbook && (
             <aside className="space-y-3 lg:sticky lg:top-6 lg:self-start">
-              <div className="rounded-xl border border-border bg-card p-4">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <div className="rounded-lg border border-border bg-card p-4">
+                <h3 className="text-xs font-semibold uppercase text-muted-foreground mb-3">
                   Metadata
                 </h3>
                 <dl className="space-y-2.5 text-sm">
@@ -359,8 +359,8 @@ export default function ProjectSkillDetailPage({
               </div>
 
               {playbook.source_interaction_ids?.length > 0 && (
-                <div className="rounded-xl border border-border bg-card p-4">
-                  <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+                <div className="rounded-lg border border-border bg-card p-4">
+                  <h3 className="text-xs font-semibold uppercase text-muted-foreground mb-3">
                     Extracted from
                   </h3>
                   <p className="text-xs text-muted-foreground mb-2">
@@ -431,7 +431,7 @@ function Prose({ text, muted = false }: { text: string; muted?: boolean }) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-border bg-card px-4 py-3",
+        "rounded-lg border border-border bg-card px-4 py-3",
         muted && "bg-muted/30",
       )}
     >
@@ -459,7 +459,7 @@ function AutoTextarea({
       onChange={(e) => onChange(e.target.value)}
       rows={rows}
       placeholder={placeholder}
-      className="w-full rounded-xl border border-input bg-transparent px-4 py-3 text-sm leading-relaxed font-sans resize-y outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 placeholder:text-muted-foreground"
+      className="w-full rounded-lg border border-input bg-transparent px-4 py-3 text-sm leading-relaxed font-sans resize-y outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 placeholder:text-muted-foreground"
     />
   );
 }

--- a/plugin/dashboard/app/skills/shared/[id]/page.tsx
+++ b/plugin/dashboard/app/skills/shared/[id]/page.tsx
@@ -293,7 +293,7 @@ export default function SharedSkillDetailPage({
         <div className="mx-auto max-w-5xl grid gap-6 lg:grid-cols-[1fr_280px]">
           <div className="space-y-6 min-w-0">
             {error && (
-              <div className="rounded-xl border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm flex items-start gap-2">
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm flex items-start gap-2">
                 <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
                 <span>{error}</span>
               </div>
@@ -458,8 +458,8 @@ export default function SharedSkillDetailPage({
 
           {playbook && (
             <aside className="space-y-3 lg:sticky lg:top-6 lg:self-start">
-              <div className="rounded-xl border border-border bg-card p-4">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <div className="rounded-lg border border-border bg-card p-4">
+                <h3 className="text-xs font-semibold uppercase text-muted-foreground mb-3">
                   Metadata
                 </h3>
                 <dl className="space-y-2.5 text-sm">
@@ -539,7 +539,7 @@ function Prose({ text, muted = false }: { text: string; muted?: boolean }) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-border bg-card px-4 py-3",
+        "rounded-lg border border-border bg-card px-4 py-3",
         muted && "bg-muted/30",
       )}
     >
@@ -567,7 +567,7 @@ function AutoTextarea({
       onChange={(e) => onChange(e.target.value)}
       rows={rows}
       placeholder={placeholder}
-      className="w-full rounded-xl border border-input bg-transparent px-4 py-3 text-sm leading-relaxed font-sans resize-y outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 placeholder:text-muted-foreground"
+      className="w-full rounded-lg border border-input bg-transparent px-4 py-3 text-sm leading-relaxed font-sans resize-y outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 placeholder:text-muted-foreground"
     />
   );
 }

--- a/plugin/dashboard/components/common/empty-state.tsx
+++ b/plugin/dashboard/components/common/empty-state.tsx
@@ -17,12 +17,14 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center text-center py-12 px-6 border border-dashed border-border rounded-xl bg-muted/20",
+        "flex flex-col items-center justify-center text-center py-12 px-6 border border-dashed border-border rounded-lg bg-card/72",
         className,
       )}
     >
       {Icon && (
-        <Icon className="h-8 w-8 text-muted-foreground/60 mb-3" strokeWidth={1.5} />
+        <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-lg border border-primary/15 bg-primary/10 text-primary">
+          <Icon className="h-6 w-6" strokeWidth={1.5} />
+        </div>
       )}
       <div className="text-sm font-medium text-foreground">{title}</div>
       {description && (

--- a/plugin/dashboard/components/common/learnings-badge.tsx
+++ b/plugin/dashboard/components/common/learnings-badge.tsx
@@ -17,7 +17,7 @@ export function LearningsBadge({
     <Badge
       variant="outline"
       className={cn(
-        "border-amber-500/40 gap-1",
+        "border-amber-500/45 bg-amber-500/10 text-amber-700 gap-1 dark:text-amber-300",
         isSmall ? "h-4 px-1.5 text-[10px] shrink-0" : "h-5",
         className,
       )}

--- a/plugin/dashboard/components/common/page-header.tsx
+++ b/plugin/dashboard/components/common/page-header.tsx
@@ -14,14 +14,16 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "border-b border-border px-6 py-5 flex flex-wrap items-start justify-between gap-4",
+        "border-b border-border bg-background/72 px-6 py-6 flex flex-wrap items-start justify-between gap-4 backdrop-blur",
         className,
       )}
     >
       <div className="min-w-[min(18rem,100%)] flex-1">
-        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        <h1 className="text-2xl font-semibold">{title}</h1>
         {description && (
-          <p className="text-sm text-muted-foreground mt-0.5">{description}</p>
+          <p className="text-sm text-muted-foreground mt-1 max-w-3xl">
+            {description}
+          </p>
         )}
       </div>
       {actions && (

--- a/plugin/dashboard/components/common/page-tabs.tsx
+++ b/plugin/dashboard/components/common/page-tabs.tsx
@@ -75,11 +75,11 @@ export function PageTabs({
         );
 
         const className = cn(
-          "relative rounded-lg border px-3 py-2.5 text-left transition-colors",
-          "hover:border-foreground/25 hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+          "relative rounded-lg border px-4 py-3 text-left transition-colors",
+          "hover:border-primary/35 hover:bg-accent/45 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
           active
-            ? "border-foreground/25 bg-card text-foreground shadow-sm before:absolute before:inset-x-3 before:top-0 before:h-0.5 before:rounded-full before:bg-foreground"
-            : "border-border bg-background/60 text-muted-foreground",
+            ? "border-primary/35 bg-card text-foreground shadow-sm before:absolute before:inset-x-4 before:top-0 before:h-0.5 before:rounded-full before:bg-primary"
+            : "border-border bg-background/70 text-muted-foreground",
         );
 
         if (item.href) {

--- a/plugin/dashboard/components/common/stat-card.tsx
+++ b/plugin/dashboard/components/common/stat-card.tsx
@@ -17,22 +17,26 @@ export function StatCard({
   return (
     <div
       className={cn(
-        "rounded-xl border border-border bg-card px-5 py-4 flex items-start justify-between gap-4",
+        "rounded-lg border border-border bg-card/92 px-5 py-4 flex items-start justify-between gap-4 shadow-sm",
         className,
       )}
     >
       <div className="min-w-0">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground font-medium">
+        <div className="text-xs uppercase text-muted-foreground font-semibold">
           {label}
         </div>
-        <div className="mt-1.5 text-2xl font-semibold tracking-tight tabular-nums">
+        <div className="mt-2 text-3xl font-semibold tabular-nums text-foreground">
           {value}
         </div>
         {hint && (
-          <div className="text-xs text-muted-foreground mt-1">{hint}</div>
+          <div className="text-xs text-muted-foreground mt-1.5">{hint}</div>
         )}
       </div>
-      {Icon && <Icon className="h-4 w-4 text-muted-foreground mt-0.5" />}
+      {Icon && (
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary/15 bg-primary/10 text-primary">
+          <Icon className="h-4 w-4" />
+        </div>
+      )}
     </div>
   );
 }

--- a/plugin/dashboard/components/layout/sidebar.tsx
+++ b/plugin/dashboard/components/layout/sidebar.tsx
@@ -11,13 +11,20 @@ export function Sidebar() {
 
   return (
     <ScrollArea className="h-full">
-      <div className="px-3 py-4">
-        <div className="px-2 mb-6">
-          <div className="font-semibold text-sm">Claude-Smart</div>
-          <div className="text-[11px] text-muted-foreground font-mono">dashboard</div>
+      <div className="px-3 py-5">
+        <div className="mb-6 rounded-lg border border-sidebar-border bg-background/55 p-3">
+          <div className="flex items-center gap-2">
+            <div className="h-2.5 w-2.5 rounded-full bg-primary" />
+            <div className="font-semibold text-sm text-sidebar-foreground">
+              Claude-Smart
+            </div>
+          </div>
+          <div className="mt-1 text-[11px] text-muted-foreground">
+            Sessions, preferences, skills, and runtime controls.
+          </div>
         </div>
 
-        <nav className="space-y-0.5">
+        <nav className="space-y-1">
           {navItems.map((item) => {
             const active =
               pathname === item.href || pathname.startsWith(`${item.href}/`);
@@ -27,13 +34,21 @@ export function Sidebar() {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  "flex items-center gap-2 px-2 py-1.5 text-sm rounded-md transition-colors",
+                  "group relative flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition-colors",
                   active
-                    ? "bg-accent text-accent-foreground font-medium"
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                    ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium shadow-sm"
+                    : "text-muted-foreground hover:bg-background/70 hover:text-foreground",
                 )}
               >
-                <Icon className="h-4 w-4 shrink-0" />
+                {active && (
+                  <span className="absolute left-0 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-full bg-primary" />
+                )}
+                <Icon
+                  className={cn(
+                    "h-4 w-4 shrink-0",
+                    active ? "text-primary" : "text-muted-foreground",
+                  )}
+                />
                 <span className="truncate">{item.label}</span>
               </Link>
             );

--- a/plugin/dashboard/components/layout/top-bar.tsx
+++ b/plugin/dashboard/components/layout/top-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useTheme } from "next-themes";
 import Image from "next/image";
-import { Moon, Sun, Menu } from "lucide-react";
+import { Link2, Menu, Moon, Sun } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useSettings } from "@/hooks/use-settings";
@@ -14,7 +14,7 @@ export function TopBar() {
   const { theme, setTheme } = useTheme();
 
   return (
-    <header className="h-14 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 flex items-center px-4 gap-3 shrink-0">
+    <header className="h-16 border-b border-border bg-card/92 backdrop-blur supports-[backdrop-filter]:bg-card/78 flex items-center px-4 gap-3 shrink-0 shadow-[0_1px_0_oklch(1_0_0/0.42)_inset] dark:shadow-none">
       <Sheet>
         <SheetTrigger
           render={<Button variant="ghost" size="icon" className="lg:hidden" />}
@@ -27,34 +27,51 @@ export function TopBar() {
       </Sheet>
 
       <div className="flex items-center gap-2 flex-1 min-w-0">
-        <Image
-          src="/claude-smart-icon.png"
-          alt="claude-smart"
-          width={24}
-          height={24}
-          className="h-6 w-6 shrink-0"
-          priority
-        />
-        <span className="text-sm font-semibold whitespace-nowrap hidden sm:block">
-          Claude-Smart
-        </span>
-        <div className="mx-2 h-5 w-px bg-border hidden sm:block" />
-        <label className="text-xs text-muted-foreground whitespace-nowrap hidden sm:block">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary/20 bg-primary/10">
+          <Image
+            src="/claude-smart-icon.png"
+            alt="claude-smart"
+            width={24}
+            height={24}
+            className="h-6 w-6"
+            priority
+          />
+        </div>
+        <div className="hidden min-w-0 sm:block">
+          <div className="text-sm font-semibold leading-5">Claude-Smart</div>
+          <div className="text-[11px] text-muted-foreground leading-4">
+            memory workbench
+          </div>
+        </div>
+        <div className="mx-2 h-8 w-px bg-border hidden md:block" />
+        <label className="hidden items-center gap-1.5 rounded-md border border-border bg-background/70 px-2 py-1 text-xs text-muted-foreground md:flex">
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_0_3px_oklch(0.72_0.14_148/0.16)]" />
           Reflexio
         </label>
-        <Input
-          value={reflexioUrl}
-          onChange={(e) => setReflexioUrl(e.target.value)}
-          placeholder="http://localhost:8071"
-          className="h-8 text-xs max-w-xs font-mono"
-        />
+        <div
+          className="relative max-w-md flex-1 sm:flex-none sm:w-[22rem]"
+          suppressHydrationWarning
+        >
+          <Link2 className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={reflexioUrl}
+            onChange={(e) => setReflexioUrl(e.target.value)}
+            placeholder="http://localhost:8071"
+            className="h-9 pl-8 text-xs font-mono bg-background/80"
+            autoComplete="off"
+            data-1p-ignore
+            data-form-type="other"
+            data-lpignore="true"
+          />
+        </div>
       </div>
 
       <Button
         variant="ghost"
         size="icon"
-        className="h-8 w-8"
+        className="h-9 w-9"
         onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        title="Toggle theme"
       >
         <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
         <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />

--- a/plugin/dashboard/components/layout/top-bar.tsx
+++ b/plugin/dashboard/components/layout/top-bar.tsx
@@ -44,7 +44,10 @@ export function TopBar() {
           </div>
         </div>
         <div className="mx-2 h-8 w-px bg-border hidden md:block" />
-        <label className="hidden items-center gap-1.5 rounded-md border border-border bg-background/70 px-2 py-1 text-xs text-muted-foreground md:flex">
+        <label
+          htmlFor="reflexio-url"
+          className="hidden items-center gap-1.5 rounded-md border border-border bg-background/70 px-2 py-1 text-xs text-muted-foreground md:flex"
+        >
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_0_3px_oklch(0.72_0.14_148/0.16)]" />
           Reflexio
         </label>
@@ -54,10 +57,12 @@ export function TopBar() {
         >
           <Link2 className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
+            id="reflexio-url"
             value={reflexioUrl}
             onChange={(e) => setReflexioUrl(e.target.value)}
             placeholder="http://localhost:8071"
             className="h-9 pl-8 text-xs font-mono bg-background/80"
+            aria-label="Reflexio endpoint URL"
             autoComplete="off"
             data-1p-ignore
             data-form-type="other"
@@ -72,6 +77,7 @@ export function TopBar() {
         className="h-9 w-9"
         onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
         title="Toggle theme"
+        aria-label="Toggle theme"
       >
         <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
         <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />

--- a/plugin/dashboard/components/ui/input.tsx
+++ b/plugin/dashboard/components/ui/input.tsx
@@ -8,6 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
     <InputPrimitive
       type={type}
       data-slot="input"
+      suppressHydrationWarning
       className={cn(
         "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -42,6 +42,14 @@ claude_smart_is_internal_invocation_env() {
   return 1
 }
 
+claude_smart_emit_continue() {
+  if [ "${CLAUDE_SMART_HOST:-claude-code}" = "codex" ]; then
+    echo '{"continue":true}'
+  else
+    echo '{"continue":true,"suppressOutput":true}'
+  fi
+}
+
 claude_smart_dashboard_unavailable_marker() {
   printf '%s\n' "$HOME/.claude-smart/dashboard-unavailable"
 }

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -67,7 +67,7 @@ LOG_MAX_BYTES="$(claude_smart_log_max_bytes)"
 mkdir -p "$STATE_DIR"
 claude_smart_trim_log_file "$LOG_FILE" "$LOG_MAX_BYTES"
 
-emit_ok() { echo '{"continue":true,"suppressOutput":true}'; }
+emit_ok() { claude_smart_emit_continue; }
 
 emit_start_failure() {
   reason="$1"

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -36,12 +36,10 @@ export EMBEDDING_PORT
 # pre-exporting these to 0.
 export CLAUDE_SMART_USE_LOCAL_CLI="${CLAUDE_SMART_USE_LOCAL_CLI:-1}"
 export CLAUDE_SMART_USE_LOCAL_EMBEDDING="${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}"
-case "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" in
-  1|true|True|yes|YES|on|ON)
-    export REFLEXIO_EMBEDDING_PROVIDER="${REFLEXIO_EMBEDDING_PROVIDER:-local_service}"
-    export REFLEXIO_EMBEDDING_SERVICE_URL="${REFLEXIO_EMBEDDING_SERVICE_URL:-http://127.0.0.1:$EMBEDDING_PORT}"
-    ;;
-esac
+if [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ]; then
+  export REFLEXIO_EMBEDDING_PROVIDER="${REFLEXIO_EMBEDDING_PROVIDER:-local_service}"
+  export REFLEXIO_EMBEDDING_SERVICE_URL="${REFLEXIO_EMBEDDING_SERVICE_URL:-http://127.0.0.1:$EMBEDDING_PORT}"
+fi
 # The backend can be spawned from contexts whose PATH lacks the host
 # CLI dir (commonly ~/.local/bin or /opt/homebrew/bin). Pin the CLI
 # explicitly if we can resolve it from our own (post-login-path) PATH.

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -36,10 +36,12 @@ export EMBEDDING_PORT
 # pre-exporting these to 0.
 export CLAUDE_SMART_USE_LOCAL_CLI="${CLAUDE_SMART_USE_LOCAL_CLI:-1}"
 export CLAUDE_SMART_USE_LOCAL_EMBEDDING="${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}"
-if [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ]; then
-  export REFLEXIO_EMBEDDING_PROVIDER="${REFLEXIO_EMBEDDING_PROVIDER:-local_service}"
-  export REFLEXIO_EMBEDDING_SERVICE_URL="${REFLEXIO_EMBEDDING_SERVICE_URL:-http://127.0.0.1:$EMBEDDING_PORT}"
-fi
+case "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" in
+  1|true|True|yes|YES|on|ON)
+    export REFLEXIO_EMBEDDING_PROVIDER="${REFLEXIO_EMBEDDING_PROVIDER:-local_service}"
+    export REFLEXIO_EMBEDDING_SERVICE_URL="${REFLEXIO_EMBEDDING_SERVICE_URL:-http://127.0.0.1:$EMBEDDING_PORT}"
+    ;;
+esac
 # The backend can be spawned from contexts whose PATH lacks the host
 # CLI dir (commonly ~/.local/bin or /opt/homebrew/bin). Pin the CLI
 # explicitly if we can resolve it from our own (post-login-path) PATH.

--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -16,7 +16,7 @@ const DASHBOARD_PORT = 3001;
 const LOG_MAX_BYTES = 10000000;
 
 function emitOk() {
-  process.stdout.write('{"continue":true,"suppressOutput":true}\n');
+  process.stdout.write('{"continue":true}\n');
 }
 
 function emitNormalizedHookOutput(stdout) {
@@ -50,9 +50,7 @@ function emitNormalizedHookOutput(stdout) {
   if (!Object.prototype.hasOwnProperty.call(merged, "continue")) {
     merged.continue = true;
   }
-  if (!Object.prototype.hasOwnProperty.call(merged, "suppressOutput")) {
-    merged.suppressOutput = true;
-  }
+  delete merged.suppressOutput;
   process.stdout.write(`${JSON.stringify(merged)}\n`);
 }
 

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -36,7 +36,7 @@ PID_FILE="$STATE_DIR/dashboard.pid"
 LOG_FILE="$STATE_DIR/dashboard.log"
 mkdir -p "$STATE_DIR"
 
-emit_ok() { echo '{"continue":true,"suppressOutput":true}'; }
+emit_ok() { claude_smart_emit_continue; }
 
 # Tree-kill the recorded process. Delegates to claude_smart_kill_tree
 # (POSIX: signal the process group; Windows: taskkill /T /F /PID).

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -19,18 +19,15 @@ case "$EVENT" in
     ;;
 esac
 export CLAUDE_SMART_HOST="$HOST"
-if [ -z "$EVENT" ]; then
-  if [ "$HOST" = "codex" ]; then
-    echo '{"continue":true}'
-  else
-    echo '{"continue":true,"suppressOutput":true}'
-  fi
-  exit 0
-fi
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
+if [ -z "$EVENT" ]; then
+  claude_smart_emit_continue
+  exit 0
+fi
+
 if claude_smart_is_internal_invocation_env; then
   claude_smart_emit_continue
   exit 0

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -18,8 +18,13 @@ case "$EVENT" in
     EVENT="${2:-}"
     ;;
 esac
+export CLAUDE_SMART_HOST="$HOST"
 if [ -z "$EVENT" ]; then
-  echo '{"continue":true,"suppressOutput":true}'
+  if [ "$HOST" = "codex" ]; then
+    echo '{"continue":true}'
+  else
+    echo '{"continue":true,"suppressOutput":true}'
+  fi
   exit 0
 fi
 
@@ -27,7 +32,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
 if claude_smart_is_internal_invocation_env; then
-  echo '{"continue":true,"suppressOutput":true}'
+  claude_smart_emit_continue
   exit 0
 fi
 # Pick up uv from the user's login-shell PATH (covers ~/.local/bin populated
@@ -70,7 +75,7 @@ print(json.dumps({
 }))
 PY
     else
-      echo '{"continue":true,"suppressOutput":true}'
+      claude_smart_emit_continue
     fi
     exit 0
   fi
@@ -82,7 +87,7 @@ if ! command -v uv >/dev/null 2>&1; then
   # the same installer detached so normal work is not blocked by first-run
   # dependency setup.
   if [ "${CLAUDE_SMART_BOOTSTRAPPING:-}" = "1" ]; then
-    echo '{"continue":true,"suppressOutput":true}'
+    claude_smart_emit_continue
     exit 0
   fi
   if [ -x "$PLUGIN_ROOT/scripts/smart-install.sh" ]; then
@@ -102,7 +107,7 @@ if ! command -v uv >/dev/null 2>&1; then
     fi
   fi
   if ! command -v uv >/dev/null 2>&1; then
-    echo '{"continue":true,"suppressOutput":true}'
+    claude_smart_emit_continue
     exit 0
   fi
 fi

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -47,7 +47,7 @@ acquire_install_lock() {
     exec 9>"$INSTALL_LOCK"
     if ! flock 9; then
       echo "[claude-smart] install lock failed; continuing without serialization" >&2
-      echo '{"continue":true,"suppressOutput":true}'
+      claude_smart_emit_continue
       exit 0
     fi
     return 0
@@ -91,7 +91,7 @@ write_failure() {
   } > "$FAILURE_MARKER"
   rm -f "$SUCCESS_MARKER"
   echo "[claude-smart] install failed: $reason" >&2
-  echo '{"continue":true,"suppressOutput":true}'
+  claude_smart_emit_continue
   exit 0
 }
 
@@ -360,7 +360,7 @@ fi
 preflight_supported_runtime_platform
 
 if install_complete; then
-  echo '{"continue":true,"suppressOutput":true}'
+  claude_smart_emit_continue
   exit 0
 fi
 
@@ -511,4 +511,4 @@ fi
 
 write_success_marker
 echo "[claude-smart] install complete. Backend and dashboard auto-start on session start." >&2
-echo '{"continue":true,"suppressOutput":true}'
+claude_smart_emit_continue

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -744,7 +744,7 @@ def test_codex_hook_ensure_root_tracks_active_plugin_root(tmp_path: Path) -> Non
 
     assert result.returncode == 0, result.stderr
     assert (reflexio / "plugin-root").resolve() == cache_root
-    assert json.loads(result.stdout) == {"continue": True, "suppressOutput": True}
+    assert json.loads(result.stdout) == {"continue": True}
 
 
 def test_codex_hook_caps_backend_log_appends(tmp_path: Path) -> None:
@@ -769,7 +769,7 @@ def test_codex_hook_caps_backend_log_appends(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout) == {"continue": True, "suppressOutput": True}
+    assert json.loads(result.stdout) == {"continue": True}
     assert log.stat().st_size <= 10_000_000
 
 


### PR DESCRIPTION
## Summary
- Refresh the claude-smart dashboard into a sharper memory workbench theme with stronger light/dark tokens, clearer app chrome, and denser operational layouts.
- Improve dashboard, sessions, skills, preferences, and configure screens so learned data is easier to scan across desktop and mobile.
- Suppress browser-extension hydration noise on the body and shared input path, and mark the Reflexio URL field to discourage password-manager decoration.
- Preserve the existing backend autostart/local embedding fixes that were already ahead of `origin/main` in the checked-out submodule pointer.

## Changes
- Theme and shell
  - Replace neutral ShadCN defaults with cyan/teal operational tokens, tuned dark mode, grid background, IBM Plex Sans, and JetBrains Mono.
  - Rework the top bar and sidebar with a clearer product identity, connection field, active nav state, and responsive mobile chrome.
- Dashboard UI
  - Upgrade stat cards, tabs, empty states, learning badges, list rows, and content cards.
  - Refine dashboard overview, sessions list, skills cards, preference cards, and configuration panels.
  - Fix narrow-screen row overflow in session summaries.
- Hydration resilience
  - Add targeted hydration suppression for extension-injected attributes on `<body>` and the shared input surface.
  - Add password-manager ignore hints to the Reflexio endpoint input.
- Existing branch content
  - Keep backend autostart guard and explicit local embedding opt-in fixes already present in the submodule checkout.

## Test Plan
- `cd plugin/dashboard && npm run lint`
- `cd plugin/dashboard && npm run build`
  - Passes with existing Next/Turbopack warnings about workspace root inference and route file tracing.
- Browser verification with `agent-browser` against `http://127.0.0.1:3002/dashboard`:
  - Desktop light dashboard screenshot: `/tmp/claude-smart-dashboard-theme-shots/screenshot-1779231896234.png`
  - Desktop dark dashboard screenshot: `/tmp/claude-smart-dashboard-theme-shots/screenshot-1779231860354.png`
  - Mobile dashboard screenshot: `/tmp/claude-smart-dashboard-theme-shots/screenshot-1779231857924.png`
  - Skills screenshot: `/tmp/claude-smart-dashboard-theme-shots/screenshot-1779231771546.png`
  - Configure screenshot: `/tmp/claude-smart-dashboard-theme-shots/screenshot-1779231774056.png`
- Verified mobile layout does not horizontally overflow with `document.documentElement.scrollWidth <= window.innerWidth`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard: "Recent learnings" card, "Most used" learnings section, and updated recent sessions layout.
  * Skills: per-skill application frequency badges.

* **Style**
  * New richer color palette, subtle grid background, refined typography, and slightly smaller corner radii.
  * Updated card layouts, spacing, blurred translucent headers/tabs, refreshed sidebar and top bar visuals.
  * Inputs, summary panels, and many cards use translucent/tinted backgrounds; responsive polish across pages.

* **Tests**
  * Hook wrapper tests updated to match the new continue-response contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->