### PR TITLE
[codex] Filter Codex suggestions metadata

### DIFF
--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -378,7 +378,10 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
     )
     if (
         runtime.is_codex()
-        and internal_call.is_codex_title_response(assistant_text)
+        and (
+            internal_call.is_codex_title_response(assistant_text)
+            or internal_call.is_codex_suggestions_response(assistant_text)
+        )
         and not prompt
         and not _has_unpublished_user_turn(session_id)
     ):

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -32,6 +32,8 @@ Detection signals, OR'd:
   - Known Codex-internal prompt templates (title generation and home-screen
     suggestions). These are model calls made by Codex itself, not user
     coding turns, and must never be reflected into claude-smart memory.
+  - Known orphan Codex-internal response bodies, for cases where the Stop
+    payload contains only the generated metadata and not the internal prompt.
 """
 
 from __future__ import annotations
@@ -140,3 +142,31 @@ def is_codex_title_response(content: Any) -> bool:
         and isinstance(parsed.get("title"), str)
         and bool(parsed["title"].strip())
     )
+
+
+def is_codex_suggestions_response(content: Any) -> bool:
+    """True for Codex's home-screen suggestion-generator response body.
+
+    Codex can run a separate suggestion task whose Stop payload contains
+    generated JSON like ``{"suggestions": [...]}`` with no corresponding user
+    turn. Those suggestions are UI metadata, not a user interaction.
+    """
+    if not isinstance(content, str):
+        return False
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(parsed, dict) or set(parsed) != {"suggestions"}:
+        return False
+    suggestions = parsed.get("suggestions")
+    if not isinstance(suggestions, list):
+        return False
+    for item in suggestions:
+        if not isinstance(item, dict):
+            return False
+        if set(item) != {"title", "description", "prompt", "appId"}:
+            return False
+        if not all(isinstance(item.get(key), str) for key in item):
+            return False
+    return True

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -310,6 +310,32 @@ def test_codex_stop_skips_orphan_title_response(session_dir, monkeypatch) -> Non
     assert calls == []
 
 
+def test_codex_stop_skips_orphan_suggestions_response(
+    session_dir, monkeypatch
+) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        stop.publish, "publish_unpublished", lambda **kw: calls.append(kw)
+    )
+
+    stop.handle(
+        {
+            "session_id": "s1",
+            "cwd": str(REPO_ROOT),
+            "last_assistant_message": (
+                '{"suggestions":[{"title":"Prepare patch",'
+                '"description":"Fix the issue.","prompt":"Make the change.",'
+                '"appId":""}]}'
+            ),
+            "transcript_path": "/does/not/exist.jsonl",
+        }
+    )
+
+    assert state.read_all("s1") == []
+    assert calls == []
+
+
 def test_codex_stop_keeps_user_requested_title_json(session_dir, monkeypatch) -> None:
     runtime.set_host(runtime.HOST_CODEX)
     calls: list[dict[str, Any]] = []
@@ -337,6 +363,43 @@ def test_codex_stop_keeps_user_requested_title_json(session_dir, monkeypatch) ->
     records = state.read_all("s1")
     assert records[-1]["role"] == "Assistant"
     assert records[-1]["content"] == '{"title":"Fix docs"}'
+    assert calls
+
+
+def test_codex_stop_keeps_user_requested_suggestions_json(
+    session_dir, monkeypatch
+) -> None:
+    runtime.set_host(runtime.HOST_CODEX)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        stop.publish, "publish_unpublished", lambda **kw: calls.append(kw)
+    )
+    state.append(
+        "s1",
+        {
+            "role": "User",
+            "content": "Return only a JSON suggestions object.",
+            "user_id": "demo",
+        },
+    )
+
+    assistant_json = (
+        '{"suggestions":[{"title":"Prepare patch",'
+        '"description":"Fix the issue.","prompt":"Make the change.",'
+        '"appId":""}]}'
+    )
+    stop.handle(
+        {
+            "session_id": "s1",
+            "cwd": str(REPO_ROOT),
+            "last_assistant_message": assistant_json,
+            "transcript_path": "/does/not/exist.jsonl",
+        }
+    )
+
+    records = state.read_all("s1")
+    assert records[-1]["role"] == "Assistant"
+    assert records[-1]["content"] == assistant_json
     assert calls
 
 

--- a/tests/test_internal_call.py
+++ b/tests/test_internal_call.py
@@ -139,6 +139,38 @@ def test_rejects_non_title_responses(content: object) -> None:
     assert internal_call.is_codex_title_response(content) is False
 
 
+def test_detects_codex_suggestions_response() -> None:
+    content = (
+        '{"suggestions":[{"title":"Prepare patch","description":"Fix the issue.",'
+        '"prompt":"Make the change.","appId":""}]}'
+    )
+
+    assert internal_call.is_codex_suggestions_response(content) is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "",
+        "not json",
+        '{"suggestions": "nope"}',
+        '{"suggestions": [{"title": "x"}]}',
+        (
+            '{"suggestions": [{"title": "x", "description": "d", '
+            '"prompt": "p", "appId": "", "extra": "e"}]}'
+        ),
+        (
+            '{"suggestions": [{"title": "x", "description": "d", '
+            '"prompt": "p", "appId": 1}]}'
+        ),
+        '{"suggestions": [], "body": "extra"}',
+        {"suggestions": []},
+    ],
+)
+def test_rejects_non_suggestions_responses(content: object) -> None:
+    assert internal_call.is_codex_suggestions_response(content) is False
+
+
 def test_returns_true_for_codex_suggestions_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Detect Codex home-screen suggestion JSON responses as internal metadata.
- Skip orphan `{"suggestions":[...]}` Stop responses when there is no unpublished user turn.
- Add regression coverage for filtering internal suggestion responses while preserving user-requested suggestion JSON.

## Root Cause

Codex suggestion generation can fire the Stop hook with only the generated assistant JSON response and no original internal prompt. The existing prompt-side guard caught the internal suggestions prompt, but missed orphan response-only payloads.

## Validation

- `uv run --project plugin pytest tests/test_internal_call.py tests/test_codex_support.py`
- pre-commit full suite: `352 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Codex auto-generated internal responses to prevent unwanted publish behavior
  * Enhanced handling to distinguish between system-generated suggestions and user-initiated requests, ensuring user-requested content is properly preserved while internal metadata is filtered

* **Tests**
  * Added comprehensive test coverage for Codex suggestion response handling and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->