### PR TITLE
Fix claude-smart linked marker UX

### DIFF
--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -220,7 +220,7 @@ def render_inline_compact_with_registry(
             item = linked_title
             if content != title:
                 item += f": {content}"
-            marker_parts.append(f"✨ claude-smart rule applied: {linked_title}")
+            marker_parts.append(linked_title)
         else:
             item = f"{content} (title: {title}"
             if rule_url:
@@ -240,7 +240,7 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
         return ""
     link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
     if link_style == "osc8" and marker_parts:
-        marker = marker_parts[0] if len(marker_parts) == 1 else "; ".join(marker_parts)
+        marker = f"✨ claude-smart rule applied: {'; '.join(marker_parts)}"
         return (
             f"If used, copy this final marker exactly, preserving its hidden "
             f"OSC 8 terminal link: `{marker}`. Skip when unrelated."

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -240,10 +240,16 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
         return ""
     link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
     if link_style == "osc8" and marker_parts:
-        marker = f"✨ claude-smart rule applied: {'; '.join(marker_parts)}"
+        marker = f"✨ claude-smart rule applied: {' | '.join(marker_parts)}"
+        separator_instruction = (
+            " Separate multiple linked memories with the visible ` | ` separator."
+            if len(marker_parts) > 1
+            else ""
+        )
         return (
             f"If used, copy this final marker exactly, preserving its hidden "
-            f"OSC 8 terminal link: `{marker}`. Skip when unrelated."
+            f"OSC 8 terminal link: `{marker}`.{separator_instruction} "
+            f"Skip when unrelated."
         )
     if link_style == "osc8":
         return (

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -106,6 +106,9 @@ def render_with_registry(
     )
     if instruction:
         sections.append(instruction)
+    exact_osc8_marker = _exact_osc8_marker_instruction(playbook_entries + profile_entries)
+    if exact_osc8_marker:
+        sections.append(exact_osc8_marker)
     return "\n".join(sections) + "\n", playbook_entries + profile_entries
 
 
@@ -182,6 +185,9 @@ def render_inline_with_registry(
     )
     if instruction:
         sections.append(instruction)
+    exact_osc8_marker = _exact_osc8_marker_instruction(playbook_entries + profile_entries)
+    if exact_osc8_marker:
+        sections.append(exact_osc8_marker)
     return "\n".join(sections) + "\n", playbook_entries + profile_entries
 
 
@@ -262,6 +268,32 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
         "with one final marker like `✨ claude-smart rule applied: "
         "[verify process state](http://localhost:3001/rules/s1-123)` using "
         "the shown rule URL; skip the marker when unrelated."
+    )
+
+
+def _exact_osc8_marker_instruction(entries: list[dict[str, Any]]) -> str:
+    if os.environ.get("CLAUDE_SMART_CITATIONS", "on") == "off":
+        return ""
+    if os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown") != "osc8":
+        return ""
+
+    marker_parts = []
+    for entry in entries:
+        rule_url = str(entry.get("rule_url") or "")
+        if not rule_url:
+            continue
+        title = _one_line(str(entry.get("title") or entry["content"]))
+        marker_parts.append(
+            _osc8_link(rule_url, _strip_trailing_sentence_punctuation(title))
+        )
+    if not marker_parts:
+        return ""
+
+    marker = f"✨ claude-smart rule applied: {' | '.join(marker_parts)}"
+    return (
+        "If any listed memory above was used, copy this exact final marker, "
+        f"preserving its hidden OSC 8 terminal links: `{marker}`. "
+        "Do not rename, summarize, or regroup the linked titles."
     )
 
 

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -214,7 +214,8 @@ def render_inline_compact_with_registry(
     if not entries:
         return "", []
 
-    item_parts = []
+    skill_parts = []
+    preference_parts = []
     marker_parts = []
     link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
     for entry in entries:
@@ -223,18 +224,26 @@ def render_inline_compact_with_registry(
         rule_url = str(entry.get("rule_url") or "")
         if link_style == "osc8" and rule_url:
             linked_title = _osc8_link(rule_url, _strip_trailing_sentence_punctuation(title))
-            item = linked_title
-            if content != title:
-                item += f": {content}"
+            item = _osc8_link(rule_url, _strip_trailing_sentence_punctuation(content))
             marker_parts.append(linked_title)
         else:
             item = f"{content} (title: {title}"
             if rule_url:
                 item += f"; open: {rule_url}"
             item += ")"
-        item_parts.append(item)
+        if entry.get("kind") == "profile":
+            preference_parts.append(item)
+        else:
+            skill_parts.append(item)
 
-    sections = [f"claude-smart: using relevant memory: {'; '.join(item_parts)}."]
+    memory_sections = []
+    if skill_parts:
+        label = "Skill" if len(skill_parts) == 1 else "Skills"
+        memory_sections.append(f"{label}: {'; '.join(skill_parts)}")
+    if preference_parts:
+        label = "Preference" if len(preference_parts) == 1 else "Preferences"
+        memory_sections.append(f"{label}: {'; '.join(preference_parts)}")
+    sections = [f"claude-smart: using relevant memory. {'. '.join(memory_sections)}."]
     instruction = _compact_citation_instruction(marker_parts)
     if instruction:
         sections.append(instruction)

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -66,8 +66,8 @@ _RAW_DASHBOARD_URL_RE = re.compile(
 )
 
 _COMPACT_INTRO = (
-    "_If a listed `[cs:…]` item materially changes your answer, end with one "
-    "final marker line. Skip the marker when no listed item changed the "
+    "_If you use any listed `[cs:…]` item to answer, you must end with one "
+    "final marker line. Skip the marker only when no listed item affected the "
     "answer."
 )
 
@@ -76,9 +76,10 @@ _MARKDOWN_MARKER_PARAGRAPH = (
     "`✨ claude-smart rule applied: "
     "[verify process state](http://localhost:3001/rules/s1-123)`. "
     "For multiple items: "
-    "`✨ claude-smart rules applied: "
-    "[git safety](http://localhost:3001/rules/s1-123), "
+    "`✨ claude-smart rule applied: "
+    "[git safety](http://localhost:3001/rules/s1-123) | "
     "[brief answer preference](http://localhost:3001/rules/p1-pref)`. "
+    "Separate multiple linked memories with the visible ` | ` separator. "
     "Use the dashboard URL shown beside each cited item; do not invent URLs. "
     "Do not include `[cs:…]` ids in the marker line. Never use the old "
     "`✨ 1 claude-smart learning applied [cs:...]` marker format._"
@@ -91,11 +92,11 @@ _OSC8_EXAMPLE_ONE = (
     "\x1b]8;;\x1b\\"
 )
 _OSC8_EXAMPLE_MULTI = (
-    "✨ claude-smart rules applied: "
+    "✨ claude-smart rule applied: "
     "\x1b]8;;http://localhost:3001/rules/s1-123\x1b\\"
     "git safety"
     "\x1b]8;;\x1b\\"
-    ", "
+    " | "
     "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\"
     "brief answer preference"
     "\x1b]8;;\x1b\\"
@@ -105,8 +106,10 @@ _OSC8_MARKER_PARAGRAPH = (
     "URLs. Format for one item: "
     f"`{_OSC8_EXAMPLE_ONE}`. For multiple items: "
     f"`{_OSC8_EXAMPLE_MULTI}`. Use the dashboard URL shown beside each cited "
-    "item; do not invent URLs. If OSC 8 is unavailable, use markdown links. "
-    "Do not include `[cs:…]` ids in the marker line._"
+    "item; do not invent URLs. Separate multiple linked memories with the "
+    "visible ` | ` separator. If OSC 8 is unavailable, use markdown links. "
+    "Do not include `[cs:…]` ids in the marker line. Do not omit the marker "
+    "after using listed memory._"
 )
 
 CITATION_MODES = ("on", "auto", "marker-only", "off")

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -268,10 +268,13 @@ def test_render_inline_compact_with_registry_is_one_logical_line(
     assert "###" not in md
     assert "- [cs:" not in md
     assert "[cs:" not in md
-    assert "claude-smart: using relevant memory:" in md
+    assert "claude-smart: using relevant memory. Skill:" in md
+    assert "Preference:" in md
     assert "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\" in md
     assert "Run uv sync after pyproject edits" in md
-    assert "Then run an import smoke test before committing." in md
+    assert "Then run an import smoke test before committing" in md
+    assert "Run uv sync after pyproject edits: Run uv sync" not in md
+    assert "title:" not in md
     assert "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in md
     assert "prefers concise answers" in md
     assert "✨ claude-smart rule applied:" in md

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -262,7 +262,17 @@ def test_render_inline_compact_with_registry_is_one_logical_line(
     assert "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in md
     assert "prefers concise answers" in md
     assert "✨ claude-smart rule applied:" in md
+    assert md.count("✨ claude-smart rule applied:") == 1
     assert "preserving its hidden OSC 8 terminal link" in md
+    assert (
+        "✨ claude-smart rule applied: "
+        "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\"
+        "Run uv sync after pyproject edits"
+        "\x1b]8;;\x1b\\; "
+        "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\"
+        "prefers concise answers"
+        "\x1b]8;;\x1b\\"
+    ) in md
     assert "open: http://localhost:3001/rules/s1-17" not in md
     assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
 

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -268,11 +268,12 @@ def test_render_inline_compact_with_registry_is_one_logical_line(
         "✨ claude-smart rule applied: "
         "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\"
         "Run uv sync after pyproject edits"
-        "\x1b]8;;\x1b\\; "
+        "\x1b]8;;\x1b\\ | "
         "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\"
         "prefers concise answers"
         "\x1b]8;;\x1b\\"
     ) in md
+    assert "visible ` | ` separator" in md
     assert "open: http://localhost:3001/rules/s1-17" not in md
     assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
 

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -107,7 +107,7 @@ def test_render_with_registry_emits_citation_instruction() -> None:
         profiles=[],
     )
     assert cs_cite.CITATION_INSTRUCTION in md
-    assert "materially changes your answer" in md
+    assert "If you use any listed" in md
     assert "Do not call a shell command" not in md
     assert "✨ claude-smart rule applied: [verify process state]" in md
     assert "[brief answer preference]" in md
@@ -222,13 +222,26 @@ def test_render_inline_with_registry_can_inject_osc8_instruction(monkeypatch) ->
     monkeypatch.setenv("CLAUDE_SMART_CITATION_LINK_STYLE", "osc8")
     md, _ = context_format.render_inline_with_registry(
         project_id="demo",
-        user_playbooks=[{"content": "x"}],
+        user_playbooks=[
+            {"content": "Use uv sync after pyproject edits.", "user_playbook_id": 17}
+        ],
         agent_playbooks=[],
-        profiles=[],
+        profiles=[{"content": "prefers concise answers", "profile_id": "pref"}],
     )
     assert "OSC 8 terminal" in md
     assert "\x1b]8;;http://localhost:3001/rules/s1-123\x1b\\" in md
     assert "✨ claude-smart rule applied: [verify process state]" not in md
+    assert "copy this exact final marker" in md
+    assert "Do not rename, summarize, or regroup the linked titles." in md
+    assert (
+        "✨ claude-smart rule applied: "
+        "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\"
+        "Use uv sync after pyproject edits"
+        "\x1b]8;;\x1b\\ | "
+        "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\"
+        "prefers concise answers"
+        "\x1b]8;;\x1b\\"
+    ) in md
 
 
 def test_render_inline_compact_with_registry_is_one_logical_line(

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -158,7 +158,8 @@ def test_rank_id_rejects_unknown_kind() -> None:
 def test_citation_instruction_on_returns_compact_string() -> None:
     text = cs_cite.citation_instruction("on")
     assert text == cs_cite.CITATION_INSTRUCTION
-    assert "materially changes your answer" in text
+    assert "If you use any listed" in text
+    assert "Skip the marker only when no listed item affected" in text
     assert "citation block is up to two lines" not in text
     assert "counterfactual" not in text.lower()
     assert "✨ claude-smart rule applied:" in text
@@ -176,6 +177,11 @@ def test_citation_instruction_osc8_uses_terminal_hyperlink_examples() -> None:
     text = cs_cite.citation_instruction("on", "osc8")
     assert "OSC 8 terminal" in text
     assert "\x1b]8;;http://localhost:3001/rules/s1-123\x1b\\" in text
+    assert "✨ claude-smart rule applied:" in text
+    assert "✨ claude-smart rules applied:" not in text
+    assert " | \x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in text
+    assert "visible ` | ` separator" in text
+    assert "Do not omit the marker after using listed memory" in text
     assert "markdown links" in text
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -965,11 +965,13 @@ def test_user_prompt_injects_compact_context_for_codex(
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
     assert markdown.endswith("\n")
     assert "\n" not in markdown.rstrip("\n")
-    assert "claude-smart: using relevant memory:" in markdown
+    assert "claude-smart: using relevant memory. Skill:" in markdown
+    assert "Preference:" in markdown
     assert "### Relevant project preferences" not in markdown
     assert "[cs:" not in markdown
     assert "Run uv sync after pyproject edits" in markdown
-    assert "Then run an import smoke test before committing." in markdown
+    assert "Then run an import smoke test before committing" in markdown
+    assert "Run uv sync after pyproject edits: Run uv sync" not in markdown
     assert "prefers anyio over asyncio" in markdown
     assert "\x1b]8;;http://localhost:3001/rules/s1\x1b\\" in markdown
     assert "✨ claude-smart rule applied:" in markdown


### PR DESCRIPTION
## Summary
- preserve full compact memory content while using OSC 8 linked marker titles
- collapse multiple marker items under one `✨ claude-smart rule applied:` prefix
- use visible ` | ` separators across Codex and Claude Code marker guidance

## Verification
- `PYTHONPATH=plugin/src uv run pytest tests/test_cs_cite.py::test_citation_instruction_osc8_uses_terminal_hyperlink_examples tests/test_context_format.py::test_render_with_registry_emits_citation_instruction tests/test_context_format.py::test_render_inline_with_registry_can_inject_osc8_instruction tests/test_context_format.py::test_render_inline_compact_with_registry_is_one_logical_line`
- `uv run ruff check --config plugin/pyproject.toml plugin/src/claude_smart/cs_cite.py plugin/src/claude_smart/context_format.py tests/test_cs_cite.py tests/test_context_format.py`
- live tmux verification in Codex and Claude Code for preference-only and mixed skill+preference retrieval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clearer citation instruction text requiring a final marker when listed items are used.
  * New explicit “copy this exact final marker” guidance for OSC8-style citations, including visible ` | ` separator rules for multi-item links.
  * Compact/inline citation output consolidated into a single logical line for consistent display.
  * Updated multi-item citation formatting to use a visible pipe separator for readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->