### PR TITLE
Pause hook retries during provider stalls

### DIFF
--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -1044,8 +1044,9 @@ def cmd_show(args: argparse.Namespace) -> int:
 def cmd_learn(args: argparse.Namespace) -> int:
     """Force reflexio extraction over the active session's interactions.
 
-    Publishes unpublished interactions with ``force_extraction=True`` so
-    extraction runs immediately rather than at the next batch interval.
+    Publishes unpublished interactions with ``force_extraction=True`` and
+    ``override_learning_stall=True`` so extraction runs immediately as an
+    explicit retry rather than at the next batch interval.
     When ``args.note`` is provided, the note is appended to the session
     buffer as a neutral User turn before publishing — letting the user
     capture an explicit insight, preference, or workflow note alongside
@@ -1083,6 +1084,7 @@ def cmd_learn(args: argparse.Namespace) -> int:
         session_id=session_id,
         project_id=project_id,
         force_extraction=True,
+        override_learning_stall=True,
         skip_aggregation=False,
     )
     if status == "ok":

--- a/plugin/src/claude_smart/publish.py
+++ b/plugin/src/claude_smart/publish.py
@@ -22,6 +22,7 @@ def publish_unpublished(
     project_id: str,
     force_extraction: bool,
     skip_aggregation: bool,
+    override_learning_stall: bool = False,
     adapter: Adapter | None = None,
 ) -> tuple[PublishStatus, int]:
     """Drain the session buffer to reflexio and stamp the high-water mark.
@@ -35,6 +36,9 @@ def publish_unpublished(
             globally per agent rather than per project.
         force_extraction (bool): Whether to ask reflexio to run extraction
             synchronously instead of queuing for the next sweep.
+        override_learning_stall (bool): Whether to bypass a recorded
+            provider auth/billing stall. Automatic hooks must leave this
+            False; explicit manual retries set it True.
         skip_aggregation (bool): When True, reflexio extracts preferences and
             raw project-specific skill entries but skips the rollup into
             shared skills. claude-smart passes False on every publish
@@ -63,6 +67,7 @@ def publish_unpublished(
         project_id=project_id,
         interactions=interactions,
         force_extraction=force_extraction,
+        override_learning_stall=override_learning_stall,
         skip_aggregation=skip_aggregation,
     )
     if ok:

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any
 
 from claude_smart import runtime
 
@@ -70,6 +71,7 @@ class Adapter:
         project_id: str,
         interactions: Sequence[dict[str, Any]],
         force_extraction: bool = False,
+        override_learning_stall: bool = False,
         skip_aggregation: bool = False,
     ) -> bool:
         """Publish buffered interactions to reflexio. Returns True on success."""
@@ -86,6 +88,7 @@ class Adapter:
                 session_id=session_id,
                 wait_for_response=False,
                 force_extraction=force_extraction,
+                override_learning_stall=override_learning_stall,
                 skip_aggregation=skip_aggregation,
             )
             return True

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -55,6 +55,7 @@ def test_publish_returns_true_on_success() -> None:
         project_id="p1",
         interactions=[{"role": "User", "content": "hi"}],
         force_extraction=True,
+        override_learning_stall=True,
     )
     assert ok is True
     # After the project-scoped preferences refactor (commit 88cb150), reflexio's
@@ -63,6 +64,7 @@ def test_publish_returns_true_on_success() -> None:
     assert client.published_kwargs["session_id"] == "s1"
     assert client.published_kwargs["agent_version"] == "claude-code"
     assert client.published_kwargs["force_extraction"] is True
+    assert client.published_kwargs["override_learning_stall"] is True
 
 
 def test_publish_returns_false_when_client_raises() -> None:

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -44,6 +44,7 @@ def test_cmd_learn_publishes_with_force_extraction(
             "session_id": "s1",
             "project_id": "test-project",
             "force_extraction": True,
+            "override_learning_stall": True,
             "skip_aggregation": False,
         }
     ]
@@ -119,6 +120,7 @@ def test_cmd_learn_with_note_appends_user_turn(
     assert records[-1]["user_id"] == "test-project"
     assert "[correction]" not in records[-1]["content"]
     assert calls and calls[0]["force_extraction"] is True
+    assert calls and calls[0]["override_learning_stall"] is True
     out = capsys.readouterr().out
     assert "Forced extraction on session `s1`" in out
     assert "including your note" in out

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1708,6 +1708,7 @@ def test_session_end_synthesises_anchor_when_buffer_ends_with_orphan_tools(
     # SessionEnd publishes synchronously so the snapshot read after the
     # hook returns sees any just-extracted rows.
     assert published_kwargs["force_extraction"] is True
+    assert published_kwargs.get("override_learning_stall") is None
 
 
 def test_session_end_uses_force_extraction_for_final_flush(
@@ -1727,6 +1728,7 @@ def test_session_end_uses_force_extraction_for_final_flush(
     )
     session_end.handle({"session_id": "s_force", "cwd": "/tmp/p"})
     assert published_kwargs["force_extraction"] is True
+    assert published_kwargs.get("override_learning_stall") is None
     # And skip_aggregation stays False — the rollup still happens.
     assert published_kwargs["skip_aggregation"] is False
 


### PR DESCRIPTION
## Summary
- pass Reflexio's explicit learning-stall override only from manual claude-smart learn retries
- leave automatic SessionEnd hook publishes on force extraction without bypassing active provider stalls
- update tests for manual learn, adapter forwarding, and SessionEnd hook behavior

## Testing
- uv run --project open_source/claude-smart/plugin ruff check --select UP035 open_source/claude-smart/plugin/src/claude_smart/reflexio_adapter.py
- uv run --project open_source/claude-smart/plugin pytest -o addopts='' open_source/claude-smart/tests/test_cli_learn.py open_source/claude-smart/tests/test_adapter.py::test_publish_returns_true_on_success open_source/claude-smart/tests/test_events.py::test_session_end_uses_force_extraction_for_final_flush open_source/claude-smart/tests/test_events.py::test_session_end_synthesises_anchor_when_buffer_ends_with_orphan_tools

Depends on ReflexioAI/reflexio#82.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated citation injection environment variable documentation with clarified default behavior and legacy value support.

* **Changes**
  * Citation instructions now enabled by default with improved compact formatting that only appends markers when materially relevant to answers.
  * Enhanced plugin path handling for resilience across different marketplace layouts.
  * Improved local development setup script to ensure proper plugin installation and updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->