### PR TITLE
fix: refresh stale dashboard after install

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -314,6 +314,7 @@ Idempotent. This single script handles the shared local-dev prep for every host 
 6. For `--host claude-code`, writes `.claude/settings.local.json` → enable `claude-smart@reflexioai-local`, disable `claude-smart@reflexioai`.
 7. For `--host claude-code`, force-sets `~/.reflexio/plugin-root` → `plugin/` so slash commands resolve to editable in-repo sources.
 8. For `--host codex`, runs `node bin/claude-smart.js install --host codex` so the installed Codex hooks are patched through the JSON-safe `scripts/codex-hook.js` adapter.
+9. Refreshes the local dashboard process. The dashboard health endpoint exposes the serving plugin root, so setup can stop a stale claude-smart dashboard from an older cache while leaving a foreign app on port `3001` alone.
 
 Then restart the target host. In a new Claude Code session, `/plugin` should show `claude-smart@reflexioai-local` and should not also show the published `claude-smart@reflexioai`. In Codex, `/plugins` should show `claude-smart` installed from the **ReflexioAI** marketplace.
 
@@ -353,7 +354,7 @@ To exercise just the Python installer path directly, run:
 uv run --project plugin claude-smart install --host codex
 ```
 
-Then fully restart Codex so hooks reload. The command installs `claude-smart` into `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/`, enables `[plugins."claude-smart@reflexioai"]`, enables Codex's hook feature flags, and seeds the per-hook trust entries in `~/.codex/config.toml`; `/plugins` should show it as installed from the **ReflexioAI** marketplace. Running `codex features enable plugin_hooks` by itself is not enough because it does not install the plugin or trust the individual hook entries. The Python installer is useful for installer development, but the Node installer is the supported local setup path for live Codex sessions because it patches hook commands through `codex-hook.js`.
+Then fully restart Codex so hooks reload. The command installs `claude-smart` into `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/`, enables `[plugins."claude-smart@reflexioai"]`, enables Codex's hook feature flags, seeds the per-hook trust entries in `~/.codex/config.toml`, and refreshes any currently running claude-smart dashboard so port `3001` does not keep serving an older cache; `/plugins` should show it as installed from the **ReflexioAI** marketplace. Running `codex features enable plugin_hooks` by itself is not enough because it does not install the plugin or trust the individual hook entries. The Python installer is useful for installer development, but the Node installer is the supported local setup path for live Codex sessions because it patches hook commands through `codex-hook.js`.
 
 The packaged Node installer path (`node bin/claude-smart.js install --host codex`, or published `npx claude-smart install --host codex`) additionally bootstraps private Node/npm plus the uv-managed Python runtime, builds the dashboard, and patches Codex hooks to the Node wrapper. The Python `uv run` path is intentionally for local development from an already-prepared checkout.
 
@@ -367,7 +368,7 @@ bash scripts/setup-local-dev.sh --host codex
 
 Avoid `~/plugins/claude-smart` for this plugin unless you also provide a patched hook manifest; Codex resolves that path before the cache, and the raw source `hooks/codex-hooks.json` uses Claude-style hook commands that can emit multiple JSON objects. The Node installer patches the copied hook manifest to call `scripts/codex-hook.js`, which normalizes hook stdout for Codex.
 
-Uninstall local Codex support with the CLI. This removes the Codex marketplace registration, installed plugin config, hook trust state, and Codex plugin cache while preserving learned data:
+Uninstall local Codex support with the CLI. This stops local claude-smart services, removes the Codex marketplace registration, installed plugin config, hook trust state, and Codex plugin cache while preserving learned data:
 
 ```bash
 uv run --project plugin claude-smart uninstall --host codex

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To uninstall:
 npx claude-smart uninstall --host codex
 ```
 
-Restart Codex after uninstalling. Learned data under `~/.reflexio/` and `~/.claude-smart/` is preserved and shared with Claude Code, so you can switch between hosts without losing skills or preferences.
+Restart Codex after uninstalling. The uninstaller stops local claude-smart services and removes plugin/cache/config state; learned data under `~/.reflexio/` and `~/.claude-smart/` is preserved and shared with Claude Code, so you can switch between hosts without losing skills or preferences.
 
 Developing the plugin itself? See [DEVELOPER.md](./DEVELOPER.md#developing-locally) for what the installer does, manual toggles via `/plugins`, and clone-based development.
 

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -76,6 +76,7 @@ const CODEX_REQUIRED_FILES = [
   "plugin/scripts/_codex_env.sh",
 ];
 const CODEX_CLI_TIMEOUT_MS = 30_000;
+const PLUGIN_SERVICE_TIMEOUT_MS = 15_000;
 const COPYTREE_IGNORE_NAMES = new Set([
   "__pycache__",
   ".venv",
@@ -360,7 +361,20 @@ function runPluginService(pluginRoot, scriptName, subcommand) {
     env: runtimeEnv(),
     stdio: "ignore",
     windowsHide: true,
+    timeout: PLUGIN_SERVICE_TIMEOUT_MS,
+    killSignal: "SIGTERM",
   });
+  if (result.error || result.signal) {
+    const reason = result.error && result.error.code === "ETIMEDOUT"
+      ? `timed out after ${PLUGIN_SERVICE_TIMEOUT_MS / 1000}s`
+      : result.error
+        ? result.error.message
+        : `terminated by ${result.signal}`;
+    process.stderr.write(
+      `warning: ${scriptName} ${subcommand} ${reason}; continuing.\n`,
+    );
+    return false;
+  }
   return result.status === 0;
 }
 

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -11,7 +11,7 @@
  */
 "use strict";
 
-const { execSync, spawn } = require("child_process");
+const { execSync, spawn, spawnSync } = require("child_process");
 const crypto = require("crypto");
 const {
   appendFileSync,
@@ -348,6 +348,32 @@ function runChecked(command, args, options = {}) {
     child.on("exit", (code) => resolve(typeof code === "number" ? code : 1));
     child.on("error", () => resolve(1));
   });
+}
+
+function runPluginService(pluginRoot, scriptName, subcommand) {
+  const script = join(pluginRoot, "scripts", scriptName);
+  if (!existsSync(script)) return false;
+  const bash = resolveCommand(isWindows() ? ["bash.exe", "bash"] : ["bash"]);
+  if (!bash) return false;
+  const result = spawnSync(bash, [script, subcommand], {
+    cwd: pluginRoot,
+    env: runtimeEnv(),
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  return result.status === 0;
+}
+
+function refreshDashboardService(pluginRoot) {
+  // dashboard-service.sh is marker-gated: stop only reaps a listener that
+  // identifies as claude-smart, so foreign apps on 3001 are left alone.
+  runPluginService(pluginRoot, "dashboard-service.sh", "stop");
+  return runPluginService(pluginRoot, "dashboard-service.sh", "start");
+}
+
+function stopClaudeSmartServices(pluginRoot) {
+  runPluginService(pluginRoot, "dashboard-service.sh", "stop");
+  runPluginService(pluginRoot, "backend-service.sh", "stop");
 }
 
 function downloadFile(url, dest) {
@@ -1161,6 +1187,7 @@ async function runUninstall(args) {
     );
     process.exit(code);
   }
+  stopClaudeSmartServices(join(PACKAGE_ROOT, "plugin"));
 
   process.stdout.write(
     [
@@ -1211,6 +1238,9 @@ async function runInstall(args) {
   try {
     const pluginRoot = await bootstrapClaudeCodeInstall();
     process.stdout.write(`Prepared claude-smart runtime at ${pluginRoot}.\n`);
+    if (refreshDashboardService(pluginRoot)) {
+      process.stdout.write("Refreshed claude-smart dashboard service.\n");
+    }
   } catch (err) {
     process.stderr.write(
       `error: claude-smart installed, but dependency bootstrap failed: ${err && err.message ? err.message : err}\n`,
@@ -1280,6 +1310,9 @@ async function runInstallCodex() {
     cacheDir = installCodexPluginCache(codexMarketplacePluginRoot(marketplaceRoot));
     process.stdout.write(`Installed Codex plugin cache at ${cacheDir}.\n`);
     await bootstrapPluginRuntime(cacheDir);
+    if (refreshDashboardService(cacheDir)) {
+      process.stdout.write("Refreshed claude-smart dashboard service.\n");
+    }
   } catch (err) {
     process.stderr.write(
       `error: automatic Codex plugin install failed: ${err && err.message ? err.message : err}\n`,
@@ -1329,6 +1362,7 @@ async function runInstallCodex() {
 }
 
 async function runUninstallCodex() {
+  stopClaudeSmartServices(join(PACKAGE_ROOT, "plugin"));
   if (!hasCli("codex")) {
     process.stdout.write("Codex CLI not found; skipping marketplace removal.\n");
     cleanupCodexInstallState();

--- a/plugin/dashboard/app/api/health/route.ts
+++ b/plugin/dashboard/app/api/health/route.ts
@@ -1,10 +1,49 @@
-export const dynamic = "force-static";
+import { readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+export const dynamic = "force-dynamic";
+
+function realpathOrSelf(value: string): string {
+  try {
+    return realpathSync(value);
+  } catch {
+    return value;
+  }
+}
+
+function pluginVersion(pluginRoot: string): string {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(path.join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+    );
+    return typeof manifest.version === "string" && manifest.version
+      ? manifest.version
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
 
 export function GET() {
-  return new Response(JSON.stringify({ service: "claude-smart-dashboard" }), {
-    headers: {
-      "content-type": "application/json",
-      "x-claude-smart-dashboard": "1",
+  const dashboardDir = realpathOrSelf(process.cwd());
+  const pluginRoot = realpathOrSelf(path.dirname(dashboardDir));
+  const version = pluginVersion(pluginRoot);
+
+  return new Response(
+    JSON.stringify({
+      service: "claude-smart-dashboard",
+      pluginRoot,
+      dashboardDir,
+      version,
+    }),
+    {
+      headers: {
+        "content-type": "application/json",
+        "x-claude-smart-dashboard": "1",
+        "x-claude-smart-plugin-root": pluginRoot,
+        "x-claude-smart-dashboard-dir": dashboardDir,
+        "x-claude-smart-version": version,
+      },
     },
-  });
+  );
 }

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -81,15 +81,40 @@ canonical_dir() {
   (cd "$dir" 2>/dev/null && pwd -P) || printf '%s\n' "$dir"
 }
 
+normalize_identity_path() {
+  path="$1"
+  if claude_smart_is_windows; then
+    if command -v cygpath >/dev/null 2>&1; then
+      path="$(cygpath -u "$path" 2>/dev/null || printf '%s\n' "$path")"
+    else
+      path="$(
+        printf '%s\n' "$path" | awk '{
+          gsub(/\\/, "/")
+          if ($0 ~ /^[A-Za-z]:/) {
+            drive = tolower(substr($0, 1, 1))
+            sub(/^[A-Za-z]:/, "/" drive)
+          }
+          print
+        }'
+      )"
+    fi
+  fi
+  while [ "${path%/}" != "$path" ] && [ "$path" != "/" ]; do
+    path="${path%/}"
+  done
+  printf '%s\n' "$path"
+}
+
 # True only if *this plugin root's* dashboard is on the port. The generic
 # x-claude-smart-dashboard marker is intentionally not enough: after an
 # install/update, an older cache can keep serving port 3001 until restarted.
 dashboard_matches_current_root() {
-  expected_root="$(canonical_dir "$PLUGIN_ROOT")"
+  expected_root="$(normalize_identity_path "$(canonical_dir "$PLUGIN_ROOT")")"
   headers="$(dashboard_health_headers)" || return 1
   printf '%s\n' "$headers" | grep -qi '^x-claude-smart-dashboard:' || return 1
   actual_root="$(printf '%s\n' "$headers" | header_value_from "x-claude-smart-plugin-root")"
   [ -n "$actual_root" ] || return 1
+  actual_root="$(normalize_identity_path "$actual_root")"
   [ "$actual_root" = "$expected_root" ]
 }
 

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -45,15 +45,71 @@ kill_group() {
 }
 
 # True if the marker header served by app/api/health is present on the
-# port. Requires curl — absence is reported as false.
+# port. Requires curl — absence is reported as false. This deliberately
+# accepts any claude-smart dashboard, including stale cache versions, so
+# stop/uninstall can safely reap them without touching foreign listeners.
 marker_responds() {
   command -v curl >/dev/null 2>&1 || return 1
   curl -sfI "http://127.0.0.1:$PORT/api/health" 2>/dev/null \
     | grep -qi '^x-claude-smart-dashboard:'
 }
 
-# True only if *our* dashboard is on the port. Uses the marker header so a
-# foreign listener on 3001 doesn't cause us to silently skip starting.
+dashboard_health_headers() {
+  command -v curl >/dev/null 2>&1 || return 1
+  curl -sfI "http://127.0.0.1:$PORT/api/health" 2>/dev/null
+}
+
+header_value_from() {
+  header_name="$1"
+  awk -v wanted="$header_name" '
+    BEGIN { wanted = tolower(wanted) ":" }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      lower = tolower(line)
+      if (index(lower, wanted) == 1) {
+        sub(/^[^:]*:[[:space:]]*/, "", line)
+        print line
+        exit
+      }
+    }
+  '
+}
+
+canonical_dir() {
+  dir="$1"
+  (cd "$dir" 2>/dev/null && pwd -P) || printf '%s\n' "$dir"
+}
+
+# True only if *this plugin root's* dashboard is on the port. The generic
+# x-claude-smart-dashboard marker is intentionally not enough: after an
+# install/update, an older cache can keep serving port 3001 until restarted.
+dashboard_matches_current_root() {
+  expected_root="$(canonical_dir "$PLUGIN_ROOT")"
+  headers="$(dashboard_health_headers)" || return 1
+  printf '%s\n' "$headers" | grep -qi '^x-claude-smart-dashboard:' || return 1
+  actual_root="$(printf '%s\n' "$headers" | header_value_from "x-claude-smart-plugin-root")"
+  [ -n "$actual_root" ] || return 1
+  [ "$actual_root" = "$expected_root" ]
+}
+
+# Kill a claude-smart dashboard listener currently holding the port. Gated by
+# marker_responds so a foreign app on 3001 is never killed.
+stop_dashboard_listener() {
+  marker_responds || return 0
+  command -v lsof >/dev/null 2>&1 || return 0
+  port_pid=$(lsof -t -i ":$PORT" -sTCP:LISTEN 2>/dev/null | head -n1)
+  [ -n "$port_pid" ] || return 0
+  kill -TERM "$port_pid" 2>/dev/null || true
+  for _ in 1 2 3 4 5; do
+    kill -0 "$port_pid" 2>/dev/null || return 0
+    sleep 0.2
+  done
+  kill -KILL "$port_pid" 2>/dev/null || true
+}
+
+# True only if *our* dashboard is on the port. Uses plugin-root identity so a
+# stale claude-smart listener doesn't cause us to silently skip starting.
 is_our_dashboard_running() {
   if [ -f "$PID_FILE" ]; then
     pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
@@ -62,7 +118,7 @@ is_our_dashboard_running() {
       # don't claim "running" when the server crashed but the group leader
       # lingered.
       if command -v curl >/dev/null 2>&1; then
-        marker_responds && return 0
+        dashboard_matches_current_root && return 0
       else
         # No curl — fall back to PID liveness alone.
         return 0
@@ -71,7 +127,7 @@ is_our_dashboard_running() {
   fi
   # No PID or dead PID — probe the port for our marker (recovers after a
   # stale PID file from a crash).
-  marker_responds && return 0
+  dashboard_matches_current_root && return 0
   return 1
 }
 
@@ -97,6 +153,10 @@ case "$CMD" in
     fi
     if [ ! -d "$DASHBOARD_DIR" ]; then emit_ok; exit 0; fi
     if is_our_dashboard_running; then claude_smart_clear_dashboard_unavailable; emit_ok; exit 0; fi
+    if marker_responds; then
+      echo "[claude-smart] dashboard: stale claude-smart dashboard on port $PORT; restarting from $PLUGIN_ROOT" >>"$LOG_FILE"
+      stop_dashboard_listener
+    fi
     if port_occupied; then
       echo "[claude-smart] dashboard: port $PORT held by another process; skipping" >>"$LOG_FILE"
       emit_ok; exit 0
@@ -152,7 +212,7 @@ case "$CMD" in
     echo "$dash_pid" > "$PID_FILE"
     dashboard_ready=0
     for _ in 1 2 3 4 5; do
-      if marker_responds; then
+      if dashboard_matches_current_root; then
         dashboard_ready=1
         claude_smart_clear_dashboard_unavailable
         break
@@ -169,21 +229,11 @@ case "$CMD" in
       kill_group "$(cat "$PID_FILE" 2>/dev/null)"
       rm -f "$PID_FILE"
     fi
-    # Fallback: if our dashboard is still responding on the port (e.g.,
+    # Fallback: if a claude-smart dashboard is still responding on the port (e.g.,
     # was started outside this script, or the PGID kill missed because
     # the process wasn't the group leader) kill whoever owns the port.
     # Gated on the marker header so we never touch a foreign listener.
-    if marker_responds && command -v lsof >/dev/null 2>&1; then
-      port_pid=$(lsof -t -i ":$PORT" -sTCP:LISTEN 2>/dev/null | head -n1)
-      if [ -n "$port_pid" ]; then
-        kill -TERM "$port_pid" 2>/dev/null || true
-        for _ in 1 2 3 4 5; do
-          kill -0 "$port_pid" 2>/dev/null || break
-          sleep 0.2
-        done
-        kill -KILL "$port_pid" 2>/dev/null || true
-      fi
-    fi
+    stop_dashboard_listener
     emit_ok
     ;;
   session-end)

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -56,7 +56,7 @@ marker_responds() {
 
 dashboard_health_headers() {
   command -v curl >/dev/null 2>&1 || return 1
-  curl -sfI "http://127.0.0.1:$PORT/api/health" 2>/dev/null
+  curl -sfI --connect-timeout 2 --max-time 5 "http://127.0.0.1:$PORT/api/health" 2>/dev/null
 }
 
 header_value_from() {

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -31,6 +31,17 @@ LOCKFILE="$PLUGIN_ROOT/uv.lock"
 
 log() { printf '[setup-local-dev] %s\n' "$*" >&2; }
 
+refresh_local_dashboard() {
+  if [ ! -x "$PLUGIN_ROOT/scripts/dashboard-service.sh" ]; then
+    return 0
+  fi
+  log "refreshing local dashboard process..."
+  # The service script is marker-gated: it only kills a listener that answers
+  # as claude-smart, so a foreign app on 3001 is left alone.
+  bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" stop >/dev/null 2>&1 || true
+  bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" start >/dev/null 2>&1 || true
+}
+
 usage() {
   cat >&2 <<'EOF'
 Usage: scripts/setup-local-dev.sh [--host claude-code|codex|both]
@@ -260,11 +271,13 @@ if [ "$SETUP_CODEX" = "1" ]; then
   (cd "$REPO_ROOT" && node bin/claude-smart.js install --host codex)
 fi
 
+refresh_local_dashboard
+
 log ""
 if [ "$SETUP_CLAUDE_CODE" = "1" ] && [ "$SETUP_CODEX" = "1" ]; then
-  log "done. Restart Claude Code and fully restart Codex to pick up the local plugin."
+  log "done. Restart Claude Code and fully restart Codex to pick up the local plugin/hooks."
 elif [ "$SETUP_CODEX" = "1" ]; then
-  log "done. Fully restart Codex to pick up the local plugin."
+  log "done. Fully restart Codex to pick up the local plugin/hooks."
 else
   log "done. Restart Claude Code to pick up the local plugin."
 fi

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -259,6 +259,7 @@ def test_dashboard_service_restarts_stale_claude_smart_dashboard() -> None:
 
     assert "dashboard_matches_current_root()" in dashboard
     assert "x-claude-smart-plugin-root" in dashboard
+    assert "curl -sfI --connect-timeout 2 --max-time 5" in dashboard
     assert "[ \"$actual_root\" = \"$expected_root\" ]" in dashboard
     assert "stale claude-smart dashboard on port $PORT; restarting" in dashboard
     assert "stop_dashboard_listener" in dashboard
@@ -273,6 +274,10 @@ def test_installers_refresh_or_stop_dashboard_services() -> None:
     assert 'bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" stop' in setup
     assert 'bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" start' in setup
     assert "function refreshDashboardService(pluginRoot)" in node_installer
+    assert "const PLUGIN_SERVICE_TIMEOUT_MS = 15_000" in node_installer
+    assert "timeout: PLUGIN_SERVICE_TIMEOUT_MS" in node_installer
+    assert 'killSignal: "SIGTERM"' in node_installer
+    assert 'result.error && result.error.code === "ETIMEDOUT"' in node_installer
     assert 'runPluginService(pluginRoot, "dashboard-service.sh", "stop")' in node_installer
     assert 'runPluginService(pluginRoot, "dashboard-service.sh", "start")' in node_installer
     assert "function stopClaudeSmartServices(pluginRoot)" in node_installer

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -260,6 +260,10 @@ def test_dashboard_service_restarts_stale_claude_smart_dashboard() -> None:
     assert "dashboard_matches_current_root()" in dashboard
     assert "x-claude-smart-plugin-root" in dashboard
     assert "curl -sfI --connect-timeout 2 --max-time 5" in dashboard
+    assert "normalize_identity_path()" in dashboard
+    assert "cygpath -u" in dashboard
+    assert 'expected_root="$(normalize_identity_path ' in dashboard
+    assert "actual_root=\"$(normalize_identity_path \"$actual_root\")\"" in dashboard
     assert "[ \"$actual_root\" = \"$expected_root\" ]" in dashboard
     assert "stale claude-smart dashboard on port $PORT; restarting" in dashboard
     assert "stop_dashboard_listener" in dashboard

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -23,6 +23,7 @@ CODEX_COMPAT = REPO_ROOT / "plugin" / "scripts" / "codex-claude-compat"
 CODEX_HOOK = REPO_ROOT / "plugin" / "scripts" / "codex-hook.js"
 BACKEND_LOG_RUNNER = REPO_ROOT / "plugin" / "scripts" / "backend-log-runner.sh"
 NODE_INSTALLER = REPO_ROOT / "bin" / "claude-smart.js"
+HEALTH_ROUTE = REPO_ROOT / "plugin" / "dashboard" / "app" / "api" / "health" / "route.ts"
 
 
 def _minimal_path(tmp_path: Path, *names: str) -> str:
@@ -240,6 +241,42 @@ def test_service_start_scripts_recover_missing_dependencies_without_cli_command(
     assert "[claude-smart] dashboard: npm is not on PATH; running installer" in dashboard
     assert "CLAUDE_SMART_BOOTSTRAPPING=1 bash \"$PLUGIN_ROOT/scripts/smart-install.sh\"" in dashboard
     assert "npm is not on PATH after installer; dashboard cannot start" in dashboard
+
+
+def test_dashboard_health_exposes_plugin_identity_for_stale_process_detection() -> None:
+    route = HEALTH_ROUTE.read_text()
+
+    assert 'export const dynamic = "force-dynamic"' in route
+    assert "realpathSync" in route
+    assert "x-claude-smart-dashboard" in route
+    assert "x-claude-smart-plugin-root" in route
+    assert "x-claude-smart-dashboard-dir" in route
+    assert "x-claude-smart-version" in route
+
+
+def test_dashboard_service_restarts_stale_claude_smart_dashboard() -> None:
+    dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
+
+    assert "dashboard_matches_current_root()" in dashboard
+    assert "x-claude-smart-plugin-root" in dashboard
+    assert "[ \"$actual_root\" = \"$expected_root\" ]" in dashboard
+    assert "stale claude-smart dashboard on port $PORT; restarting" in dashboard
+    assert "stop_dashboard_listener" in dashboard
+    assert "foreign app on 3001 is never killed" in dashboard
+
+
+def test_installers_refresh_or_stop_dashboard_services() -> None:
+    setup = SETUP_LOCAL_DEV.read_text()
+    node_installer = NODE_INSTALLER.read_text()
+
+    assert "refresh_local_dashboard()" in setup
+    assert 'bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" stop' in setup
+    assert 'bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" start' in setup
+    assert "function refreshDashboardService(pluginRoot)" in node_installer
+    assert 'runPluginService(pluginRoot, "dashboard-service.sh", "stop")' in node_installer
+    assert 'runPluginService(pluginRoot, "dashboard-service.sh", "start")' in node_installer
+    assert "function stopClaudeSmartServices(pluginRoot)" in node_installer
+    assert "Refreshed claude-smart dashboard service." in node_installer
 
 
 def test_service_start_scripts_guard_internal_invocations() -> None:


### PR DESCRIPTION
## Summary
- Make the dashboard health endpoint report the serving plugin root, dashboard directory, and plugin version.
- Restart stale claude-smart dashboard listeners after install/setup when port 3001 is still serving an older cache.
- Stop local claude-smart services during uninstall while preserving learned data.

## Changes
- Dashboard health now exposes identity headers used by service scripts to distinguish the current plugin from stale cache processes.
- `dashboard-service.sh` compares the running dashboard's plugin root against the current plugin root before reusing it.
- Local dev and packaged installers refresh the dashboard service after installing; uninstallers stop claude-smart services before removing plugin state.
- Added installer/script regression checks and updated README/developer docs for the new service behavior.

## Test Plan
- `bash -n scripts/setup-local-dev.sh plugin/scripts/dashboard-service.sh plugin/scripts/smart-install.sh`
- `node --check bin/claude-smart.js`
- `npm run lint -- app/api/health/route.ts`
- `npm run build`
- `uv run --project plugin pytest -c plugin/pyproject.toml tests/test_install_scripts.py`
- `uv run --project plugin python -c "import claude_smart"`
- Manually restarted the dashboard and verified `/api/health` reports the current plugin root/version and `/rules/p1-f5b6` resolves successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer and local-dev setup now attempt a best-effort dashboard refresh and report refresh success.

* **Bug Fixes**
  * Stronger detection of stale dashboard instances and safer cleanup to avoid port conflicts.
  * Uninstall now stops local dashboard/backend services for more reliable teardown.

* **Documentation**
  * Clarified local-dev restart/refresh steps and expanded uninstall guidance about stopped services and preserved data paths.

* **Tests**
  * Added tests for dashboard health/identity, stale-dashboard restart, and installer refresh/stop behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->