### PR TITLE
Improve claude-smart citation marker UX

### DIFF
--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -473,7 +473,7 @@ function runHook(root, event) {
         REFLEXIO_URL: readBackendUrl(),
         CLAUDE_SMART_HOST: "codex",
         CLAUDE_SMART_CLI_PATH: process.env.CLAUDE_SMART_CLI_PATH || codexCompatPath(root),
-        CLAUDE_SMART_CITATION_LINK_STYLE: process.env.CLAUDE_SMART_CITATION_LINK_STYLE || "markdown",
+        CLAUDE_SMART_CITATION_LINK_STYLE: process.env.CLAUDE_SMART_CITATION_LINK_STYLE || "osc8",
       },
       input,
       stdio: ["pipe", "pipe", "inherit"],

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -19,6 +19,9 @@ case "$EVENT" in
     ;;
 esac
 export CLAUDE_SMART_HOST="$HOST"
+if [ "$HOST" = "codex" ] && [ -z "${CLAUDE_SMART_CITATION_LINK_STYLE:-}" ]; then
+  export CLAUDE_SMART_CITATION_LINK_STYLE="osc8"
+fi
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -185,6 +185,80 @@ def render_inline_with_registry(
     return "\n".join(sections) + "\n", playbook_entries + profile_entries
 
 
+def render_inline_compact_with_registry(
+    *,
+    project_id: str,
+    user_playbooks: Iterable[Any],
+    agent_playbooks: Iterable[Any],
+    profiles: Iterable[Any],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Render mid-session context as one compact logical line.
+
+    Codex currently displays ``UserPromptSubmit.additionalContext`` in the TUI.
+    This renderer preserves the model-visible ids and rule URLs needed for
+    citation tracking while avoiding the multi-line markdown block used by
+    hosts that can hide hook context.
+    """
+    del project_id  # kept for symmetry with ``render_inline_with_registry``.
+    _, playbook_entries = _format_combined_playbooks(
+        agent_playbooks=agent_playbooks, user_playbooks=user_playbooks
+    )
+    _, profile_entries = _format_profiles(profiles)
+    entries = playbook_entries + profile_entries
+    if not entries:
+        return "", []
+
+    item_parts = []
+    marker_parts = []
+    link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
+    for entry in entries:
+        title = _one_line(str(entry.get("title") or entry["content"]))
+        content = _one_line(str(entry["content"]))
+        rule_url = str(entry.get("rule_url") or "")
+        if link_style == "osc8" and rule_url:
+            linked_title = _osc8_link(rule_url, _strip_trailing_sentence_punctuation(title))
+            item = linked_title
+            if content != title:
+                item += f": {content}"
+            marker_parts.append(f"✨ claude-smart rule applied: {linked_title}")
+        else:
+            item = f"{content} (title: {title}"
+            if rule_url:
+                item += f"; open: {rule_url}"
+            item += ")"
+        item_parts.append(item)
+
+    sections = [f"claude-smart: using relevant memory: {'; '.join(item_parts)}."]
+    instruction = _compact_citation_instruction(marker_parts)
+    if instruction:
+        sections.append(instruction)
+    return " ".join(sections) + "\n", entries
+
+
+def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
+    if os.environ.get("CLAUDE_SMART_CITATIONS", "on") == "off":
+        return ""
+    link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
+    if link_style == "osc8" and marker_parts:
+        marker = marker_parts[0] if len(marker_parts) == 1 else "; ".join(marker_parts)
+        return (
+            f"If used, copy this final marker exactly, preserving its hidden "
+            f"OSC 8 terminal link: `{marker}`. Skip when unrelated."
+        )
+    if link_style == "osc8":
+        return (
+            "If used, end with `✨ claude-smart rule applied:` followed by "
+            "the same linked memory text; keep the link, but do not show the "
+            "URL. Skip when unrelated."
+        )
+    return (
+        "Only if a listed [cs:...] item materially changes your answer, end "
+        "with one final marker like `✨ claude-smart rule applied: "
+        "[verify process state](http://localhost:3001/rules/s1-123)` using "
+        "the shown rule URL; skip the marker when unrelated."
+    )
+
+
 def _format_combined_playbooks(
     *,
     agent_playbooks: Iterable[Any],
@@ -319,6 +393,18 @@ def _title_from_content(content: str, limit: int = 80) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 1].rstrip() + "…"
+
+
+def _one_line(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _osc8_link(url: str, label: str) -> str:
+    return f"\x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\"
+
+
+def _strip_trailing_sentence_punctuation(text: str) -> str:
+    return text.rstrip().rstrip(".!?")
 
 
 def _field(obj: Any, name: str) -> Any:

--- a/plugin/src/claude_smart/context_inject.py
+++ b/plugin/src/claude_smart/context_inject.py
@@ -17,6 +17,7 @@ turn) — see the two call sites for the small policy differences.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 
@@ -59,7 +60,13 @@ def emit_context(
         query=query,
         top_k=top_k,
     )
-    markdown, registry = context_format.render_inline_with_registry(
+    renderer = (
+        context_format.render_inline_compact_with_registry
+        if hook_event_name == "UserPromptSubmit"
+        and os.environ.get("CLAUDE_SMART_HOST") == "codex"
+        else context_format.render_inline_with_registry
+    )
+    markdown, registry = renderer(
         project_id=project_id,
         user_playbooks=user_playbooks,
         agent_playbooks=agent_playbooks,

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -80,7 +80,8 @@ _MARKDOWN_MARKER_PARAGRAPH = (
     "[git safety](http://localhost:3001/rules/s1-123), "
     "[brief answer preference](http://localhost:3001/rules/p1-pref)`. "
     "Use the dashboard URL shown beside each cited item; do not invent URLs. "
-    "Do not include `[cs:…]` ids in the marker line._"
+    "Do not include `[cs:…]` ids in the marker line. Never use the old "
+    "`✨ 1 claude-smart learning applied [cs:...]` marker format._"
 )
 
 _OSC8_EXAMPLE_ONE = (

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -3,9 +3,9 @@
 #
 # Does what the published install wrapper does for end users, plus the
 # extra steps that only make sense when you're iterating on this repo:
-#   1. Initialize the reflexio submodule.
+#   1. Initialize the reflexio submodule fallback.
 #   2. Uncomment the `[tool.uv.sources]` block in plugin/pyproject.toml so
-#      uv resolves reflexio-ai from the vendored submodule (editable).
+#      uv resolves reflexio-ai from a local Reflexio checkout (editable).
 #   3. `git update-index --skip-worktree` plugin/pyproject.toml + uv.lock
 #      so the local divergence is invisible to `git status`.
 #   4. `uv sync` from plugin/.
@@ -30,6 +30,62 @@ PYPROJECT="$PLUGIN_ROOT/pyproject.toml"
 LOCKFILE="$PLUGIN_ROOT/uv.lock"
 
 log() { printf '[setup-local-dev] %s\n' "$*" >&2; }
+
+is_reflexio_checkout() {
+  [ -f "$1/pyproject.toml" ] && [ -d "$1/reflexio" ]
+}
+
+resolve_reflexio_source() {
+  if [ -n "${CLAUDE_SMART_LOCAL_REFLEXIO_PATH:-}" ]; then
+    if is_reflexio_checkout "$CLAUDE_SMART_LOCAL_REFLEXIO_PATH"; then
+      (cd "$CLAUDE_SMART_LOCAL_REFLEXIO_PATH" && pwd)
+      return 0
+    fi
+    log "ERROR: CLAUDE_SMART_LOCAL_REFLEXIO_PATH is not a Reflexio checkout: $CLAUDE_SMART_LOCAL_REFLEXIO_PATH"
+    exit 1
+  fi
+
+  # In reflexio-enterprise worktrees, claude-smart and reflexio are sibling
+  # submodules under open_source/. Prefer that current workspace checkout over
+  # claude-smart's nested fallback so local-dev installs do not pin an older
+  # Reflexio client into ~/.reflexio/plugin-root.
+  sibling_reflexio="$REPO_ROOT/../reflexio"
+  if is_reflexio_checkout "$sibling_reflexio"; then
+    (cd "$sibling_reflexio" && pwd)
+    return 0
+  fi
+
+  bundled_reflexio="$REPO_ROOT/reflexio"
+  if is_reflexio_checkout "$bundled_reflexio"; then
+    (cd "$bundled_reflexio" && pwd)
+    return 0
+  fi
+
+  log "ERROR: could not find a Reflexio checkout at $sibling_reflexio or $bundled_reflexio"
+  exit 1
+}
+
+verify_reflexio_client() {
+  (cd "$PLUGIN_ROOT" && REFLEXIO_SOURCE_PATH="$REFLEXIO_ABS" uv run --quiet python - <<'PY'
+import inspect
+import os
+import sys
+
+from reflexio import ReflexioClient
+
+signature = inspect.signature(ReflexioClient.publish_interaction)
+if "override_learning_stall" not in signature.parameters:
+    print(
+        "[setup-local-dev] ERROR: selected Reflexio client does not support "
+        "override_learning_stall: "
+        f"{os.environ.get('REFLEXIO_SOURCE_PATH')}",
+        file=sys.stderr,
+    )
+    print(f"[setup-local-dev] signature: {signature}", file=sys.stderr)
+    sys.exit(1)
+PY
+  )
+}
 
 refresh_local_dashboard() {
   if [ ! -x "$PLUGIN_ROOT/scripts/dashboard-service.sh" ]; then
@@ -105,16 +161,17 @@ case "$HOST" in
     ;;
 esac
 
-log "initializing reflexio submodule..."
+log "initializing reflexio submodule fallback..."
 (cd "$REPO_ROOT" && git submodule update --init --recursive reflexio)
 
 log "enabling [tool.uv.sources] override in plugin/pyproject.toml..."
-# Use an absolute path for the reflexio submodule. Relative paths like
+# Use an absolute path for the Reflexio checkout. Relative paths like
 # "../reflexio" get resolved by uv against the literal --project path,
 # which breaks when slash commands pass the ~/.reflexio/plugin-root
 # symlink (uv does not canonicalize) — it would resolve to
 # $HOME/.reflexio/reflexio, which does not exist.
-REFLEXIO_ABS="$REPO_ROOT/reflexio"
+REFLEXIO_ABS="$(resolve_reflexio_source)"
+log "using Reflexio source at $REFLEXIO_ABS"
 sed -i.bak -E \
   -e 's|^# \[tool\.uv\.sources\]$|[tool.uv.sources]|' \
   -e "s|^(# )?reflexio-ai = \\{ path = \"[^\"]*\", editable = true \\}\$|reflexio-ai = { path = \"$REFLEXIO_ABS\", editable = true }|" \
@@ -131,6 +188,7 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 log "running uv sync in plugin/ ..."
 (cd "$PLUGIN_ROOT" && uv sync --quiet)
+verify_reflexio_client
 
 REFLEXIO_ENV="$HOME/.reflexio/.env"
 mkdir -p "$(dirname "$REFLEXIO_ENV")"
@@ -281,7 +339,7 @@ elif [ "$SETUP_CODEX" = "1" ]; then
 else
   log "done. Restart Claude Code to pick up the local plugin."
 fi
-log "  pyproject.toml → editable reflexio-ai from ../reflexio"
+log "  pyproject.toml → editable reflexio-ai from $REFLEXIO_ABS"
 log "  ~/.reflexio/.env → local-CLI + local-embedding providers"
 if [ "$SETUP_CLAUDE_CODE" = "1" ]; then
   log "  Claude Code user marketplaces → reflexioai-local ($LOCAL_MKT_DIR)"

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -231,6 +231,42 @@ def test_render_inline_with_registry_can_inject_osc8_instruction(monkeypatch) ->
     assert "✨ claude-smart rule applied: [verify process state]" not in md
 
 
+def test_render_inline_compact_with_registry_is_one_logical_line(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_SMART_CITATION_LINK_STYLE", "osc8")
+    md, registry = context_format.render_inline_compact_with_registry(
+        project_id="demo",
+        user_playbooks=[
+            {
+                "content": (
+                    "Run uv sync after pyproject edits. "
+                    "Then run an import smoke test before committing."
+                ),
+                "user_playbook_id": 17,
+            }
+        ],
+        agent_playbooks=[],
+        profiles=[{"content": "prefers concise answers", "profile_id": "pref"}],
+    )
+
+    assert md.endswith("\n")
+    assert "\n" not in md.rstrip("\n")
+    assert "###" not in md
+    assert "- [cs:" not in md
+    assert "[cs:" not in md
+    assert "claude-smart: using relevant memory:" in md
+    assert "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\" in md
+    assert "Run uv sync after pyproject edits" in md
+    assert "Then run an import smoke test before committing." in md
+    assert "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in md
+    assert "prefers concise answers" in md
+    assert "✨ claude-smart rule applied:" in md
+    assert "preserving its hidden OSC 8 terminal link" in md
+    assert "open: http://localhost:3001/rules/s1-17" not in md
+    assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
+
+
 def test_render_inline_with_registry_marker_only_is_enabled_alias(
     monkeypatch,
 ) -> None:

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -162,6 +162,8 @@ def test_citation_instruction_on_returns_compact_string() -> None:
     assert "citation block is up to two lines" not in text
     assert "counterfactual" not in text.lower()
     assert "✨ claude-smart rule applied:" in text
+    assert "Never use the old" in text
+    assert "✨ 1 claude-smart learning applied [cs:...]" in text
 
 
 def test_citation_instruction_legacy_modes_stay_enabled() -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -935,6 +935,48 @@ def test_user_prompt_injects_context_when_hits_present(
         assert entry["title"]
 
 
+def test_user_prompt_injects_compact_context_for_codex(
+    session_dir, monkeypatch
+) -> None:
+    """Codex receives a one-line context because the TUI displays it."""
+    monkeypatch.setenv("CLAUDE_SMART_HOST", "codex")
+    monkeypatch.setenv("CLAUDE_SMART_CITATION_LINK_STYLE", "osc8")
+    _stub_user_prompt_adapter(
+        monkeypatch,
+        playbooks=[
+            {
+                "content": (
+                    "Run uv sync after pyproject edits. "
+                    "Then run an import smoke test before committing."
+                ),
+                "trigger": "pyproject.toml",
+            }
+        ],
+        profiles=[{"content": "prefers anyio over asyncio"}],
+    )
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    user_prompt.handle(
+        {"session_id": "s1", "prompt": "edit pyproject.toml", "cwd": "/r"}
+    )
+
+    payload = json.loads(buf.getvalue().strip())
+    markdown = payload["hookSpecificOutput"]["additionalContext"]
+    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert markdown.endswith("\n")
+    assert "\n" not in markdown.rstrip("\n")
+    assert "claude-smart: using relevant memory:" in markdown
+    assert "### Relevant project preferences" not in markdown
+    assert "[cs:" not in markdown
+    assert "Run uv sync after pyproject edits" in markdown
+    assert "Then run an import smoke test before committing." in markdown
+    assert "prefers anyio over asyncio" in markdown
+    assert "\x1b]8;;http://localhost:3001/rules/s1\x1b\\" in markdown
+    assert "✨ claude-smart rule applied:" in markdown
+    assert "preserving its hidden OSC 8 terminal link" in markdown
+    assert "open: http://localhost:3001/rules/s1" not in markdown
+
+
 def test_user_prompt_writes_nothing_when_search_empty(session_dir, monkeypatch) -> None:
     """No hits → no stdout output, but the prompt is still buffered."""
     _stub_user_prompt_adapter(monkeypatch, playbooks=[], profiles=[])

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -454,6 +454,49 @@ def test_hook_entry_self_heals_missing_uv_without_cli_command() -> None:
     assert 'bash "$HERE/dashboard-service.sh" start' in script
 
 
+def test_hook_entry_defaults_codex_citation_links_to_osc8(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uv = bin_dir / "uv"
+    uv.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' "{\\"hookSpecificOutput\\":'
+        '{\\"hookEventName\\":\\"UserPromptSubmit\\",'
+        '\\"additionalContext\\":\\"$CLAUDE_SMART_CITATION_LINK_STYLE\\"}}"\n'
+    )
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env.pop("CLAUDE_SMART_CITATION_LINK_STYLE", None)
+    result = subprocess.run(
+        [str(HOOK_ENTRY), "codex", "user-prompt"],
+        env=env,
+        text=True,
+        input=json.dumps({"session_id": "s1", "prompt": "What food do I like?"}),
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(result.stdout)
+    assert parsed["hookSpecificOutput"]["additionalContext"] == "osc8"
+
+    env["CLAUDE_SMART_CITATION_LINK_STYLE"] = "markdown"
+    result = subprocess.run(
+        [str(HOOK_ENTRY), "codex", "user-prompt"],
+        env=env,
+        text=True,
+        input=json.dumps({"session_id": "s1", "prompt": "What food do I like?"}),
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(result.stdout)
+    assert parsed["hookSpecificOutput"]["additionalContext"] == "markdown"
+
+
 def test_node_installer_platform_preflight_messages() -> None:
     node = shutil.which("node")
     if not node:
@@ -920,6 +963,41 @@ def test_codex_hook_normalizer_removes_suppress_output_for_hooks(
 
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == {"continue": True}
+
+
+def test_codex_hook_defaults_citation_links_to_osc8(tmp_path: Path) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for codex hook wrapper tests")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uv = bin_dir / "uv"
+    uv.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' "{\\"hookSpecificOutput\\":'
+        '{\\"hookEventName\\":\\"UserPromptSubmit\\",'
+        '\\"additionalContext\\":\\"$CLAUDE_SMART_CITATION_LINK_STYLE\\"}}"\n'
+    )
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = str(bin_dir)
+    env["CLAUDE_PLUGIN_ROOT"] = str(REPO_ROOT / "plugin")
+    env.pop("CLAUDE_SMART_CITATION_LINK_STYLE", None)
+    result = subprocess.run(
+        [node, str(CODEX_HOOK), "hook", "user-prompt"],
+        env=env,
+        text=True,
+        input=json.dumps({"session_id": "s1", "prompt": "What food do I like?"}),
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(result.stdout)
+    assert parsed["hookSpecificOutput"]["additionalContext"] == "osc8"
+    assert parsed["continue"] is True
 
 
 def test_install_fingerprint_hash_tracks_lib_changes(tmp_path: Path) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -309,6 +309,17 @@ def test_setup_local_dev_refreshes_claude_code_local_plugin() -> None:
     assert "installing/updating claude-smart@reflexioai-local" in script
 
 
+def test_setup_local_dev_prefers_workspace_reflexio_checkout() -> None:
+    script = SETUP_LOCAL_DEV.read_text()
+
+    assert "CLAUDE_SMART_LOCAL_REFLEXIO_PATH" in script
+    assert 'sibling_reflexio="$REPO_ROOT/../reflexio"' in script
+    assert 'bundled_reflexio="$REPO_ROOT/reflexio"' in script
+    assert "using Reflexio source at $REFLEXIO_ABS" in script
+    assert "override_learning_stall" in script
+    assert "selected Reflexio client does not support" in script
+
+
 def test_backend_service_configures_shared_embedding_daemon() -> None:
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 


### PR DESCRIPTION
## Summary
- default Codex citation links to OSC 8 terminal hyperlinks
- use compact one-line Codex UserPromptSubmit context while keeping richer context elsewhere
- prevent Claude Code from using the legacy numbered marker format
- add focused tests for marker instructions, compact context, and install script defaults

## Tests
- uv run ruff check --config plugin/pyproject.toml plugin/src/claude_smart/cs_cite.py tests/test_cs_cite.py tests/test_context_format.py tests/test_events.py
- PYTHONPATH=plugin/src uv run pytest tests/test_cs_cite.py::test_citation_instruction_on_returns_compact_string tests/test_context_format.py::test_render_inline_compact_with_registry_is_one_logical_line tests/test_events.py::test_user_prompt_injects_compact_context_for_codex tests/test_events.py::test_user_prompt_injects_context_when_hits_present tests/test_install_scripts.py::test_hook_entry_defaults_codex_citation_links_to_osc8 tests/test_install_scripts.py::test_codex_hook_defaults_citation_links_to_osc8

## Manual verification
- Reinstalled with scripts/setup-local-dev.sh for Codex and Claude Code
- Verified Codex and Claude Code in tmux sessions; OSC 8 marker links are present and unrelated prompts skip markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compact single-line context rendering for mid-session memory with optional OSC‑8 terminal link labels.
  * Codex-host behavior: OSC‑8 is used as the default citation link style when unspecified.
  * Citation instructions updated to forbid legacy marker formats.

* **Tests**
  * Added and extended tests covering compact context rendering, OSC‑8 link styling, and Codex-default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->