### PR TITLE
[codex] Improve dashboard learning lists

### DIFF
--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -35,6 +35,7 @@ interface RecentLearning {
   href: string;
   content: string;
   createdAt: number;
+  statKey: string;
 }
 
 export default function DashboardPage() {
@@ -64,7 +65,7 @@ export default function DashboardPage() {
           reflexio
             .getAllProfiles({ reflexioUrl, limit: 100 })
             .catch(() => ({ user_profiles: [] as UserProfile[] })),
-          fetch("/api/rules/applied?daysBack=30&limit=5", {
+          fetch("/api/rules/applied?daysBack=30&limit=200", {
             cache: "no-store",
           })
             .then((r) => r.json())
@@ -96,7 +97,14 @@ export default function DashboardPage() {
   const approvedSharedSkills = (sharedSkills ?? []).filter(
     (p) => agentPlaybookStatusLabel(p) === "APPROVED",
   );
-  const currentPreferences = (preferences ?? []).filter((p) => p.status == null);
+ const currentPreferences = (preferences ?? []).filter((p) => p.status == null);
+  const statsByRule = useMemo(() => {
+    const map = new Map<string, PlaybookApplicationStat>();
+    for (const s of topApplied ?? []) {
+      map.set(`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`, s);
+    }
+    return map;
+  }, [topApplied]);
   const recentLearnings = useMemo(() => {
     const items: RecentLearning[] = [
       ...currentProjectSkills.map((p) => ({
@@ -105,6 +113,7 @@ export default function DashboardPage() {
         href: `/skills/project/${encodeURIComponent(p.user_playbook_id)}`,
         content: p.content,
         createdAt: p.created_at,
+        statKey: `playbook:user_playbook:${p.user_playbook_id}`,
       })),
       ...approvedSharedSkills.map((p) => ({
         id: `shared:${p.agent_playbook_id}`,
@@ -112,6 +121,7 @@ export default function DashboardPage() {
         href: `/skills/shared/${encodeURIComponent(p.agent_playbook_id)}`,
         content: p.content,
         createdAt: p.created_at,
+        statKey: `playbook:agent_playbook:${p.agent_playbook_id}`,
       })),
       ...currentPreferences.map((p) => ({
         id: `preference:${p.profile_id}`,
@@ -119,6 +129,7 @@ export default function DashboardPage() {
         href: `/preferences/project/${encodeURIComponent(p.profile_id)}`,
         content: p.content,
         createdAt: p.last_modified_timestamp,
+        statKey: `profile:profile:${p.profile_id}`,
       })),
     ];
     const seen = new Set<string>();
@@ -178,189 +189,193 @@ export default function DashboardPage() {
         )}
 
         <div className="grid min-w-0 gap-6 lg:grid-cols-2">
-        <section className="min-w-0 rounded-lg border border-border bg-card/86 p-4 shadow-sm">
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h2 className="text-sm font-semibold">Recent sessions</h2>
-              <p className="text-xs text-muted-foreground">
-                Latest local buffers and cited learnings.
-              </p>
-            </div>
-            <Link
-              href="/sessions"
-              className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
-            >
-              View all <ExternalLink className="h-3 w-3" />
-            </Link>
-          </div>
-          {sessions && sessions.length > 0 ? (
-            <div className="rounded-lg border border-border divide-y divide-border bg-background/70 overflow-hidden">
-              {sessions.slice(0, 5).map((s) => (
-                <Link
-                  key={s.session_id}
-                  href={`/sessions/${s.session_id}`}
-                  className="flex flex-col gap-2 px-4 py-3 transition-colors hover:bg-accent/45 sm:flex-row sm:items-center sm:justify-between"
-                >
-                  <div className="min-w-0 flex w-full items-center gap-3">
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-                      <MessageSquare className="h-4 w-4" />
-                    </span>
-                    <code className="font-mono text-xs truncate">
-                      {truncateId(s.session_id, 10, 6)}
-                    </code>
-                    <LearningsBadge count={s.learning_interaction_count} />
-                  </div>
-                  <div className="flex w-full items-center justify-end gap-4 text-xs text-muted-foreground sm:w-auto sm:shrink-0">
-                    <span>{s.turn_count} turns</span>
-                    <span>{formatRelative(s.last_activity)}</span>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          ) : (
-            <EmptyState
-              icon={MessageSquare}
-              title="No sessions yet"
-              description="Run Claude Code with claude-smart enabled — sessions will appear here."
-            />
-          )}
-        </section>
-
-        <section className="min-w-0 rounded-lg border border-border bg-card/86 p-4 shadow-sm">
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h2 className="text-sm font-semibold">Recent learnings</h2>
-              <p className="text-xs text-muted-foreground">
-                New skills and preferences extracted from recent patterns.
-              </p>
-            </div>
-            <div className="flex items-center gap-3">
+          <section className="min-w-0">
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h2 className="text-sm font-semibold">Recent sessions</h2>
+                <p className="text-xs text-muted-foreground">
+                  Latest local buffers and cited learnings.
+                </p>
+              </div>
               <Link
-                href="/skills"
+                href="/sessions"
                 className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
               >
-                Skills <ExternalLink className="h-3 w-3" />
-              </Link>
-              <Link
-                href="/preferences"
-                className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
-              >
-                Preferences <ExternalLink className="h-3 w-3" />
+                View all <ExternalLink className="h-3 w-3" />
               </Link>
             </div>
-          </div>
-          {recentLearnings.length > 0 ? (
-            <div className="rounded-lg border border-border divide-y divide-border bg-background/70 overflow-hidden">
-              {recentLearnings.map((item) => (
-                <Link
-                  key={item.id}
-                  href={item.href}
-                  className="flex min-w-0 items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-accent/45"
-                >
-                  <div className="min-w-0 flex flex-1 items-center gap-3">
-                    {learningIcon(item.kind)}
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm truncate">{item.content}</p>
-                      <div className="mt-1 flex items-center gap-2">
-                        <Badge variant="outline" className="h-5 text-[10px]">
-                          {learningKindLabel(item.kind)}
-                        </Badge>
-                        <span className="text-[11px] text-muted-foreground">
-                          {learningScope(item.kind)}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
-                    <span>{formatRelative(item.createdAt)}</span>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          ) : (
-            <EmptyState
-              icon={BookOpen}
-              title="No learnings yet"
-              description="Keep using Claude with claude-smart enabled. Skills and preferences are extracted automatically when patterns emerge."
-            />
-          )}
-        </section>
-
-        <section className="min-w-0 lg:col-span-2">
-          <div className="flex items-center justify-between mb-3">
-            <div className="flex items-center gap-2">
-              <h2 className="text-sm font-semibold">
-                Most used claude-smart learnings
-              </h2>
-              <span className="text-[11px] text-muted-foreground">
-                last 30 days
-              </span>
-            </div>
-            <Link
-              href="/sessions"
-              className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
-            >
-              Review sessions <ExternalLink className="h-3 w-3" />
-            </Link>
-          </div>
-          {topApplied === null ? (
-            <div className="text-sm text-muted-foreground">Loading...</div>
-          ) : topApplied.length > 0 ? (
-            <div className="rounded-xl border border-border divide-y divide-border bg-card">
-              {topApplied.slice(0, 5).map((s) => {
-                const href = s.href ?? null;
-                const label = appliedRuleLabel(s);
-                const rowBody = (
-                  <>
-                    <div className="min-w-0 flex flex-1 items-center gap-3">
-                      <Sparkles className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm truncate">
-                          {s.title || (
-                            <span className="text-muted-foreground italic">
-                              (rule removed)
-                            </span>
-                          )}
-                        </p>
-                        <p className="text-[11px] text-muted-foreground">
-                          {label} · {truncate(s.real_id, 12)}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
-                      <Badge variant="secondary" className="text-[10px]">
-                        Used {s.applied_count}×
-                      </Badge>
-                      <span>{formatRelative(s.last_applied_at)}</span>
-                    </div>
-                  </>
-                );
-                return href ? (
+            {sessions && sessions.length > 0 ? (
+              <div className="rounded-lg border border-border divide-y divide-border bg-card/92 shadow-sm overflow-hidden">
+                {sessions.slice(0, 5).map((s) => (
                   <Link
-                    key={`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`}
-                    href={href}
-                    className="flex min-w-0 items-center justify-between gap-3 px-4 py-3 hover:bg-accent/40 transition-colors"
+                    key={s.session_id}
+                    href={`/sessions/${s.session_id}`}
+                    className="flex flex-col gap-2 px-4 py-3 transition-colors hover:bg-accent/45 sm:flex-row sm:items-center sm:justify-between"
                   >
-                    {rowBody}
+                    <div className="min-w-0 flex w-full items-center gap-3">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                        <MessageSquare className="h-4 w-4" />
+                      </span>
+                      <code className="font-mono text-xs truncate">
+                        {truncateId(s.session_id, 10, 6)}
+                      </code>
+                      <LearningsBadge count={s.learning_interaction_count} />
+                    </div>
+                    <div className="flex w-full items-center justify-end gap-4 text-xs text-muted-foreground sm:w-auto sm:shrink-0">
+                      <span>{s.turn_count} turns</span>
+                      <span>{formatRelative(s.last_activity)}</span>
+                    </div>
                   </Link>
-                ) : (
-                  <div
-                    key={`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`}
-                    className="flex min-w-0 items-center justify-between gap-3 px-4 py-3"
-                  >
-                    {rowBody}
-                  </div>
-                );
-              })}
+                ))}
+              </div>
+            ) : (
+              <EmptyState
+                icon={MessageSquare}
+                title="No sessions yet"
+                description="Run Claude Code with claude-smart enabled — sessions will appear here."
+              />
+            )}
+          </section>
+
+          <section className="min-w-0">
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h2 className="text-sm font-semibold">Recent learnings</h2>
+                <p className="text-xs text-muted-foreground">
+                  New skills and preferences extracted from recent patterns.
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <Link
+                  href="/skills"
+                  className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
+                >
+                  Skills <ExternalLink className="h-3 w-3" />
+                </Link>
+                <Link
+                  href="/preferences"
+                  className="text-xs text-primary hover:text-foreground inline-flex items-center gap-1"
+                >
+                  Preferences <ExternalLink className="h-3 w-3" />
+                </Link>
+              </div>
             </div>
-          ) : (
-            <EmptyState
-              icon={Sparkles}
-              title="No applied learnings yet"
-              description="When a claude-smart learning is cited in a local assistant response, it will appear here with usage and recency."
-            />
-          )}
-        </section>
+            {recentLearnings.length > 0 ? (
+              <div className="rounded-lg border border-border divide-y divide-border bg-card/92 shadow-sm overflow-hidden">
+                {recentLearnings.map((item) => {
+                  const stat = statsByRule.get(item.statKey);
+                  return (
+                    <Link
+                      key={item.id}
+                      href={item.href}
+                      className="flex min-w-0 items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-accent/45"
+                    >
+                      <div className="min-w-0 flex flex-1 items-center gap-3">
+                        {learningIcon(item.kind)}
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm truncate">{item.content}</p>
+                          <div className="mt-1 flex flex-wrap items-center gap-2">
+                            <Badge variant="outline" className="h-5 text-[10px]">
+                              {learningKindLabel(item.kind)}
+                            </Badge>
+                            <span className="text-[11px] text-muted-foreground">
+                              {learningScope(item.kind)}
+                            </span>
+                            <LearningApplicationStatBadge stat={stat} />
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
+                        <span>{formatRelative(item.createdAt)}</span>
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            ) : (
+              <EmptyState
+                icon={BookOpen}
+                title="No learnings yet"
+                description="Keep using Claude with claude-smart enabled. Skills and preferences are extracted automatically when patterns emerge."
+              />
+            )}
+          </section>
+
+          <section className="min-w-0 lg:col-span-2">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <h2 className="text-sm font-semibold">
+                  Most used claude-smart learnings
+                </h2>
+                <span className="text-[11px] text-muted-foreground">
+                  last 30 days
+                </span>
+              </div>
+              <Link
+                href="/sessions"
+                className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+              >
+                Review sessions <ExternalLink className="h-3 w-3" />
+              </Link>
+            </div>
+            {topApplied === null ? (
+              <div className="text-sm text-muted-foreground">Loading...</div>
+            ) : topApplied.length > 0 ? (
+              <div className="rounded-lg border border-border divide-y divide-border bg-card/92 shadow-sm">
+                {topApplied.slice(0, 5).map((s) => {
+                  const href = s.href ?? null;
+                  const label = appliedRuleLabel(s);
+                  const rowBody = (
+                    <>
+                      <div className="min-w-0 flex flex-1 items-center gap-3">
+                        <Sparkles className="h-4 w-4 text-muted-foreground shrink-0" />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm truncate">
+                            {s.title || (
+                              <span className="text-muted-foreground italic">
+                                (rule removed)
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-[11px] text-muted-foreground">
+                            {label} · {truncate(s.real_id, 12)}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
+                        <Badge variant="secondary" className="text-[10px]">
+                          Used {s.applied_count}×
+                        </Badge>
+                        <span>{formatRelative(s.last_applied_at)}</span>
+                      </div>
+                    </>
+                  );
+                  return href ? (
+                    <Link
+                      key={`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`}
+                      href={href}
+                      className="flex min-w-0 items-center justify-between gap-3 px-4 py-3 hover:bg-accent/40 transition-colors"
+                    >
+                      {rowBody}
+                    </Link>
+                  ) : (
+                    <div
+                      key={`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`}
+                      className="flex min-w-0 items-center justify-between gap-3 px-4 py-3"
+                    >
+                      {rowBody}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <EmptyState
+                icon={Sparkles}
+                title="No applied learnings yet"
+                description="When a claude-smart learning is cited in a local assistant response, it will appear here with usage and recency."
+              />
+            )}
+          </section>
         </div>
       </div>
     </div>
@@ -384,4 +399,27 @@ function learningIcon(kind: RecentLearningKind) {
 
 function learningKindLabel(kind: RecentLearningKind): string {
   return kind === "preference" ? "preference" : "skill";
+}
+
+function LearningApplicationStatBadge({
+  stat,
+}: {
+  stat: PlaybookApplicationStat | undefined;
+}) {
+  if (!stat || stat.applied_count === 0) {
+    return (
+      <Badge
+        variant="outline"
+        className="h-5 text-[10px] text-muted-foreground"
+      >
+        Never applied
+      </Badge>
+    );
+  }
+  const last = formatRelative(stat.last_applied_at);
+  return (
+    <Badge variant="secondary" className="h-5 text-[10px]">
+      Applied {stat.applied_count}×{stat.last_applied_at ? ` · ${last}` : ""}
+    </Badge>
+  );
 }

--- a/plugin/dashboard/app/preferences/page.tsx
+++ b/plugin/dashboard/app/preferences/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Users, ChevronRight } from "lucide-react";
 import { PageHeader } from "@/components/common/page-header";
@@ -8,40 +8,94 @@ import { EmptyState } from "@/components/common/empty-state";
 import { DeleteAllButton } from "@/components/common/delete-all-button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { reflexio } from "@/lib/reflexio-client";
 import { useSettings } from "@/hooks/use-settings";
 import { formatRelative, truncateId } from "@/lib/format";
-import type { UserProfile } from "@/lib/types";
+import type { PlaybookApplicationStat, UserProfile } from "@/lib/types";
+
+type PreferenceSort = "newest" | "applied";
+
+function profileStatKey(profile: UserProfile): string {
+  return `profile:profile:${profile.profile_id}`;
+}
 
 export default function PreferencesPage() {
   const { reflexioUrl } = useSettings();
   const [profiles, setProfiles] = useState<UserProfile[] | null>(null);
+  const [appStats, setAppStats] = useState<PlaybookApplicationStat[] | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<PreferenceSort>("newest");
   const [filter, setFilter] = useState("");
 
   useEffect(() => {
     let cancelled = false;
-    reflexio
-      .getAllProfiles({ reflexioUrl })
-      .then((res) => {
+    async function load() {
+      try {
+        const [profileRes, statsRes] = await Promise.all([
+          reflexio.getAllProfiles({ reflexioUrl }),
+          fetch("/api/rules/applied?daysBack=30&limit=200", {
+            cache: "no-store",
+          })
+            .then((r) => r.json())
+            .catch(() => ({
+              success: false,
+              stats: [] as PlaybookApplicationStat[],
+            })),
+        ]);
+        if (cancelled) return;
+        setProfiles(profileRes.user_profiles ?? []);
+        setAppStats(statsRes.stats ?? []);
+        setError(null);
+      } catch (e) {
         if (!cancelled) {
-          setProfiles(res.user_profiles ?? []);
-          setError(null);
+          setError(e instanceof Error ? e.message : String(e));
         }
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
-      });
+      }
+    }
+    load();
     return () => {
       cancelled = true;
     };
   }, [reflexioUrl]);
 
-  const filtered = (profiles ?? []).filter(
-    (p) =>
-      p.content.toLowerCase().includes(filter.toLowerCase()) ||
-      p.user_id.toLowerCase().includes(filter.toLowerCase()),
-  );
+  const statsByProfile = useMemo(() => {
+    const map = new Map<string, PlaybookApplicationStat>();
+    for (const s of appStats ?? []) {
+      map.set(`${s.kind}:${s.source_kind ?? "unknown"}:${s.real_id}`, s);
+    }
+    return map;
+  }, [appStats]);
+
+  const filtered = useMemo(() => {
+    const query = filter.toLowerCase();
+    const matches = (profiles ?? []).filter(
+      (p) =>
+        p.content.toLowerCase().includes(query) ||
+        p.user_id.toLowerCase().includes(query),
+    );
+    return matches.sort((a, b) => {
+      if (sortBy === "applied") {
+        const aStat = statsByProfile.get(profileStatKey(a));
+        const bStat = statsByProfile.get(profileStatKey(b));
+        const appliedDelta =
+          (bStat?.applied_count ?? 0) - (aStat?.applied_count ?? 0);
+        if (appliedDelta !== 0) return appliedDelta;
+        const recencyDelta =
+          (bStat?.last_applied_at ?? 0) - (aStat?.last_applied_at ?? 0);
+        if (recencyDelta !== 0) return recencyDelta;
+      }
+      return b.last_modified_timestamp - a.last_modified_timestamp;
+    });
+  }, [filter, profiles, sortBy, statsByProfile]);
 
   return (
     <div className="flex-1 overflow-auto">
@@ -49,7 +103,21 @@ export default function PreferencesPage() {
         title="Preferences"
         description="Project-scoped preferences extracted from interactions."
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex max-w-full flex-wrap items-center justify-end gap-2">
+            <Select
+              value={sortBy}
+              onValueChange={(v) => setSortBy((v as PreferenceSort) ?? "newest")}
+            >
+              <SelectTrigger size="sm" className="w-36 text-xs bg-background/80">
+                <SelectValue placeholder="Sort">
+                  {sortBy === "applied" ? "Most applied" : "Newest"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="newest">Newest</SelectItem>
+                <SelectItem value="applied">Most applied</SelectItem>
+              </SelectContent>
+            </Select>
             <Input
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
@@ -85,44 +153,76 @@ export default function PreferencesPage() {
             description="Keep using Claude with claude-smart enabled — preferences will appear here automatically as the extractor learns patterns from your interactions."
           />
         ) : (
-          <div className="grid gap-3 md:grid-cols-2">
-            {filtered.map((p) => (
-              <Link
-                key={p.profile_id}
-                href={`/preferences/project/${encodeURIComponent(p.profile_id)}`}
-                className="group block rounded-lg border border-border bg-card/92 p-4 shadow-sm transition-colors hover:border-primary/35 hover:bg-accent/45"
-              >
-                <header className="flex items-center justify-between gap-2 mb-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <Badge variant="outline" className="h-5 font-mono text-[10px]">
-                      {truncateId(p.user_id, 32, 8)}
-                    </Badge>
-                    {p.status && (
-                      <Badge variant="secondary" className="h-5 text-[10px]">
-                        {p.status}
+          <div className="overflow-hidden rounded-lg border border-border bg-card/92 shadow-sm">
+            {filtered.map((p) => {
+              const stat = statsByProfile.get(profileStatKey(p));
+              return (
+                <Link
+                  key={p.profile_id}
+                  href={`/preferences/project/${encodeURIComponent(p.profile_id)}`}
+                  className="group block border-b border-border px-4 py-3.5 transition-colors last:border-b-0 hover:bg-accent/35"
+                >
+                  <header className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <Badge variant="outline" className="h-5 font-mono text-[10px]">
+                        {truncateId(p.user_id, 32, 8)}
                       </Badge>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1.5 shrink-0">
-                    <span className="text-[11px] text-muted-foreground">
-                      {formatRelative(p.last_modified_timestamp)}
-                    </span>
-                    <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/60 group-hover:text-foreground transition-colors" />
-                  </div>
-                </header>
-                <p className="rounded-md border border-border bg-background/60 px-3 py-2 text-sm leading-relaxed line-clamp-4">
-                  {p.content}
-                </p>
-                {p.source && (
-                  <p className="text-[11px] text-muted-foreground mt-2 font-mono">
-                    source: {p.source}
+                      {p.status && (
+                        <Badge variant="secondary" className="h-5 text-[10px]">
+                          {p.status}
+                        </Badge>
+                      )}
+                      <PreferenceApplicationStatBadge stat={stat} />
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <span className="text-[11px] text-muted-foreground">
+                        {formatRelative(p.last_modified_timestamp)}
+                      </span>
+                      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/60 group-hover:text-foreground transition-colors" />
+                    </div>
+                  </header>
+                  <p className="max-w-5xl text-sm leading-relaxed line-clamp-3">
+                    {p.content}
                   </p>
-                )}
-              </Link>
-            ))}
+                  {p.source && (
+                    <p className="text-[11px] text-muted-foreground mt-2 font-mono">
+                      source: {p.source}
+                    </p>
+                  )}
+                </Link>
+              );
+            })}
           </div>
         )}
       </div>
     </div>
+  );
+}
+
+function PreferenceApplicationStatBadge({
+  stat,
+}: {
+  stat: PlaybookApplicationStat | undefined;
+}) {
+  if (!stat || stat.applied_count === 0) {
+    return (
+      <Badge
+        variant="outline"
+        className="h-5 text-[10px] text-muted-foreground"
+        title="No citations recorded yet for this preference. It will count once an assistant reply cites it."
+      >
+        Never applied
+      </Badge>
+    );
+  }
+  const last = formatRelative(stat.last_applied_at);
+  return (
+    <Badge
+      variant="secondary"
+      className="h-5 text-[10px]"
+      title={`Last applied ${last}`}
+    >
+      Applied {stat.applied_count}×{stat.last_applied_at ? ` · ${last}` : ""}
+    </Badge>
   );
 }

--- a/plugin/dashboard/app/skills/page.tsx
+++ b/plugin/dashboard/app/skills/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { BookOpen, Layers3 } from "lucide-react";
+import { BookOpen, ChevronRight, Layers3 } from "lucide-react";
 import { PageHeader } from "@/components/common/page-header";
 import { EmptyState } from "@/components/common/empty-state";
 import { DeleteAllButton } from "@/components/common/delete-all-button";
@@ -34,6 +34,9 @@ import type {
 
 type SkillKind = "project" | "shared";
 type SkillStatus = StatusLabel | AgentPlaybookStatusLabel;
+type SkillSort = "newest" | "applied";
+
+const ALL_LIFECYCLE_STATUSES: (string | null)[] = [null, "pending", "archived"];
 
 const SHARED_STATUS_META: Record<
   AgentPlaybookStatusLabel,
@@ -90,6 +93,12 @@ function sharedSkill(p: AgentPlaybook): SkillCard {
   };
 }
 
+function skillStatKey(skill: SkillCard): string {
+  const sourceKind =
+    skill.kind === "shared" ? "agent_playbook" : "user_playbook";
+  return `playbook:${sourceKind}:${skill.id}`;
+}
+
 export default function SkillsPage() {
   const { reflexioUrl } = useSettings();
   const [projectSkills, setProjectSkills] = useState<UserPlaybook[] | null>(null);
@@ -101,6 +110,7 @@ export default function SkillsPage() {
   const [activeKind, setActiveKind] = useState<SkillKind>("project");
   const [agentVersion, setAgentVersion] = useState<string>("__all__");
   const [statusFilter, setStatusFilter] = useState<string>("CURRENT");
+  const [sortBy, setSortBy] = useState<SkillSort>("newest");
   const [search, setSearch] = useState("");
 
   useEffect(() => {
@@ -108,8 +118,16 @@ export default function SkillsPage() {
     async function load() {
       try {
         const [projectRes, sharedRes, statsRes] = await Promise.all([
-          reflexio.getUserPlaybooks({ reflexioUrl, limit: 200 }),
-          reflexio.getAgentPlaybooks({ reflexioUrl, limit: 200 }),
+          reflexio.getUserPlaybooks({
+            reflexioUrl,
+            limit: 500,
+            statusFilter: ALL_LIFECYCLE_STATUSES,
+          }),
+          reflexio.getAgentPlaybooks({
+            reflexioUrl,
+            limit: 500,
+            statusFilter: ALL_LIFECYCLE_STATUSES,
+          }),
           fetch("/api/rules/applied?daysBack=30&limit=200", {
             cache: "no-store",
           })
@@ -155,7 +173,7 @@ export default function SkillsPage() {
   }, [activeSkills]);
 
   const filtered = useMemo(() => {
-    return activeSkills.filter((p) => {
+    const matches = activeSkills.filter((p) => {
       if (agentVersion !== "__all__" && p.agentVersion !== agentVersion)
         return false;
       if (statusFilter !== "__all__" && p.status !== statusFilter) return false;
@@ -166,10 +184,24 @@ export default function SkillsPage() {
       }
       return true;
     });
-  }, [activeSkills, agentVersion, statusFilter, search]);
+    return matches.sort((a, b) => {
+      if (sortBy === "applied") {
+        const aStat = statsByRule.get(skillStatKey(a));
+        const bStat = statsByRule.get(skillStatKey(b));
+        const appliedDelta =
+          (bStat?.applied_count ?? 0) - (aStat?.applied_count ?? 0);
+        if (appliedDelta !== 0) return appliedDelta;
+        const recencyDelta =
+          (bStat?.last_applied_at ?? 0) - (aStat?.last_applied_at ?? 0);
+        if (recencyDelta !== 0) return recencyDelta;
+      }
+      return b.createdAt - a.createdAt;
+    });
+  }, [activeSkills, agentVersion, search, sortBy, statsByRule, statusFilter]);
 
   const projectCount = projectSkills?.length ?? 0;
   const sharedCount = sharedSkills?.length ?? 0;
+  const visibleActiveCount = filtered.length;
   const activeCount = activeKind === "project" ? projectCount : sharedCount;
   const loading = projectSkills === null || sharedSkills === null;
   const hasNoSharedSkills = activeKind === "shared" && sharedCount === 0;
@@ -208,7 +240,9 @@ export default function SkillsPage() {
               onValueChange={(v) => setStatusFilter(v ?? "__all__")}
             >
               <SelectTrigger size="sm" className="w-36 text-xs bg-background/80">
-                <SelectValue placeholder="Status" />
+                <SelectValue placeholder="Status">
+                  {statusFilterLabel(activeKind, statusFilter)}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="__all__">All</SelectItem>
@@ -240,6 +274,20 @@ export default function SkillsPage() {
                     </SelectItem>
                   </>
                 )}
+              </SelectContent>
+            </Select>
+            <Select
+              value={sortBy}
+              onValueChange={(v) => setSortBy((v as SkillSort) ?? "newest")}
+            >
+              <SelectTrigger size="sm" className="w-36 text-xs bg-background/80">
+                <SelectValue placeholder="Sort">
+                  {sortBy === "applied" ? "Most applied" : "Newest"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="newest">Newest</SelectItem>
+                <SelectItem value="applied">Most applied</SelectItem>
               </SelectContent>
             </Select>
             <Input
@@ -275,14 +323,14 @@ export default function SkillsPage() {
               id: "project",
               label: "Project-specific skills",
               description: "Repo-local rules learned from direct corrections",
-              count: projectCount,
+              count: activeKind === "project" ? visibleActiveCount : projectCount,
               icon: BookOpen,
             },
             {
               id: "shared",
               label: "Shared skills",
               description: "Rollups available across projects",
-              count: sharedCount,
+              count: activeKind === "shared" ? visibleActiveCount : sharedCount,
               icon: Layers3,
             },
           ]}
@@ -311,49 +359,58 @@ export default function SkillsPage() {
             }
           />
         ) : (
-          <div className="grid gap-3 lg:grid-cols-2">
+          <div className="overflow-hidden rounded-lg border border-border bg-card/92 shadow-sm">
             {filtered.map((p) => {
-              const sourceKind =
-                p.kind === "shared" ? "agent_playbook" : "user_playbook";
-              const stat = statsByRule.get(`playbook:${sourceKind}:${p.id}`);
+              const stat = statsByRule.get(skillStatKey(p));
               return (
-              <Link
-                key={`${p.kind}:${p.id}`}
-                href={`/skills/${p.kind}/${p.id}`}
-                className="block rounded-lg border border-border bg-card/92 p-4 shadow-sm transition-colors hover:border-primary/35 hover:bg-accent/45"
-              >
-                <header className="flex items-center justify-between gap-2 mb-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <Badge variant="outline" className="h-5 font-mono text-[10px]">
-                      {p.agentVersion}
-                    </Badge>
-                    <StatusBadge kind={p.kind} status={p.status} />
-                    <Badge variant="secondary" className="h-5 text-[10px]">
-                      {p.kind === "project" ? "project-specific" : "shared"}
-                    </Badge>
-                    <ApplicationStatBadge stat={stat} />
-                  </div>
-                  <span className="text-[11px] text-muted-foreground shrink-0">
-                    {formatRelative(p.createdAt)}
-                  </span>
-                </header>
-                <p
-                  className={cn(
-                    "rounded-md border border-border bg-background/60 px-3 py-2 text-sm leading-relaxed line-clamp-4",
-                    !p.trigger && "text-muted-foreground italic",
-                  )}
+                <Link
+                  key={`${p.kind}:${p.id}`}
+                  href={`/skills/${p.kind}/${p.id}`}
+                  className="group block border-b border-border px-4 py-3.5 transition-colors last:border-b-0 hover:bg-accent/35"
                 >
-                  {p.trigger || "Always applies"}
-                </p>
-                <p className="text-xs text-muted-foreground mt-2 line-clamp-2">
-                  <span className="font-medium">Rule:</span> {p.content}
-                </p>
-                {p.rationale && (
-                  <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
-                    <span className="font-medium">Why:</span> {p.rationale}
+                  <header className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <Badge
+                        variant="outline"
+                        className="h-5 max-w-56 truncate font-mono text-[10px]"
+                      >
+                        {p.agentVersion}
+                      </Badge>
+                      <StatusBadge kind={p.kind} status={p.status} />
+                      <Badge variant="secondary" className="h-5 text-[10px]">
+                        {p.kind === "project" ? "project-specific" : "shared"}
+                      </Badge>
+                      <ApplicationStatBadge stat={stat} />
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
+                      <span className="text-[11px] text-muted-foreground">
+                        {formatRelative(p.createdAt)}
+                      </span>
+                      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/60 transition-colors group-hover:text-foreground" />
+                    </div>
+                  </header>
+                  <p
+                    className={cn(
+                      "max-w-5xl text-sm leading-relaxed line-clamp-3",
+                      !p.trigger && "text-muted-foreground italic",
+                    )}
+                  >
+                    <span className="mr-2 align-baseline text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      Trigger
+                    </span>
+                    {p.trigger || "Always applies"}
                   </p>
-                )}
-              </Link>
+                  <p className="mt-2 max-w-5xl text-xs leading-relaxed text-muted-foreground line-clamp-2">
+                    <span className="font-medium text-foreground/80">Rule:</span>{" "}
+                    {p.content}
+                  </p>
+                  {p.rationale && (
+                    <p className="mt-1 max-w-5xl text-xs leading-relaxed text-muted-foreground line-clamp-2">
+                      <span className="font-medium text-foreground/80">Why:</span>{" "}
+                      {p.rationale}
+                    </p>
+                  )}
+                </Link>
               );
             })}
           </div>
@@ -385,6 +442,18 @@ function ApplicationStatBadge({ stat }: { stat: PlaybookApplicationStat | undefi
       Applied {stat.applied_count}×{stat.last_applied_at ? ` · ${last}` : ""}
     </Badge>
   );
+}
+
+function statusFilterLabel(kind: SkillKind, status: string): string {
+  if (status === "__all__") return "All";
+  if (kind === "shared") {
+    const meta = SHARED_STATUS_META[status as AgentPlaybookStatusLabel];
+    if (meta) return meta.label;
+  }
+  if (status === "CURRENT") return "Current";
+  if (status === "PENDING") return "Pending";
+  if (status === "ARCHIVED") return "Archived";
+  return status;
 }
 
 function StatusBadge({


### PR DESCRIPTION
## Summary
- flatten dashboard skills and preferences list rows to remove nested card surfaces
- show applied-count badges and add Most applied sorting for skills and preferences
- make the skills status filter fetch and display all lifecycle statuses correctly

## Validation
- npm run lint -- app/skills/page.tsx
- npm run lint -- app/preferences/page.tsx app/dashboard/page.tsx
- npm run build
- pre-commit pytest: 355 passed
- browser verification at http://localhost:3002/skills, /preferences, and /dashboard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application statistics badges now appear on dashboard recent learnings and profile preferences, showing usage information.
  * New sort options added to preferences (by newest or applied count) and skills pages.

* **UI/UX Improvements**
  * Redesigned dashboard layout for recent items sections.
  * Converted preferences from grid-based to list layout.
  * Enhanced skills page display with improved filtering and sorting capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->