### PR TITLE
feat: add managed Reflexio mode and HTTP timeout safety

### DIFF
--- a/MANAGED_REFLEXIO.md
+++ b/MANAGED_REFLEXIO.md
@@ -1,0 +1,177 @@
+# Managed Reflexio for claude-smart
+
+This guide explains how to run claude-smart against the managed Reflexio
+service instead of the local Reflexio backend.
+
+Managed mode is opt-in. If you install claude-smart without an API key, setup
+uses the current local backend flow and stores data on your machine. If you pass
+an API key, setup writes managed-service credentials to `~/.reflexio/.env` and
+hooks send learning data to `https://www.reflexio.ai/`.
+
+## When to Use Managed Mode
+
+Use managed mode when you want:
+
+- Shared Reflexio state across machines.
+- No local Reflexio backend process.
+- Managed storage and authentication through Reflexio.
+
+Use local mode when you want:
+
+- Fully local storage under `~/.reflexio/`.
+- Offline-friendly semantic search and extraction.
+- No external Reflexio service dependency.
+
+## Install with Managed Reflexio
+
+Set your managed Reflexio API key in your shell:
+
+```bash
+export REFLEXIO_API_KEY="rflx-your-api-key"
+```
+
+Install for Claude Code:
+
+```bash
+npx claude-smart install --api-key "$REFLEXIO_API_KEY"
+```
+
+Install for Codex:
+
+```bash
+npx claude-smart install --host codex --api-key "$REFLEXIO_API_KEY"
+```
+
+The default managed URL is:
+
+```text
+https://www.reflexio.ai/
+```
+
+To override it:
+
+```bash
+npx claude-smart install \
+  --api-key "$REFLEXIO_API_KEY" \
+  --reflexio-url "https://www.reflexio.ai/"
+```
+
+After install, restart Claude Code or Codex so hooks reload with the new
+configuration.
+
+## What Setup Writes
+
+Managed setup writes these values to `~/.reflexio/.env`:
+
+```env
+REFLEXIO_URL="https://www.reflexio.ai/"
+REFLEXIO_API_KEY="rflx-your-api-key"
+```
+
+The file is written with mode `0600`. Unknown keys, comments, and unrelated
+settings are preserved.
+
+Local setup still writes only the local-mode flags:
+
+```env
+CLAUDE_SMART_USE_LOCAL_CLI=1
+CLAUDE_SMART_USE_LOCAL_EMBEDDING=1
+```
+
+`REFLEXIO_URL` and `REFLEXIO_API_KEY` are written only when `--api-key` is
+provided.
+
+## Verify Managed Access
+
+Use a harmless read endpoint to verify the API key:
+
+```bash
+curl -fsS \
+  -H "User-Agent: claude-smart" \
+  -H "Authorization: Bearer $REFLEXIO_API_KEY" \
+  https://www.reflexio.ai/api/whoami
+```
+
+A successful response returns JSON describing the authenticated organization and
+storage routing.
+
+You can also check claude-smart's backend status:
+
+```bash
+bash ~/.reflexio/plugin-root/scripts/backend-service.sh status
+```
+
+In managed mode, it should report the remote `REFLEXIO_URL` instead of starting
+or requiring the local backend on `http://localhost:8071`.
+
+## Dashboard Behavior
+
+The claude-smart dashboard still runs locally. In managed mode, its Reflexio API
+proxy forwards requests to the configured `REFLEXIO_URL` and includes:
+
+```text
+Authorization: Bearer <REFLEXIO_API_KEY>
+User-Agent: claude-smart
+```
+
+The bearer token is attached only when the proxy target matches the configured
+`REFLEXIO_URL` origin. If you temporarily point the dashboard endpoint field at
+another URL, the proxy can forward the request, but it will not send the managed
+API key to that alternate origin.
+
+Open the dashboard the same way as local mode:
+
+- Claude Code: `/claude-smart:dashboard`
+- Codex: `bash ~/.reflexio/plugin-root/scripts/dashboard-open.sh`
+
+The dashboard Environment page can view or update `REFLEXIO_URL` and
+`REFLEXIO_API_KEY`.
+
+## Citation Links
+
+When claude-smart is using a remote `REFLEXIO_URL`, citation links point to the
+managed Reflexio list pages for now:
+
+- Profiles: `https://www.reflexio.ai/profiles`
+- Playbooks: `https://www.reflexio.ai/playbooks`
+
+Local mode keeps using local dashboard rule links such as
+`http://localhost:3001/rules/...`.
+
+## Switch Back to Local Mode
+
+Edit `~/.reflexio/.env` and remove:
+
+```env
+REFLEXIO_URL=...
+REFLEXIO_API_KEY=...
+```
+
+Then make sure the local flags are present:
+
+```env
+CLAUDE_SMART_USE_LOCAL_CLI=1
+CLAUDE_SMART_USE_LOCAL_EMBEDDING=1
+```
+
+Restart Claude Code or Codex, or run:
+
+```bash
+bash ~/.reflexio/plugin-root/scripts/backend-service.sh start
+```
+
+Local mode will use the local Reflexio backend at `http://localhost:8071`.
+
+## Troubleshooting
+
+If managed learning does not appear:
+
+- Confirm `REFLEXIO_API_KEY` is present in `~/.reflexio/.env`.
+- Confirm `REFLEXIO_URL` points at `https://www.reflexio.ai/`.
+- Run the `curl` command above and check for HTTP 200.
+- Restart Claude Code or Codex after changing `.env`.
+- Check `~/.claude-smart/backend.log` for hook startup messages.
+
+If the local backend starts unexpectedly, check for a localhost URL in
+`~/.reflexio/.env`. Any non-local `REFLEXIO_URL` puts claude-smart in managed
+mode; an absent or localhost URL uses local mode.

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -15,6 +15,7 @@ const { execSync, spawn, spawnSync } = require("child_process");
 const crypto = require("crypto");
 const {
   appendFileSync,
+  chmodSync,
   cpSync,
   existsSync,
   lstatSync,
@@ -37,6 +38,7 @@ const CODEX_MARKETPLACE_NAME = "reflexioai";
 const CODEX_MARKETPLACE_DISPLAY_NAME = "ReflexioAI";
 const CODEX_PLUGIN_ID = `claude-smart@${CODEX_MARKETPLACE_NAME}`;
 const REFLEXIO_ENV_PATH = join(homedir(), ".reflexio", ".env");
+const MANAGED_REFLEXIO_URL = "https://www.reflexio.ai/";
 const REFLEXIO_DIR = join(homedir(), ".reflexio");
 const CLAUDE_SMART_STATE_DIR = join(homedir(), ".claude-smart");
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
@@ -206,7 +208,80 @@ function seedReflexioEnv() {
   const prefix = existing && !existing.endsWith("\n") ? "\n" : "";
   const body = missing.map((f) => `${f}=1`).join("\n") + "\n";
   appendFileSync(REFLEXIO_ENV_PATH, prefix + body);
+  chmodSync(REFLEXIO_ENV_PATH, 0o600);
   return missing;
+}
+
+function escapeEnvValue(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function parseEnvLine(line) {
+  let trimmed = String(line || "").trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+  if (trimmed.startsWith("export ")) trimmed = trimmed.slice("export ".length).trimStart();
+  const eq = trimmed.indexOf("=");
+  if (eq < 0) return null;
+  const key = trimmed.slice(0, eq).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null;
+  return { key };
+}
+
+function setReflexioEnvVars(values) {
+  mkdirSync(dirname(REFLEXIO_ENV_PATH), { recursive: true });
+  const existing = existsSync(REFLEXIO_ENV_PATH)
+    ? readFileSync(REFLEXIO_ENV_PATH, "utf8")
+    : "";
+  const lines = existing ? existing.split(/\r?\n/) : [];
+  const seen = new Set();
+  const out = [];
+  for (const line of lines) {
+    const parsed = parseEnvLine(line);
+    if (parsed && Object.prototype.hasOwnProperty.call(values, parsed.key)) {
+      out.push(`${parsed.key}="${escapeEnvValue(values[parsed.key])}"`);
+      seen.add(parsed.key);
+    } else {
+      out.push(line);
+    }
+  }
+  const added = [];
+  for (const [key, value] of Object.entries(values)) {
+    if (seen.has(key)) continue;
+    out.push(`${key}="${escapeEnvValue(value)}"`);
+    added.push(key);
+  }
+  const content = out.join("\n").replace(/\n*$/, "\n");
+  writeFileSync(REFLEXIO_ENV_PATH, content);
+  chmodSync(REFLEXIO_ENV_PATH, 0o600);
+  return added;
+}
+
+function maskSecret(value) {
+  if (!value) return "";
+  if (value.length <= 8) return "*".repeat(value.length);
+  const prefix = value.slice(0, 8).includes("-") ? value.slice(0, 5) : value.slice(0, 4);
+  return `${prefix}****${value.slice(-4)}`;
+}
+
+function configureReflexioSetup(args) {
+  const apiKey = parseOptionalArg(args, "--api-key").trim();
+  if (apiKey) {
+    const reflexioUrl = parseOptionalArg(args, "--reflexio-url") || MANAGED_REFLEXIO_URL;
+    const added = setReflexioEnvVars({
+      REFLEXIO_URL: reflexioUrl,
+      REFLEXIO_API_KEY: apiKey,
+    });
+    const changed = added.length > 0 ? added.join(", ") : "managed Reflexio settings";
+    process.stdout.write(
+      `Configured ${REFLEXIO_ENV_PATH} for managed Reflexio (${changed}; API key ${maskSecret(apiKey)}).\n`,
+    );
+    return;
+  }
+
+  const added = seedReflexioEnv();
+  if (added.length > 0) {
+    process.stdout.write(`Seeded ${REFLEXIO_ENV_PATH} with ${added.join(", ")}.\n`);
+  }
 }
 
 function findClaudeCodePluginRoot() {
@@ -724,6 +799,7 @@ function printHelp() {
       "  npx claude-smart install                       Install the plugin into Claude Code",
       "  npx claude-smart install --host codex          Register the plugin marketplace for Codex",
       "  npx claude-smart install --source <owner/repo> Override the marketplace source",
+      "  npx claude-smart install --api-key <key>        Use managed Reflexio service",
       "  npx claude-smart uninstall --host codex        Remove the Codex marketplace registration",
       "  npx claude-smart --help                        Show this help",
       "",
@@ -732,6 +808,7 @@ function printHelp() {
       `  2. claude plugin install ${PLUGIN_SPEC}`,
       "  3. Appends CLAUDE_SMART_USE_LOCAL_CLI=1 and CLAUDE_SMART_USE_LOCAL_EMBEDDING=1",
       "     to ~/.reflexio/.env (idempotent).",
+      "     Passing --api-key writes REFLEXIO_URL and REFLEXIO_API_KEY instead.",
       "",
       "Codex install:",
       `  1. Copies the bundled marketplace to ${CODEX_MARKETPLACE_DIR}`,
@@ -758,6 +835,17 @@ function parseSource(args) {
   const value = args[idx + 1];
   if (!value) {
     process.stderr.write("error: --source requires a value (e.g. owner/repo)\n");
+    process.exit(1);
+  }
+  return value;
+}
+
+function parseOptionalArg(args, flag) {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return "";
+  const value = args[idx + 1];
+  if (!value) {
+    process.stderr.write(`error: ${flag} requires a value\n`);
     process.exit(1);
   }
   return value;
@@ -1215,7 +1303,7 @@ async function runUninstall(args) {
 
 async function runInstall(args) {
   if (parseHost(args) === "codex") {
-    await runInstallCodex();
+    await runInstallCodex(args);
     return;
   }
 
@@ -1243,12 +1331,7 @@ async function runInstall(args) {
     }
   }
 
-  const added = seedReflexioEnv();
-  if (added.length > 0) {
-    process.stdout.write(
-      `Seeded ${REFLEXIO_ENV_PATH} with ${added.join(", ")}.\n`,
-    );
-  }
+  configureReflexioSetup(args);
   try {
     const pluginRoot = await bootstrapClaudeCodeInstall();
     process.stdout.write(`Prepared claude-smart runtime at ${pluginRoot}.\n`);
@@ -1276,7 +1359,7 @@ async function runInstall(args) {
   );
 }
 
-async function runInstallCodex() {
+async function runInstallCodex(args) {
   if (!hasCli("codex")) {
     process.stderr.write("error: 'codex' CLI not found on PATH. Install Codex first.\n");
     process.exit(1);
@@ -1323,6 +1406,7 @@ async function runInstallCodex() {
   try {
     cacheDir = installCodexPluginCache(codexMarketplacePluginRoot(marketplaceRoot));
     process.stdout.write(`Installed Codex plugin cache at ${cacheDir}.\n`);
+    configureReflexioSetup(args);
     await bootstrapPluginRuntime(cacheDir);
     if (refreshDashboardService(cacheDir)) {
       process.stdout.write("Refreshed claude-smart dashboard service.\n");
@@ -1357,11 +1441,6 @@ async function runInstallCodex() {
     process.exit(1);
   } else {
     process.stdout.write(`Trusted and enabled ${trustedHookCount} claude-smart Codex hooks.\n`);
-  }
-
-  const added = seedReflexioEnv();
-  if (added.length > 0) {
-    process.stdout.write(`Seeded ${REFLEXIO_ENV_PATH} with ${added.join(", ")}.\n`);
   }
 
   process.stdout.write(
@@ -1446,6 +1525,7 @@ module.exports = {
   copyCodexMarketplace,
   ensurePrivateNode,
   ensureUv,
+  configureReflexioSetup,
   patchCodexHooksForNode,
   platformSupportError,
 };

--- a/plugin/dashboard/app/api/config/route.ts
+++ b/plugin/dashboard/app/api/config/route.ts
@@ -1,16 +1,25 @@
 import { NextResponse } from "next/server";
 import { readConfig, writeConfig } from "@/lib/config-file";
+import type { ClaudeSmartConfig } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
+function publicConfig(config: ClaudeSmartConfig): ClaudeSmartConfig {
+  return {
+    ...config,
+    REFLEXIO_API_KEY: "",
+    REFLEXIO_API_KEY_SET: Boolean(config.REFLEXIO_API_KEY),
+  };
+}
+
 export async function GET() {
   const config = await readConfig();
-  return NextResponse.json(config);
+  return NextResponse.json(publicConfig(config));
 }
 
 export async function PUT(req: Request) {
   const body = await req.json();
   await writeConfig(body);
   const config = await readConfig();
-  return NextResponse.json(config);
+  return NextResponse.json(publicConfig(config));
 }

--- a/plugin/dashboard/app/api/reflexio/[...path]/route.ts
+++ b/plugin/dashboard/app/api/reflexio/[...path]/route.ts
@@ -1,16 +1,42 @@
 import { NextResponse } from "next/server";
 import { originOnly } from "@/lib/reflexio-url";
+import { readConfig } from "@/lib/config-file";
 
 export const dynamic = "force-dynamic";
 
 const DEFAULT_URL = "http://localhost:8071";
 
-function reflexioBase(req: Request): string {
+function isLocalUrl(raw: string | null): boolean {
+  if (!raw) return false;
+  try {
+    const url = new URL(raw);
+    return ["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function reflexioConfig(req: Request): Promise<{ base: string; apiKey: string }> {
+  const config = await readConfig();
   const header = req.headers.get("x-reflexio-url");
   const fromHeader = header ? originOnly(header) : null;
-  if (fromHeader) return fromHeader;
+  const apiKey = config.REFLEXIO_API_KEY || process.env.REFLEXIO_API_KEY || "";
   const fromEnv = originOnly(process.env.REFLEXIO_URL ?? "");
-  return fromEnv ?? DEFAULT_URL;
+  const fromConfig = originOnly(config.REFLEXIO_URL ?? "");
+  const configuredBase = fromEnv ?? fromConfig;
+  if (
+    fromHeader &&
+    !(isLocalUrl(fromHeader) && configuredBase && !isLocalUrl(configuredBase))
+  ) {
+    return {
+      base: fromHeader,
+      apiKey: fromHeader === configuredBase ? apiKey : "",
+    };
+  }
+  return {
+    base: configuredBase ?? DEFAULT_URL,
+    apiKey: configuredBase ? apiKey : "",
+  };
 }
 
 async function proxy(
@@ -20,12 +46,16 @@ async function proxy(
   const { path } = await context.params;
   const targetPath = path.join("/");
   const url = new URL(req.url);
-  const target = `${reflexioBase(req)}/${targetPath}${url.search}`;
+  const { base, apiKey } = await reflexioConfig(req);
+  const target = `${base}/${targetPath}${url.search}`;
 
   const headers = new Headers(req.headers);
   headers.delete("host");
   headers.delete("x-reflexio-url");
   headers.delete("connection");
+  headers.delete("authorization");
+  headers.set("user-agent", "claude-smart");
+  if (apiKey) headers.set("authorization", `Bearer ${apiKey}`);
 
   const init: RequestInit = {
     method: req.method,

--- a/plugin/dashboard/app/configure/env/page.tsx
+++ b/plugin/dashboard/app/configure/env/page.tsx
@@ -16,6 +16,7 @@ export default function ConfigureEnvPage() {
   const [config, setConfig] = useState<ClaudeSmartConfig | null>(null);
   const [hookConfig, setHookConfig] = useState<ClaudeCodeHookConfig | null>(null);
   const [hookDirty, setHookDirty] = useState(false);
+  const [apiKeyDirty, setApiKeyDirty] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -31,6 +32,7 @@ export default function ConfigureEnvPage() {
         setConfig(envConfig);
         setHookConfig(claudeConfig);
         setHookDirty(false);
+        setApiKeyDirty(false);
       })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)));
   }, []);
@@ -63,11 +65,14 @@ export default function ConfigureEnvPage() {
     setSaving(true);
     setError(null);
     try {
+      const envUpdate: Partial<ClaudeSmartConfig> = { ...config };
+      if (!apiKeyDirty) delete envUpdate.REFLEXIO_API_KEY;
+      delete envUpdate.REFLEXIO_API_KEY_SET;
       const [envRes, hookRes] = await Promise.all([
         fetch("/api/config", {
           method: "PUT",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify(config),
+          body: JSON.stringify(envUpdate),
         }),
         fetch("/api/claude-settings", {
           method: "PUT",
@@ -90,6 +95,7 @@ export default function ConfigureEnvPage() {
       setConfig(updated);
       setHookConfig(updatedHook);
       setHookDirty(false);
+      setApiKeyDirty(false);
       setSaved(true);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -164,6 +170,25 @@ export default function ConfigureEnvPage() {
                   onChange={(e) => update("REFLEXIO_URL", e.target.value)}
                   className="font-mono text-xs bg-background/80"
                   placeholder="http://localhost:8071/"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>REFLEXIO_API_KEY</Label>
+                <Input
+                  type="password"
+                  value={String(config.REFLEXIO_API_KEY ?? "")}
+                  onChange={(e) => {
+                    setApiKeyDirty(true);
+                    update("REFLEXIO_API_KEY", e.target.value);
+                  }}
+                  className="font-mono text-xs bg-background/80"
+                  placeholder={
+                    config.REFLEXIO_API_KEY_SET
+                      ? "(configured - leave blank to keep existing key)"
+                      : "(empty - local mode)"
+                  }
+                  autoComplete="off"
                 />
               </div>
 

--- a/plugin/dashboard/hooks/use-settings.tsx
+++ b/plugin/dashboard/hooks/use-settings.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useSyncExternalStore,
   ReactNode,
@@ -66,9 +67,44 @@ function parse(json: string): Settings {
   }
 }
 
+function isLocalUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return ["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const raw = useSyncExternalStore(subscribe, readStorage, () => DEFAULT_JSON);
   const settings = useMemo(() => parse(raw), [raw]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function syncManagedUrl() {
+      try {
+        const res = await fetch("/api/config", { cache: "no-store" });
+        if (!res.ok) return;
+        const config = (await res.json()) as { REFLEXIO_URL?: string };
+        const configuredUrl = config.REFLEXIO_URL;
+        if (
+          !cancelled &&
+          configuredUrl &&
+          !isLocalUrl(configuredUrl) &&
+          isLocalUrl(settings.reflexioUrl)
+        ) {
+          writeStorage({ reflexioUrl: configuredUrl });
+        }
+      } catch {
+        // Keep the dashboard on its local default when config cannot be read.
+      }
+    }
+    void syncManagedUrl();
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.reflexioUrl]);
 
   const setReflexioUrl = useCallback((url: string) => {
     writeStorage({ reflexioUrl: url });

--- a/plugin/dashboard/lib/config-file.ts
+++ b/plugin/dashboard/lib/config-file.ts
@@ -10,6 +10,7 @@ import type { ClaudeSmartConfig } from "./types";
 
 const KNOWN_KEYS = [
   "REFLEXIO_URL",
+  "REFLEXIO_API_KEY",
   "CLAUDE_SMART_USE_LOCAL_CLI",
   "CLAUDE_SMART_USE_LOCAL_EMBEDDING",
   "CLAUDE_SMART_CLI_PATH",
@@ -47,6 +48,7 @@ function parseLine(line: string): { key: string; value: string } | null {
 export async function readConfig(): Promise<ClaudeSmartConfig> {
   const defaults: ClaudeSmartConfig = {
     REFLEXIO_URL: "http://localhost:8071/",
+    REFLEXIO_API_KEY: "",
     CLAUDE_SMART_USE_LOCAL_CLI: false,
     CLAUDE_SMART_USE_LOCAL_EMBEDDING: false,
     CLAUDE_SMART_CLI_PATH: "",

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -113,12 +113,14 @@ export interface SessionDetail {
 
 export interface ClaudeSmartConfig {
   REFLEXIO_URL: string;
+  REFLEXIO_API_KEY: string;
+  REFLEXIO_API_KEY_SET?: boolean;
   CLAUDE_SMART_USE_LOCAL_CLI: boolean;
   CLAUDE_SMART_USE_LOCAL_EMBEDDING: boolean;
   CLAUDE_SMART_CLI_PATH: string;
   CLAUDE_SMART_CLI_TIMEOUT: string;
   CLAUDE_SMART_STATE_DIR: string;
-  [extra: string]: string | boolean;
+  [extra: string]: string | boolean | undefined;
 }
 
 export interface ClaudeCodeHookConfig {

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -32,6 +32,59 @@ claude_smart_prepend_node_bins() {
   export PATH="$_CS_NODE_ROOT/bin:$_CS_NODE_ROOT:$PATH"
 }
 
+claude_smart_env_unquote() {
+  local value first last
+  value="$1"
+  first="${value%"${value#?}"}"
+  last="${value#"${value%?}"}"
+  if { [ "$first" = '"' ] && [ "$last" = '"' ]; } || { [ "$first" = "'" ] && [ "$last" = "'" ]; }; then
+    value="${value#?}"
+    value="${value%?}"
+  fi
+  printf '%s\n' "$value"
+}
+
+claude_smart_source_reflexio_env() {
+  local env_file line key value
+  env_file="$HOME/.reflexio/.env"
+  [ -f "$env_file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] || continue
+    case "$line" in
+      \#*) continue ;;
+      export\ *) line="${line#export }" ;;
+    esac
+    key="${line%%=*}"
+    [ "$key" != "$line" ] || continue
+    value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    case "$key" in
+      REFLEXIO_URL|REFLEXIO_API_KEY|CLAUDE_SMART_USE_LOCAL_CLI|CLAUDE_SMART_USE_LOCAL_EMBEDDING|CLAUDE_SMART_BACKEND_AUTOSTART|CLAUDE_SMART_DASHBOARD_AUTOSTART|CLAUDE_SMART_CLI_PATH|CLAUDE_SMART_CLI_TIMEOUT|CLAUDE_SMART_STATE_DIR|CLAUDE_SMART_ENABLE_OPTIMIZER)
+        if [ -z "$(eval "printf '%s' \"\${$key:-}\"")" ]; then
+          value="$(claude_smart_env_unquote "$value")"
+          export "$key=$value"
+        fi
+        ;;
+    esac
+  done < "$env_file"
+}
+
+claude_smart_reflexio_url_is_remote() {
+  local url
+  url="${REFLEXIO_URL:-}"
+  [ -n "$url" ] || return 1
+  case "$url" in
+    http://localhost|http://localhost/|http://localhost:*|http://127.0.0.1|http://127.0.0.1/|http://127.0.0.1:*|http://0.0.0.0|http://0.0.0.0/|http://0.0.0.0:*|http://\[::1\]|http://\[::1\]/|http://\[::1\]:*)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
 claude_smart_is_internal_invocation_env() {
   if [ "${CLAUDE_SMART_INTERNAL:-}" = "1" ]; then
     return 0

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -22,6 +22,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 . "$HERE/_lib.sh"
 claude_smart_source_login_path
 claude_smart_prepend_astral_bins
+claude_smart_source_reflexio_env
 
 CMD="${1:-start}"
 PORT=8071
@@ -182,6 +183,10 @@ case "$CMD" in
     if claude_smart_is_internal_invocation_env; then
       emit_ok; exit 0
     fi
+    if claude_smart_reflexio_url_is_remote; then
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: remote REFLEXIO_URL configured; skipping local backend start"
+      emit_ok; exit 0
+    fi
     # Opt-out: users who don't want the backend managed by the hook can
     # set CLAUDE_SMART_BACKEND_AUTOSTART=0.
     if [ "${CLAUDE_SMART_BACKEND_AUTOSTART:-1}" = "0" ]; then
@@ -269,7 +274,13 @@ case "$CMD" in
     emit_ok
     ;;
   status)
-    if is_our_backend_running; then echo "running on http://localhost:$PORT"; else echo "not running"; fi
+    if claude_smart_reflexio_url_is_remote; then
+      echo "remote configured at $REFLEXIO_URL"
+    elif is_our_backend_running; then
+      echo "running on http://localhost:$PORT"
+    else
+      echo "not running"
+    fi
     ;;
   *)
     emit_ok

--- a/plugin/scripts/cli.sh
+++ b/plugin/scripts/cli.sh
@@ -15,6 +15,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 claude_smart_source_login_path
 claude_smart_prepend_astral_bins
 claude_smart_prepend_node_bins
+claude_smart_source_reflexio_env
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 

--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -160,6 +160,56 @@ function writeBackendUrl(port) {
   fs.writeFileSync(backendUrlFile(), `http://localhost:${port}/\n`);
 }
 
+function unquoteEnvValue(value) {
+  const trimmed = String(value || "").trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function loadReflexioEnv() {
+  const file = path.join(REFLEXIO_DIR, ".env");
+  let text;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return;
+  }
+  const allowed = new Set([
+    "REFLEXIO_URL",
+    "REFLEXIO_API_KEY",
+    "CLAUDE_SMART_USE_LOCAL_CLI",
+    "CLAUDE_SMART_USE_LOCAL_EMBEDDING",
+    "CLAUDE_SMART_BACKEND_AUTOSTART",
+    "CLAUDE_SMART_DASHBOARD_AUTOSTART",
+    "CLAUDE_SMART_CLI_PATH",
+    "CLAUDE_SMART_CLI_TIMEOUT",
+    "CLAUDE_SMART_STATE_DIR",
+    "CLAUDE_SMART_ENABLE_OPTIMIZER",
+  ]);
+  for (const rawLine of text.split(/\r?\n/)) {
+    let line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    if (line.startsWith("export ")) line = line.slice("export ".length).trimStart();
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!allowed.has(key) || process.env[key]) continue;
+    process.env[key] = unquoteEnvValue(line.slice(eq + 1));
+  }
+}
+
+function reflexioUrlIsRemote() {
+  const url = process.env.REFLEXIO_URL || "";
+  if (!url) return false;
+  return !/^http:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i.test(url);
+}
+
 function codexCompatPath(root) {
   const filename = process.platform === "win32"
     ? "codex-claude-compat.cmd"
@@ -333,6 +383,11 @@ async function startBackend(root) {
     emitOk();
     return;
   }
+  if (reflexioUrlIsRemote()) {
+    appendLog("backend.log", "[claude-smart] backend: remote REFLEXIO_URL configured; skipping local backend start");
+    emitOk();
+    return;
+  }
   const pidFile = path.join(STATE_DIR, "backend.pid");
   for (const port of [DEFAULT_BACKEND_PORT, FALLBACK_BACKEND_PORT]) {
     if (pidAlive(readPid(pidFile)) && await healthOk(port, "/health")) {
@@ -486,6 +541,7 @@ function runHook(root, event) {
 
 async function main() {
   prependRuntimePath();
+  loadReflexioEnv();
   const root = pluginRoot();
   process.env.PLUGIN_ROOT = root;
   process.env.CLAUDE_PLUGIN_ROOT = root;

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -23,6 +23,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 . "$HERE/_lib.sh"
 claude_smart_source_login_path
 claude_smart_prepend_node_bins
+claude_smart_source_reflexio_env
 
 CMD="${1:-start}"
 PORT=3001

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -42,6 +42,7 @@ claude_smart_source_login_path
 # Explicit fallback for the astral.sh installer's default paths, in case
 # the user's login-shell rc hasn't yet been re-sourced to pick them up.
 claude_smart_prepend_astral_bins
+claude_smart_source_reflexio_env
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -14,6 +14,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 claude_smart_source_login_path
 claude_smart_prepend_astral_bins
 claude_smart_prepend_node_bins
+claude_smart_source_reflexio_env
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
@@ -105,8 +106,10 @@ install_complete() {
   command -v uv >/dev/null 2>&1 || return 1
   [ -d "$PLUGIN_ROOT/.venv" ] || return 1
   [ -f "$HOME/.reflexio/.env" ] || return 1
-  grep -q '^CLAUDE_SMART_USE_LOCAL_CLI=' "$HOME/.reflexio/.env" || return 1
-  grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$HOME/.reflexio/.env" || return 1
+  if [ -z "${REFLEXIO_API_KEY:-}" ]; then
+    grep -q '^CLAUDE_SMART_USE_LOCAL_CLI=' "$HOME/.reflexio/.env" || return 1
+    grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$HOME/.reflexio/.env" || return 1
+  fi
   if [ -d "$PLUGIN_ROOT/dashboard" ]; then
     [ -d "$PLUGIN_ROOT/dashboard/.next" ] || [ -f "$MARKER_DIR/dashboard-build.pid" ] || [ -f "$(claude_smart_dashboard_unavailable_marker)" ] || return 1
   fi
@@ -431,13 +434,15 @@ fi
 REFLEXIO_ENV="$HOME/.reflexio/.env"
 mkdir -p "$(dirname "$REFLEXIO_ENV")"
 touch "$REFLEXIO_ENV"
-if ! grep -q '^CLAUDE_SMART_USE_LOCAL_CLI=' "$REFLEXIO_ENV"; then
-  printf '\n# Route reflexio generation through the local Claude Code CLI\nCLAUDE_SMART_USE_LOCAL_CLI=1\n' >> "$REFLEXIO_ENV"
-  echo "[claude-smart] appended CLAUDE_SMART_USE_LOCAL_CLI=1 to $REFLEXIO_ENV" >&2
-fi
-if ! grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$REFLEXIO_ENV"; then
-  printf '# Use the in-process ONNX embedder (chromadb) — no API key for semantic search\nCLAUDE_SMART_USE_LOCAL_EMBEDDING=1\n' >> "$REFLEXIO_ENV"
-  echo "[claude-smart] appended CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 to $REFLEXIO_ENV" >&2
+if [ -z "${REFLEXIO_API_KEY:-}" ]; then
+  if ! grep -q '^CLAUDE_SMART_USE_LOCAL_CLI=' "$REFLEXIO_ENV"; then
+    printf '\n# Route reflexio generation through the local Claude Code CLI\nCLAUDE_SMART_USE_LOCAL_CLI=1\n' >> "$REFLEXIO_ENV"
+    echo "[claude-smart] appended CLAUDE_SMART_USE_LOCAL_CLI=1 to $REFLEXIO_ENV" >&2
+  fi
+  if ! grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$REFLEXIO_ENV"; then
+    printf '# Use the in-process ONNX embedder (chromadb) — no API key for semantic search\nCLAUDE_SMART_USE_LOCAL_EMBEDDING=1\n' >> "$REFLEXIO_ENV"
+    echo "[claude-smart] appended CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 to $REFLEXIO_ENV" >&2
+  fi
 fi
 # Migrate stale REFLEXIO_URL from reflexio's library default (8081) to the
 # plugin backend port (8071). Matches the quoted and unquoted forms but

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -33,10 +33,11 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from claude_smart import context_format, ids, publish, state
+from claude_smart import context_format, env_config, ids, publish, state
 from claude_smart.reflexio_adapter import Adapter
 
-_REFLEXIO_ENV_PATH = Path.home() / ".reflexio" / ".env"
+_REFLEXIO_ENV_PATH = env_config.REFLEXIO_ENV_PATH
+_MANAGED_REFLEXIO_URL = env_config.MANAGED_REFLEXIO_URL
 _DEFAULT_MARKETPLACE_SOURCE = "ReflexioAI/claude-smart"
 _PLUGIN_SPEC = "claude-smart@reflexioai"
 _CODEX_MARKETPLACE_NAME = "reflexioai"
@@ -137,7 +138,19 @@ def _seed_reflexio_env() -> list[str]:
     prefix = "" if not existing or existing.endswith("\n") else "\n"
     with _REFLEXIO_ENV_PATH.open("a") as fh:
         fh.write(prefix + "\n".join(f"{f}=1" for f in missing) + "\n")
+    _REFLEXIO_ENV_PATH.chmod(0o600)
     return missing
+
+
+def _seed_managed_reflexio_env(*, api_key: str, reflexio_url: str) -> list[str]:
+    """Write managed Reflexio connection settings to ``~/.reflexio/.env``."""
+    return env_config.set_env_vars(
+        _REFLEXIO_ENV_PATH,
+        {
+            env_config.REFLEXIO_URL_ENV: reflexio_url,
+            env_config.REFLEXIO_API_KEY_ENV: api_key,
+        },
+    )
 
 
 def _find_claude_code_plugin_root() -> Path | None:
@@ -172,10 +185,9 @@ def _find_claude_code_plugin_root() -> Path | None:
         ]
     )
     for candidate in candidates:
-        if (
-            (candidate / "pyproject.toml").is_file()
-            and (candidate / "scripts" / "smart-install.sh").is_file()
-        ):
+        if (candidate / "pyproject.toml").is_file() and (
+            candidate / "scripts" / "smart-install.sh"
+        ).is_file():
             return candidate
     return None
 
@@ -745,7 +757,26 @@ def _register_codex_marketplace(root: Path) -> tuple[bool, str]:
     return False, output or "Codex CLI does not expose plugin marketplace commands"
 
 
-def cmd_install_codex(_args: argparse.Namespace) -> int:
+def _configure_reflexio_setup(args: argparse.Namespace) -> None:
+    api_key = (getattr(args, "api_key", "") or "").strip()
+    if api_key:
+        reflexio_url = (
+            getattr(args, "reflexio_url", "") or _MANAGED_REFLEXIO_URL
+        ).strip()
+        added = _seed_managed_reflexio_env(api_key=api_key, reflexio_url=reflexio_url)
+        changed = ", ".join(added) if added else "managed Reflexio settings"
+        sys.stdout.write(
+            f"Configured {_REFLEXIO_ENV_PATH} for managed Reflexio "
+            f"({changed}; API key {env_config.mask_secret(api_key)}).\n"
+        )
+        return
+
+    added = _seed_reflexio_env()
+    if added:
+        sys.stdout.write(f"Seeded {_REFLEXIO_ENV_PATH} with {', '.join(added)}.\n")
+
+
+def cmd_install_codex(args: argparse.Namespace) -> int:
     """Install the claude-smart plugin marketplace for Codex.
 
     Only supported from a source checkout — the wheel ships the Python
@@ -777,9 +808,7 @@ def cmd_install_codex(_args: argparse.Namespace) -> int:
         return 1
     marketplace_root = _prepare_codex_local_marketplace()
 
-    added = _seed_reflexio_env()
-    if added:
-        sys.stdout.write(f"Seeded {_REFLEXIO_ENV_PATH} with {', '.join(added)}.\n")
+    _configure_reflexio_setup(args)
 
     hooks_ok, hooks_msg = _enable_codex_plugin_hooks()
     if hooks_ok:
@@ -881,9 +910,7 @@ def cmd_install(args: argparse.Namespace) -> int:
             sys.stderr.write(f"error: {' '.join(cmd)} failed (exit {exc.returncode})\n")
             return exc.returncode or 1
 
-    added = _seed_reflexio_env()
-    if added:
-        sys.stdout.write(f"Seeded {_REFLEXIO_ENV_PATH} with {', '.join(added)}.\n")
+    _configure_reflexio_setup(args)
 
     bootstrapped, message = _bootstrap_claude_code_install()
     if not bootstrapped:
@@ -1035,6 +1062,13 @@ def cmd_show(args: argparse.Namespace) -> int:
         agent_playbooks=agent_playbooks,
         profiles=profiles,
     )
+    if not md and adapter.read_errors:
+        sys.stdout.write(
+            "Could not read skills or preferences from Reflexio for "
+            f"project `{project_id}` at `{adapter.url}`.\n"
+            f"First error: {adapter.read_errors[0]}\n"
+        )
+        return 1
     sys.stdout.write(
         md or f"_No skills or preferences yet for project `{project_id}`._\n"
     )
@@ -1045,8 +1079,9 @@ def cmd_learn(args: argparse.Namespace) -> int:
     """Force reflexio extraction over the active session's interactions.
 
     Publishes unpublished interactions with ``force_extraction=True`` and
-    ``override_learning_stall=True`` so extraction runs immediately as an
-    explicit retry rather than at the next batch interval.
+    ``override_learning_stall=True`` as an explicit retry request rather than
+    waiting for the next batch interval. The publish call itself remains
+    non-blocking: ``Adapter.publish`` sends ``wait_for_response=False``.
     When ``args.note`` is provided, the note is appended to the session
     buffer as a neutral User turn before publishing — letting the user
     capture an explicit insight, preference, or workflow note alongside
@@ -1584,7 +1619,13 @@ def _resolve_reflexio_url() -> str:
         str: The ``REFLEXIO_URL`` env var if set, otherwise the default
             local backend endpoint.
     """
+    env_config.load_reflexio_env()
     return os.environ.get("REFLEXIO_URL", "http://localhost:8071/")
+
+
+def _resolve_reflexio_api_key() -> str:
+    env_config.load_reflexio_env()
+    return os.environ.get("REFLEXIO_API_KEY", "")
 
 
 def _format_deleted_counts(deleted_counts: object) -> str:
@@ -1655,7 +1696,10 @@ def cmd_clear_user(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        client = ReflexioClient(url_endpoint=_resolve_reflexio_url())
+        client = ReflexioClient(
+            url_endpoint=_resolve_reflexio_url(),
+            api_key=_resolve_reflexio_api_key(),
+        )
         # The companion reflexio PR adds ``clear_user_data``; keep the
         # CLI buildable until both sides ship together.
         response = client.clear_user_data(user_id)  # pyright: ignore[reportAttributeAccessIssue]
@@ -1686,6 +1730,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--source",
         default=_DEFAULT_MARKETPLACE_SOURCE,
         help="Marketplace ref — GitHub owner/repo, or a local directory path",
+    )
+    inst.add_argument(
+        "--api-key",
+        default="",
+        help="Configure managed Reflexio with this API key instead of local mode",
+    )
+    inst.add_argument(
+        "--reflexio-url",
+        default=_MANAGED_REFLEXIO_URL,
+        help="Managed Reflexio URL used only when --api-key is provided",
     )
     inst.set_defaults(func=cmd_install)
 
@@ -1778,6 +1832,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    env_config.load_reflexio_env()
     parser = _build_parser()
     args = parser.parse_args(argv)
     return args.func(args)

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import os
 from collections.abc import Iterable
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
-from claude_smart import cs_cite
+from claude_smart import cs_cite, env_config
 
 _DASHBOARD_URL_ENV = "CLAUDE_SMART_DASHBOARD_URL"
 _CITATION_LINK_STYLE_ENV = "CLAUDE_SMART_CITATION_LINK_STYLE"
 _DEFAULT_DASHBOARD_URL = "http://localhost:3001"
+_REFLEXIO_URL_ENV = "REFLEXIO_URL"
+_LOCAL_REFLEXIO_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
 
 
 def _first_nonempty(*values: Any) -> str:
@@ -100,13 +102,15 @@ def render_with_registry(
     if profile_lines:
         sections.append("### Project preferences")
         sections.extend(profile_lines)
-    instruction = cs_cite.citation_instruction(
+    instruction = _citation_instruction(
         os.environ.get("CLAUDE_SMART_CITATIONS", "on"),
         os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown"),
     )
     if instruction:
         sections.append(instruction)
-    exact_osc8_marker = _exact_osc8_marker_instruction(playbook_entries + profile_entries)
+    exact_osc8_marker = _exact_osc8_marker_instruction(
+        playbook_entries + profile_entries
+    )
     if exact_osc8_marker:
         sections.append(exact_osc8_marker)
     return "\n".join(sections) + "\n", playbook_entries + profile_entries
@@ -179,13 +183,15 @@ def render_inline_with_registry(
     if profile_lines:
         sections.append("### Relevant project preferences")
         sections.extend(profile_lines)
-    instruction = cs_cite.citation_instruction(
+    instruction = _citation_instruction(
         os.environ.get("CLAUDE_SMART_CITATIONS", "on"),
         os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown"),
     )
     if instruction:
         sections.append(instruction)
-    exact_osc8_marker = _exact_osc8_marker_instruction(playbook_entries + profile_entries)
+    exact_osc8_marker = _exact_osc8_marker_instruction(
+        playbook_entries + profile_entries
+    )
     if exact_osc8_marker:
         sections.append(exact_osc8_marker)
     return "\n".join(sections) + "\n", playbook_entries + profile_entries
@@ -223,7 +229,9 @@ def render_inline_compact_with_registry(
         content = _one_line(str(entry["content"]))
         rule_url = str(entry.get("rule_url") or "")
         if link_style == "osc8" and rule_url:
-            linked_title = _osc8_link(rule_url, _strip_trailing_sentence_punctuation(title))
+            linked_title = _osc8_link(
+                rule_url, _strip_trailing_sentence_punctuation(title)
+            )
             item = _osc8_link(rule_url, _strip_trailing_sentence_punctuation(content))
             marker_parts.append(linked_title)
         else:
@@ -261,22 +269,38 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
             if len(marker_parts) > 1
             else ""
         )
-        return (
+        return _remoteize_citation_instruction(
             f"If used, copy this final marker exactly, preserving its hidden "
             f"OSC 8 terminal link: `{marker}`.{separator_instruction} "
             f"Skip when unrelated."
         )
     if link_style == "osc8":
-        return (
+        return _remoteize_citation_instruction(
             "If used, end with `✨ claude-smart rule applied:` followed by "
             "the same linked memory text; keep the link, but do not show the "
             "URL. Skip when unrelated."
         )
-    return (
+    return _remoteize_citation_instruction(
         "Only if a listed [cs:...] item materially changes your answer, end "
         "with one final marker like `✨ claude-smart rule applied: "
         "[verify process state](http://localhost:3001/rules/s1-123)` using "
         "the shown rule URL; skip the marker when unrelated."
+    )
+
+
+def _citation_instruction(mode: str, link_style: str) -> str:
+    return _remoteize_citation_instruction(
+        cs_cite.citation_instruction(mode, link_style)
+    )
+
+
+def _remoteize_citation_instruction(text: str) -> str:
+    playbooks_url = _remote_reflexio_page_url("playbook")
+    profiles_url = _remote_reflexio_page_url("profile")
+    if not text or not playbooks_url or not profiles_url:
+        return text
+    return text.replace("http://localhost:3001/rules/s1-123", playbooks_url).replace(
+        "http://localhost:3001/rules/p1-pref", profiles_url
     )
 
 
@@ -344,7 +368,7 @@ def _append_playbook_bullet(
     item_id = cs_cite.rank_id("playbook", rank, real_id)
     title = _title_from_content(content)
     dashboard_url = _dashboard_url("playbook", real_id, source_kind)
-    rule_url = _rule_url(item_id)
+    rule_url = _rule_url(item_id, "playbook")
     bullet = f"- [cs:{item_id}] {content}"
     if trigger:
         bullet += f" _(when: {trigger})_"
@@ -383,7 +407,7 @@ def _format_profiles(
         item_id = cs_cite.rank_id("profile", rank, real_id)
         title = _title_from_content(content)
         dashboard_url = _dashboard_url("profile", real_id)
-        rule_url = _rule_url(item_id)
+        rule_url = _rule_url(item_id, "profile")
         bullet = f"- [cs:{item_id}] {content}"
         if rule_url:
             bullet += f" _(open: {rule_url})_"
@@ -403,6 +427,9 @@ def _format_profiles(
 
 
 def _dashboard_url(kind: str, real_id: Any, source_kind: str | None = None) -> str:
+    remote_url = _remote_reflexio_page_url(kind)
+    if remote_url:
+        return remote_url
     if real_id is None:
         return ""
     encoded_id = quote(str(real_id), safe="")
@@ -415,12 +442,39 @@ def _dashboard_url(kind: str, real_id: Any, source_kind: str | None = None) -> s
     return ""
 
 
-def _rule_url(item_id: str) -> str:
+def _rule_url(item_id: str, kind: str) -> str:
+    remote_url = _remote_reflexio_page_url(kind)
+    if remote_url:
+        return remote_url
     if not item_id:
         return ""
     encoded_id = quote(item_id, safe="")
     base = os.environ.get(_DASHBOARD_URL_ENV, _DEFAULT_DASHBOARD_URL).rstrip("/")
     return f"{base}/rules/{encoded_id}"
+
+
+def _remote_reflexio_page_url(kind: str) -> str:
+    origin = _remote_reflexio_origin()
+    if not origin:
+        return ""
+    if kind == "profile":
+        return f"{origin}/profiles"
+    if kind == "playbook":
+        return f"{origin}/playbooks"
+    return ""
+
+
+def _remote_reflexio_origin() -> str:
+    env_config.load_reflexio_env()
+    raw = os.environ.get(_REFLEXIO_URL_ENV, "").strip()
+    if not raw:
+        return ""
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    if (parsed.hostname or "").lower() in _LOCAL_REFLEXIO_HOSTS:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
 
 
 def _title_from_content(content: str, limit: int = 80) -> str:

--- a/plugin/src/claude_smart/env_config.py
+++ b/plugin/src/claude_smart/env_config.py
@@ -1,0 +1,102 @@
+"""Shared ``~/.reflexio/.env`` helpers for claude-smart."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+REFLEXIO_ENV_PATH = Path.home() / ".reflexio" / ".env"
+MANAGED_REFLEXIO_URL = "https://www.reflexio.ai/"
+REFLEXIO_URL_ENV = "REFLEXIO_URL"
+REFLEXIO_API_KEY_ENV = "REFLEXIO_API_KEY"
+
+
+def parse_env_line(line: str) -> tuple[str, str] | None:
+    """Parse a simple dotenv ``KEY=value`` line.
+
+    This intentionally ignores comments, blank lines, and shell features. The
+    Reflexio env writer emits plain quoted assignments, which is all
+    claude-smart needs here.
+    """
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped[len("export ") :].lstrip()
+    key, sep, raw_value = stripped.partition("=")
+    if not sep:
+        return None
+    key = key.strip()
+    if not key or not key.replace("_", "").isalnum() or key[0].isdigit():
+        return None
+    value = raw_value.strip()
+    if len(value) >= 2 and (
+        (value[0] == value[-1] == '"') or (value[0] == value[-1] == "'")
+    ):
+        value = value[1:-1]
+    return key, value
+
+
+def load_reflexio_env(path: Path | None = None) -> None:
+    """Load ``~/.reflexio/.env`` into ``os.environ`` without overriding values."""
+    path = path or REFLEXIO_ENV_PATH
+    try:
+        text = path.read_text()
+    except OSError:
+        return
+    for line in text.splitlines():
+        parsed = parse_env_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        os.environ.setdefault(key, value)
+
+
+def set_env_vars(path: Path, values: dict[str, str]) -> list[str]:
+    """Upsert dotenv keys while preserving comments and unrelated entries."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing = path.read_text()
+    except OSError:
+        existing = ""
+
+    lines = existing.splitlines()
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in lines:
+        parsed = parse_env_line(line)
+        if parsed is None:
+            out.append(line)
+            continue
+        key, _old = parsed
+        if key in values:
+            out.append(f'{key}="{_escape_env_value(values[key])}"')
+            seen.add(key)
+        else:
+            out.append(line)
+
+    added: list[str] = []
+    for key, value in values.items():
+        if key in seen:
+            continue
+        out.append(f'{key}="{_escape_env_value(value)}"')
+        added.append(key)
+
+    content = "\n".join(out)
+    path.write_text(content + ("\n" if content else ""), encoding="utf-8")
+    path.chmod(0o600)
+    return added
+
+
+def mask_secret(value: str) -> str:
+    """Return a display-safe API key preview."""
+    if not value:
+        return ""
+    if len(value) <= 8:
+        return "*" * len(value)
+    prefix = value[:5] if "-" in value[:8] else value[:4]
+    return f"{prefix}****{value[-4:]}"
+
+
+def _escape_env_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -8,17 +8,26 @@ from __future__ import annotations
 
 import logging
 import os
+import inspect
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
+from claude_smart import env_config
 from claude_smart import runtime
 
 _LOGGER = logging.getLogger(__name__)
 
 _ENV_URL = "REFLEXIO_URL"
+_ENV_API_KEY = "REFLEXIO_API_KEY"
 _DEFAULT_URL = "http://localhost:8071/"
+# Cap every HTTP round-trip from a hook so a hung backend can't stall the
+# Claude Code / Codex session. reflexio's client default is 300s, which is
+# fine for batch workloads but unacceptable on the hook path — a single
+# unhealthy POST would freeze the user's prompt. 5s matches the precedent
+# in ``ids.py`` for short-lived hook HTTP calls.
+_HTTP_TIMEOUT_SECONDS = 5
 _SEARCH_MODE_HYBRID = "hybrid"  # reflexio.models.config_schema.SearchMode.HYBRID
 _UNIFIED_ENTITY_TYPES = ("profiles", "user_playbooks", "agent_playbooks")
 _AGENT_PLAYBOOK_APPROVAL_STATUSES = ("pending", "approved")
@@ -35,9 +44,13 @@ class Adapter:
     """
 
     url: str = ""
+    api_key: str = ""
+    read_errors: list[str] = field(default_factory=list, init=False)
 
     def __post_init__(self) -> None:
+        env_config.load_reflexio_env()
         self.url = self.url or os.environ.get(_ENV_URL, _DEFAULT_URL)
+        self.api_key = self.api_key or os.environ.get(_ENV_API_KEY, "")
         self._client: Any | None = None
 
     # -----------------------------------------------------------------
@@ -54,7 +67,18 @@ class Adapter:
             _LOGGER.debug("reflexio not importable: %s", exc)
             return None
         try:
-            self._client = ReflexioClient(url_endpoint=self.url)
+            try:
+                self._client = ReflexioClient(
+                    url_endpoint=self.url,
+                    api_key=self.api_key,
+                    timeout=_HTTP_TIMEOUT_SECONDS,
+                )
+            except TypeError:
+                # Pre-0.2.x reflexio releases didn't accept ``timeout``;
+                # fall back so hooks still work against older pinned clients.
+                self._client = ReflexioClient(
+                    url_endpoint=self.url, api_key=self.api_key
+                )
         except Exception as exc:  # noqa: BLE001 — adapter must never raise.
             _LOGGER.warning("Failed to construct ReflexioClient: %s", exc)
             return None
@@ -81,16 +105,22 @@ class Adapter:
         if client is None:
             return False
         try:
-            client.publish_interaction(
-                user_id=project_id,
-                interactions=list(interactions),
-                agent_version=runtime.agent_version(),
-                session_id=session_id,
-                wait_for_response=False,
-                force_extraction=force_extraction,
-                override_learning_stall=override_learning_stall,
-                skip_aggregation=skip_aggregation,
-            )
+            kwargs = {
+                "user_id": project_id,
+                "interactions": list(interactions),
+                "agent_version": runtime.agent_version(),
+                "session_id": session_id,
+                "wait_for_response": False,
+                "force_extraction": force_extraction,
+                "skip_aggregation": skip_aggregation,
+            }
+            if _supports_keyword(client.publish_interaction, "override_learning_stall"):
+                kwargs["override_learning_stall"] = override_learning_stall
+            elif override_learning_stall:
+                _LOGGER.debug(
+                    "publish_interaction client does not support override_learning_stall"
+                )
+            client.publish_interaction(**kwargs)
             return True
         except Exception as exc:  # noqa: BLE001
             _LOGGER.warning("publish_interaction failed: %s", exc)
@@ -235,13 +265,20 @@ class Adapter:
         if client is None:
             return []
         try:
-            response = client.search_user_playbooks(
-                user_id=project_id,
-                status_filter=[None],  # None => CURRENT in reflexio's filter API
-                top_k=top_k,
-            )
+            if hasattr(client, "get_user_playbooks"):
+                response = client.get_user_playbooks(
+                    user_id=project_id,
+                    status_filter=[None],  # None => CURRENT in reflexio's filter API
+                    limit=top_k,
+                )
+            else:
+                response = client.search_user_playbooks(
+                    user_id=project_id,
+                    status_filter=[None],
+                    top_k=top_k,
+                )
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("search_user_playbooks failed: %s", exc)
+            self._record_read_error("fetch_user_playbooks", exc)
             return []
         return _extract_items(response, "user_playbooks")
 
@@ -263,13 +300,20 @@ class Adapter:
         if client is None:
             return []
         try:
-            response = client.search_agent_playbooks(
-                agent_version=runtime.agent_version(),
-                status_filter=[None],
-                top_k=top_k,
-            )
+            if hasattr(client, "get_agent_playbooks"):
+                response = client.get_agent_playbooks(
+                    agent_version=runtime.agent_version(),
+                    status_filter=[None],
+                    limit=top_k,
+                )
+            else:
+                response = client.search_agent_playbooks(
+                    agent_version=runtime.agent_version(),
+                    status_filter=[None],
+                    top_k=top_k,
+                )
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("search_agent_playbooks failed: %s", exc)
+            self._record_read_error("fetch_agent_playbooks", exc)
             return []
         return _filter_rejected_agent_playbooks(
             _extract_items(response, "agent_playbooks")
@@ -281,13 +325,20 @@ class Adapter:
         if client is None:
             return []
         try:
+            if hasattr(client, "get_all_profiles"):
+                response = client.get_all_profiles(limit=max(top_k * 20, 100))
+                return [
+                    item
+                    for item in _extract_items(response, "user_profiles")
+                    if _field(item, "user_id") == project_id
+                ][:top_k]
             response = client.search_user_profiles(
                 user_id=project_id,
                 query="",
                 top_k=top_k,
             )
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("search_user_profiles failed: %s", exc)
+            self._record_read_error("fetch_project_profiles", exc)
             return []
         return _extract_items(response, "user_profiles")
 
@@ -332,7 +383,7 @@ class Adapter:
                 search_mode=_SEARCH_MODE_HYBRID,
             )
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("unified search failed: %s", exc)
+            self._record_read_error("unified search", exc)
             return [], [], []
         return (
             _extract_items(response, "user_playbooks"),
@@ -377,6 +428,11 @@ class Adapter:
             )
         return up_future.result(), ap_future.result(), pr_future.result()
 
+    def _record_read_error(self, operation: str, exc: Exception) -> None:
+        message = f"{operation}: {exc}"
+        self.read_errors.append(message)
+        _LOGGER.debug("%s failed: %s", operation, exc)
+
 
 def _extract_items(response: Any, field: str) -> list[Any]:
     """Pull a list field from a reflexio response object or dict, tolerating shape drift."""
@@ -387,6 +443,23 @@ def _extract_items(response: Any, field: str) -> list[Any]:
     else:
         value = getattr(response, field, None)
     return list(value) if value else []
+
+
+def _field(item: Any, field: str) -> Any:
+    if isinstance(item, dict):
+        return item.get(field)
+    return getattr(item, field, None)
+
+
+def _supports_keyword(callable_obj: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return False
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return keyword in signature.parameters
 
 
 def _filter_rejected_agent_playbooks(items: list[Any]) -> list[Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,18 @@ def clear_optimizer_opt_in(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def clear_reflexio_connection_env(monkeypatch, tmp_path):
+    """Keep managed-service connection settings from leaking between tests."""
+    from claude_smart import env_config
+
+    monkeypatch.setattr(
+        env_config, "REFLEXIO_ENV_PATH", tmp_path / ".reflexio" / ".env"
+    )
+    monkeypatch.delenv("REFLEXIO_URL", raising=False)
+    monkeypatch.delenv("REFLEXIO_API_KEY", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def reset_runtime_host(monkeypatch):
     """Keep host-specific tests from leaking runtime state."""
     from claude_smart import runtime

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from types import SimpleNamespace
 from typing import Any
@@ -47,6 +48,120 @@ def _adapter_with(client) -> reflexio_adapter.Adapter:
     return a
 
 
+def test_adapter_constructs_client_with_env_url_and_api_key(
+    monkeypatch, tmp_path
+) -> None:
+    env_path = tmp_path / ".reflexio" / ".env"
+    env_path.parent.mkdir()
+    env_path.write_text(
+        'REFLEXIO_URL="https://www.reflexio.ai/"\nREFLEXIO_API_KEY="rflx-test-key"\n'
+    )
+    monkeypatch.setattr(reflexio_adapter.env_config, "REFLEXIO_ENV_PATH", env_path)
+    monkeypatch.delenv("REFLEXIO_URL", raising=False)
+    monkeypatch.delenv("REFLEXIO_API_KEY", raising=False)
+    seen: dict[str, str] = {}
+
+    class FakeReflexioClient:
+        def __init__(self, *, url_endpoint: str, api_key: str):
+            seen["url_endpoint"] = url_endpoint
+            seen["api_key"] = api_key
+
+    monkeypatch.setitem(
+        sys.modules,
+        "reflexio",
+        SimpleNamespace(ReflexioClient=FakeReflexioClient),
+    )
+
+    adapter = reflexio_adapter.Adapter()
+
+    assert adapter._get_client() is not None
+    assert seen == {
+        "url_endpoint": "https://www.reflexio.ai/",
+        "api_key": "rflx-test-key",
+    }
+
+
+def test_adapter_passes_short_http_timeout_to_client(monkeypatch, tmp_path) -> None:
+    """Hooks must cap reflexio HTTP calls so an unhealthy backend can't stall a session."""
+    monkeypatch.setattr(
+        reflexio_adapter.env_config, "REFLEXIO_ENV_PATH", tmp_path / "missing.env"
+    )
+    monkeypatch.setenv("REFLEXIO_URL", "https://x.example/")
+    monkeypatch.setenv("REFLEXIO_API_KEY", "k")
+    seen: dict[str, Any] = {}
+
+    class FakeReflexioClient:
+        def __init__(self, *, url_endpoint: str, api_key: str, timeout: int):
+            seen["timeout"] = timeout
+
+    monkeypatch.setitem(
+        sys.modules,
+        "reflexio",
+        SimpleNamespace(ReflexioClient=FakeReflexioClient),
+    )
+
+    reflexio_adapter.Adapter()._get_client()
+
+    assert seen["timeout"] == reflexio_adapter._HTTP_TIMEOUT_SECONDS
+    assert 0 < reflexio_adapter._HTTP_TIMEOUT_SECONDS <= 30
+
+
+def test_adapter_falls_back_when_client_rejects_timeout_kwarg(
+    monkeypatch, tmp_path
+) -> None:
+    """Older reflexio releases lack ``timeout``; constructor must still succeed."""
+    monkeypatch.setattr(
+        reflexio_adapter.env_config, "REFLEXIO_ENV_PATH", tmp_path / "missing.env"
+    )
+    monkeypatch.setenv("REFLEXIO_URL", "https://x.example/")
+    monkeypatch.setenv("REFLEXIO_API_KEY", "k")
+    call_count = {"n": 0}
+
+    class FakeReflexioClient:
+        def __init__(self, *, url_endpoint: str, api_key: str):
+            call_count["n"] += 1
+
+    monkeypatch.setitem(
+        sys.modules,
+        "reflexio",
+        SimpleNamespace(ReflexioClient=FakeReflexioClient),
+    )
+
+    assert reflexio_adapter.Adapter()._get_client() is not None
+    assert call_count["n"] == 1
+
+
+def test_adapter_process_env_overrides_reflexio_env(monkeypatch, tmp_path) -> None:
+    env_path = tmp_path / ".reflexio" / ".env"
+    env_path.parent.mkdir()
+    env_path.write_text(
+        'REFLEXIO_URL="https://from-file.example/"\nREFLEXIO_API_KEY="file-key"\n'
+    )
+    monkeypatch.setattr(reflexio_adapter.env_config, "REFLEXIO_ENV_PATH", env_path)
+    monkeypatch.setenv("REFLEXIO_URL", "https://from-env.example/")
+    monkeypatch.setenv("REFLEXIO_API_KEY", "env-key")
+    seen: dict[str, str] = {}
+
+    class FakeReflexioClient:
+        def __init__(self, *, url_endpoint: str, api_key: str):
+            seen["url_endpoint"] = url_endpoint
+            seen["api_key"] = api_key
+
+    monkeypatch.setitem(
+        sys.modules,
+        "reflexio",
+        SimpleNamespace(ReflexioClient=FakeReflexioClient),
+    )
+
+    adapter = reflexio_adapter.Adapter()
+
+    assert adapter._get_client() is not None
+    assert seen == {
+        "url_endpoint": "https://from-env.example/",
+        "api_key": "env-key",
+    }
+
+
 def test_publish_returns_true_on_success() -> None:
     client = _FakeClient()
     a = _adapter_with(client)
@@ -63,8 +178,52 @@ def test_publish_returns_true_on_success() -> None:
     assert client.published_kwargs["user_id"] == "p1"
     assert client.published_kwargs["session_id"] == "s1"
     assert client.published_kwargs["agent_version"] == "claude-code"
+    assert client.published_kwargs["wait_for_response"] is False
     assert client.published_kwargs["force_extraction"] is True
     assert client.published_kwargs["override_learning_stall"] is True
+
+
+def test_publish_omits_override_learning_stall_when_client_lacks_keyword() -> None:
+    class OldPublishClient:
+        def __init__(self) -> None:
+            self.published_kwargs: dict[str, Any] = {}
+
+        def publish_interaction(
+            self,
+            *,
+            user_id,
+            interactions,
+            agent_version,
+            session_id,
+            wait_for_response,
+            force_extraction,
+            skip_aggregation,
+        ):
+            self.published_kwargs = {
+                "user_id": user_id,
+                "interactions": interactions,
+                "agent_version": agent_version,
+                "session_id": session_id,
+                "wait_for_response": wait_for_response,
+                "force_extraction": force_extraction,
+                "skip_aggregation": skip_aggregation,
+            }
+
+    client = OldPublishClient()
+    a = _adapter_with(client)
+
+    ok = a.publish(
+        session_id="s1",
+        project_id="p1",
+        interactions=[{"role": "User", "content": "hi"}],
+        force_extraction=True,
+        override_learning_stall=True,
+    )
+
+    assert ok is True
+    assert client.published_kwargs["user_id"] == "p1"
+    assert client.published_kwargs["force_extraction"] is True
+    assert "override_learning_stall" not in client.published_kwargs
 
 
 def test_publish_returns_false_when_client_raises() -> None:
@@ -319,6 +478,53 @@ def test_fetch_all_absorbs_per_leg_failure() -> None:
     assert profiles == [{"content": "p"}]
 
 
+def test_fetch_all_prefers_no_query_list_endpoints_for_show() -> None:
+    class ListClient:
+        def __init__(self):
+            self.user_kwargs: dict[str, Any] = {}
+            self.agent_kwargs: dict[str, Any] = {}
+            self.profile_kwargs: dict[str, Any] = {}
+
+        def get_user_playbooks(self, **kwargs):
+            self.user_kwargs = kwargs
+            return SimpleNamespace(user_playbooks=[{"content": "u"}])
+
+        def get_agent_playbooks(self, **kwargs):
+            self.agent_kwargs = kwargs
+            return SimpleNamespace(
+                agent_playbooks=[{"content": "a", "playbook_status": "approved"}]
+            )
+
+        def get_all_profiles(self, **kwargs):
+            self.profile_kwargs = kwargs
+            return SimpleNamespace(
+                user_profiles=[
+                    {"user_id": "other", "content": "hidden"},
+                    {"user_id": "proj", "content": "p"},
+                ]
+            )
+
+    client = ListClient()
+    a = _adapter_with(client)
+
+    user_pb, agent_pb, profiles = a.fetch_all(project_id="proj")
+
+    assert user_pb == [{"content": "u"}]
+    assert agent_pb == [{"content": "a", "playbook_status": "approved"}]
+    assert profiles == [{"user_id": "proj", "content": "p"}]
+    assert client.user_kwargs == {
+        "user_id": "proj",
+        "status_filter": [None],
+        "limit": 10,
+    }
+    assert client.agent_kwargs == {
+        "agent_version": "claude-code",
+        "status_filter": [None],
+        "limit": 10,
+    }
+    assert client.profile_kwargs["limit"] >= 100
+
+
 def test_fetch_user_playbooks_passes_project_id_and_default_top_k() -> None:
     """/show uses a narrow broad-fetch default; prompt-time search carries specificity."""
     client = _RecordingClient(user_playbook_resp=SimpleNamespace(user_playbooks=[]))
@@ -557,10 +763,16 @@ def test_fetch_stall_state_returns_none_when_client_unavailable():
 
 
 def test_fetch_stall_state_passes_through_when_clean(monkeypatch):
-    stub = _StubClientWithStallState(SimpleNamespace(
-        stalled=False, reason=None, stalled_at=None,
-        reset_estimate=None, notified_in_cc=False, error_message=None,
-    ))
+    stub = _StubClientWithStallState(
+        SimpleNamespace(
+            stalled=False,
+            reason=None,
+            stalled_at=None,
+            reset_estimate=None,
+            notified_in_cc=False,
+            error_message=None,
+        )
+    )
     adapter = reflexio_adapter.Adapter(url="http://x/")
     monkeypatch.setattr(adapter, "_get_client", lambda: stub)
     state = adapter.fetch_stall_state()

--- a/tests/test_cli_clear_user.py
+++ b/tests/test_cli_clear_user.py
@@ -68,7 +68,10 @@ def test_clear_user_invokes_client_method_with_user_id(
     rc = cli.cmd_clear_user(_args(user_id="bob", yes=True))
 
     assert rc == 0
-    factory.assert_called_once_with(url_endpoint="http://localhost:8071/")
+    factory.assert_called_once_with(
+        url_endpoint="http://localhost:8071/",
+        api_key="",
+    )
     fake_client.clear_user_data.assert_called_once_with("bob")
     assert "Cleared user 'bob'" in capsys.readouterr().out
 

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import stat
 from pathlib import Path
 
@@ -24,7 +23,9 @@ def _installed_plugin(tmp_path: Path, version: str = "9.8.7") -> Path:
     scripts.mkdir(parents=True)
     (root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
     install = scripts / "smart-install.sh"
-    install.write_text("#!/usr/bin/env bash\nprintf '%s\\n' \"$PWD\" > \"$HOME/bootstrap-ran\"\n")
+    install.write_text(
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$PWD" > "$HOME/bootstrap-ran"\n'
+    )
     install.chmod(install.stat().st_mode | stat.S_IXUSR)
     return root
 
@@ -32,7 +33,9 @@ def _installed_plugin(tmp_path: Path, version: str = "9.8.7") -> Path:
 def _isolate_home(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
     monkeypatch.setattr(cli, "_REFLEXIO_DIR", tmp_path / ".reflexio")
-    monkeypatch.setattr(cli, "_INSTALL_FAILURE_MARKER", tmp_path / ".claude-smart" / "install-failed")
+    monkeypatch.setattr(
+        cli, "_INSTALL_FAILURE_MARKER", tmp_path / ".claude-smart" / "install-failed"
+    )
     monkeypatch.setenv("HOME", str(tmp_path))
 
 
@@ -59,7 +62,7 @@ def test_bootstrap_claude_code_install_reports_failure_marker(
     install = plugin_root / "scripts" / "smart-install.sh"
     install.write_text(
         "#!/usr/bin/env bash\n"
-        "mkdir -p \"$HOME/.claude-smart\"\n"
+        'mkdir -p "$HOME/.claude-smart"\n'
         "printf 'network unavailable\\n' > \"$HOME/.claude-smart/install-failed\"\n"
     )
     install.chmod(install.stat().st_mode | stat.S_IXUSR)
@@ -89,13 +92,74 @@ def test_bootstrap_claude_code_install_refuses_real_plugin_root_directory(
     assert sentinel.read_text() == "do not delete"
 
 
-def test_cmd_install_fails_when_dependency_bootstrap_fails(monkeypatch, tmp_path: Path) -> None:
+def test_cmd_install_fails_when_dependency_bootstrap_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
     _installed_plugin(tmp_path)
     _isolate_home(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
-    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **kw: argparse.Namespace(returncode=0))
-    monkeypatch.setattr(cli, "_bootstrap_claude_code_install", lambda: (False, "uv failed"))
+    monkeypatch.setattr(
+        cli.subprocess, "run", lambda *a, **kw: argparse.Namespace(returncode=0)
+    )
+    monkeypatch.setattr(
+        cli, "_bootstrap_claude_code_install", lambda: (False, "uv failed")
+    )
 
     rc = cli.cmd_install(argparse.Namespace(host="claude-code", source="unused"))
 
     assert rc == 1
+
+
+def test_install_setup_default_seeds_only_local_flags(
+    monkeypatch, tmp_path: Path
+) -> None:
+    env_path = tmp_path / ".reflexio" / ".env"
+    monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
+
+    cli._configure_reflexio_setup(
+        argparse.Namespace(api_key="", reflexio_url="https://www.reflexio.ai/")
+    )
+
+    text = env_path.read_text()
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in text
+    assert "REFLEXIO_URL" not in text
+    assert "REFLEXIO_API_KEY" not in text
+    assert env_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_install_setup_api_key_configures_managed_reflexio(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    env_path = tmp_path / ".reflexio" / ".env"
+    env_path.parent.mkdir()
+    env_path.write_text("# keep\nUNKNOWN=value\n")
+    monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
+
+    cli._configure_reflexio_setup(
+        argparse.Namespace(
+            api_key="rflx-test-secret",
+            reflexio_url="https://managed.example/",
+        )
+    )
+
+    text = env_path.read_text()
+    assert "# keep" in text
+    assert "UNKNOWN=value" in text
+    assert 'REFLEXIO_URL="https://managed.example/"' in text
+    assert 'REFLEXIO_API_KEY="rflx-test-secret"' in text
+    assert "CLAUDE_SMART_USE_LOCAL_CLI" not in text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING" not in text
+    assert env_path.stat().st_mode & 0o777 == 0o600
+    out = capsys.readouterr().out
+    assert "rflx-****cret" in out
+    assert "rflx-test-secret" not in out
+
+
+def test_install_parser_defaults_managed_url_only_when_api_key_is_present() -> None:
+    args = cli._build_parser().parse_args(["install", "--api-key", "rflx-key"])
+
+    assert args.api_key == "rflx-key"
+    assert args.reflexio_url == "https://www.reflexio.ai/"

--- a/tests/test_cli_show.py
+++ b/tests/test_cli_show.py
@@ -1,0 +1,47 @@
+"""Tests for the user-facing ``claude-smart show`` command."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from claude_smart import cli
+
+
+def test_show_reports_reflexio_read_errors(monkeypatch, capsys) -> None:
+    class BrokenAdapter:
+        url = "https://www.reflexio.ai/"
+        read_errors = ["fetch_project_profiles: 503 Service Temporarily Unavailable"]
+
+        def fetch_all(self, **_kwargs):
+            return [], [], []
+
+    monkeypatch.setattr(cli.ids, "resolve_project_id", lambda: "claude-smart")
+    monkeypatch.setattr(cli, "Adapter", BrokenAdapter)
+
+    code = cli.cmd_show(SimpleNamespace(project=None))
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "Could not read skills or preferences from Reflexio" in out
+    assert "project `claude-smart`" in out
+    assert "https://www.reflexio.ai/" in out
+    assert "503 Service Temporarily Unavailable" in out
+    assert "_No skills or preferences yet" not in out
+
+
+def test_show_reports_empty_when_reflexio_read_succeeds(monkeypatch, capsys) -> None:
+    class EmptyAdapter:
+        url = "https://www.reflexio.ai/"
+        read_errors: list[str] = []
+
+        def fetch_all(self, **_kwargs):
+            return [], [], []
+
+    monkeypatch.setattr(cli.ids, "resolve_project_id", lambda: "claude-smart")
+    monkeypatch.setattr(cli, "Adapter", EmptyAdapter)
+
+    code = cli.cmd_show(SimpleNamespace(project=None))
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "_No skills or preferences yet for project `claude-smart`._" in out

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -50,6 +50,16 @@ def test_codex_skill_documents_command_mapping() -> None:
     assert "bash ~/.reflexio/plugin-root/scripts/cli.sh clear-all --yes" in skill
 
 
+def test_codex_hook_loads_managed_reflexio_env_and_skips_backend_start() -> None:
+    script = (REPO_ROOT / "plugin" / "scripts" / "codex-hook.js").read_text()
+
+    assert "function loadReflexioEnv()" in script
+    assert '"REFLEXIO_API_KEY"' in script
+    assert "function reflexioUrlIsRemote()" in script
+    assert "remote REFLEXIO_URL configured; skipping local backend start" in script
+    assert "loadReflexioEnv();" in script
+
+
 def test_codex_marketplace_points_at_plugin_root() -> None:
     marketplace = _read_json(".agents/plugins/marketplace.json")
     entry = marketplace["plugins"][0]
@@ -310,9 +320,7 @@ def test_codex_stop_skips_orphan_title_response(session_dir, monkeypatch) -> Non
     assert calls == []
 
 
-def test_codex_stop_skips_orphan_suggestions_response(
-    session_dir, monkeypatch
-) -> None:
+def test_codex_stop_skips_orphan_suggestions_response(session_dir, monkeypatch) -> None:
     runtime.set_host(runtime.HOST_CODEX)
     calls: list[dict[str, Any]] = []
     monkeypatch.setattr(

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -333,6 +333,46 @@ def test_render_inline_with_registry_includes_dashboard_urls(monkeypatch) -> Non
     assert by_id["p1-pref"]["rule_url"] == "http://127.0.0.1:3333/rules/p1-pref"
 
 
+def test_render_inline_with_registry_uses_remote_reflexio_list_pages(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("REFLEXIO_URL", "https://www.reflexio.ai/")
+    md, registry = context_format.render_inline_with_registry(
+        project_id="demo",
+        user_playbooks=[{"content": "use safe git flow", "user_playbook_id": 17}],
+        agent_playbooks=[{"content": "use shared flow", "agent_playbook_id": 42}],
+        profiles=[{"content": "prefers concise answers", "profile_id": "pref/one"}],
+    )
+
+    assert "open: https://www.reflexio.ai/playbooks" in md
+    assert "open: https://www.reflexio.ai/profiles" in md
+    assert "/rules/" not in md
+    by_id = {e["id"]: e for e in registry}
+    assert by_id["s1-42"]["dashboard_url"] == "https://www.reflexio.ai/playbooks"
+    assert by_id["s1-42"]["rule_url"] == "https://www.reflexio.ai/playbooks"
+    assert by_id["s2-17"]["dashboard_url"] == "https://www.reflexio.ai/playbooks"
+    assert by_id["s2-17"]["rule_url"] == "https://www.reflexio.ai/playbooks"
+    assert by_id["p1-pref"]["dashboard_url"] == "https://www.reflexio.ai/profiles"
+    assert by_id["p1-pref"]["rule_url"] == "https://www.reflexio.ai/profiles"
+
+
+def test_render_inline_osc8_uses_remote_reflexio_list_pages(monkeypatch) -> None:
+    monkeypatch.setenv("REFLEXIO_URL", "https://www.reflexio.ai/")
+    monkeypatch.setenv("CLAUDE_SMART_CITATION_LINK_STYLE", "osc8")
+
+    md, _ = context_format.render_inline_with_registry(
+        project_id="demo",
+        user_playbooks=[{"content": "use safe git flow", "user_playbook_id": 17}],
+        agent_playbooks=[],
+        profiles=[{"content": "prefers concise answers", "profile_id": "pref/one"}],
+    )
+
+    assert "\x1b]8;;https://www.reflexio.ai/playbooks\x1b\\" in md
+    assert "\x1b]8;;https://www.reflexio.ai/profiles\x1b\\" in md
+    assert "http://localhost:3001/rules/s1-17" not in md
+    assert "http://localhost:3001/rules/p1-pref" not in md
+
+
 def test_render_inline_with_registry_off_omits_instruction(monkeypatch) -> None:
     monkeypatch.setenv("CLAUDE_SMART_CITATIONS", "off")
     md, _ = context_format.render_inline_with_registry(

--- a/tests/test_dashboard_managed_reflexio.py
+++ b/tests/test_dashboard_managed_reflexio.py
@@ -1,0 +1,71 @@
+"""Static checks for dashboard managed Reflexio support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dashboard_config_knows_reflexio_api_key() -> None:
+    config = (REPO_ROOT / "plugin" / "dashboard" / "lib" / "config-file.ts").read_text()
+    types = (REPO_ROOT / "plugin" / "dashboard" / "lib" / "types.ts").read_text()
+    page = (
+        REPO_ROOT / "plugin" / "dashboard" / "app" / "configure" / "env" / "page.tsx"
+    ).read_text()
+
+    assert '"REFLEXIO_API_KEY"' in config
+    assert "REFLEXIO_API_KEY: string;" in types
+    assert "REFLEXIO_API_KEY_SET?: boolean;" in types
+    assert "<Label>REFLEXIO_API_KEY</Label>" in page
+    assert 'type="password"' in page
+    assert "apiKeyDirty" in page
+    assert "delete envUpdate.REFLEXIO_API_KEY" in page
+    assert "leave blank to keep existing key" in page
+
+
+def test_dashboard_config_endpoint_masks_reflexio_api_key() -> None:
+    route = (
+        REPO_ROOT / "plugin" / "dashboard" / "app" / "api" / "config" / "route.ts"
+    ).read_text()
+
+    assert "function publicConfig" in route
+    assert 'REFLEXIO_API_KEY: ""' in route
+    assert "REFLEXIO_API_KEY_SET: Boolean(config.REFLEXIO_API_KEY)" in route
+    assert "return NextResponse.json(publicConfig(config))" in route
+
+
+def test_dashboard_proxy_forwards_bearer_auth_without_client_auth() -> None:
+    route = (
+        REPO_ROOT
+        / "plugin"
+        / "dashboard"
+        / "app"
+        / "api"
+        / "reflexio"
+        / "[...path]"
+        / "route.ts"
+    ).read_text()
+
+    assert 'headers.delete("authorization")' in route
+    assert 'headers.set("user-agent", "claude-smart")' in route
+    assert 'headers.set("authorization", `Bearer ${apiKey}`)' in route
+    assert "readConfig" in route
+    assert "function isLocalUrl" in route
+    assert "configuredBase" in route
+    assert 'apiKey: fromHeader === configuredBase ? apiKey : ""' in route
+    assert 'apiKey: configuredBase ? apiKey : ""' in route
+
+
+def test_dashboard_settings_adopt_managed_reflexio_url() -> None:
+    settings = (
+        REPO_ROOT / "plugin" / "dashboard" / "hooks" / "use-settings.tsx"
+    ).read_text()
+
+    assert 'fetch("/api/config", { cache: "no-store" })' in settings
+    assert "REFLEXIO_URL?: string" in settings
+    assert "function isLocalUrl" in settings
+    assert "!isLocalUrl(configuredUrl)" in settings
+    assert "isLocalUrl(settings.reflexioUrl)" in settings
+    assert "writeStorage({ reflexioUrl: configuredUrl })" in settings

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -23,7 +23,9 @@ CODEX_COMPAT = REPO_ROOT / "plugin" / "scripts" / "codex-claude-compat"
 CODEX_HOOK = REPO_ROOT / "plugin" / "scripts" / "codex-hook.js"
 BACKEND_LOG_RUNNER = REPO_ROOT / "plugin" / "scripts" / "backend-log-runner.sh"
 NODE_INSTALLER = REPO_ROOT / "bin" / "claude-smart.js"
-HEALTH_ROUTE = REPO_ROOT / "plugin" / "dashboard" / "app" / "api" / "health" / "route.ts"
+HEALTH_ROUTE = (
+    REPO_ROOT / "plugin" / "dashboard" / "app" / "api" / "health" / "route.ts"
+)
 
 
 def _minimal_path(tmp_path: Path, *names: str) -> str:
@@ -87,7 +89,9 @@ def _fake_node_dist(tmp_path: Path, *, bad_checksum: bool = False) -> Path:
     return dist
 
 
-def _run_private_node_install(tmp_path: Path, base_url: str) -> subprocess.CompletedProcess[str]:
+def _run_private_node_install(
+    tmp_path: Path, base_url: str
+) -> subprocess.CompletedProcess[str]:
     env = _isolated_env(tmp_path)
     env["CLAUDE_SMART_INSTALL_PRIVATE_NODE_ONLY"] = "1"
     env["CLAUDE_SMART_NODE_BASE_URL"] = base_url
@@ -231,16 +235,62 @@ def test_backend_service_uses_capped_logging() -> None:
     assert '>>"$LOG_FILE"' not in service
 
 
-def test_service_start_scripts_recover_missing_dependencies_without_cli_command() -> None:
+def test_service_start_scripts_recover_missing_dependencies_without_cli_command() -> (
+    None
+):
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
     dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
 
     assert "[claude-smart] backend: uv not on PATH; running installer" in backend
-    assert "CLAUDE_SMART_BOOTSTRAPPING=1 bash \"$PLUGIN_ROOT/scripts/smart-install.sh\"" in backend
+    assert (
+        'CLAUDE_SMART_BOOTSTRAPPING=1 bash "$PLUGIN_ROOT/scripts/smart-install.sh"'
+        in backend
+    )
     assert "[claude-smart] backend: uv not on PATH after installer; skipping" in backend
-    assert "[claude-smart] dashboard: npm is not on PATH; running installer" in dashboard
-    assert "CLAUDE_SMART_BOOTSTRAPPING=1 bash \"$PLUGIN_ROOT/scripts/smart-install.sh\"" in dashboard
+    assert (
+        "[claude-smart] dashboard: npm is not on PATH; running installer" in dashboard
+    )
+    assert (
+        'CLAUDE_SMART_BOOTSTRAPPING=1 bash "$PLUGIN_ROOT/scripts/smart-install.sh"'
+        in dashboard
+    )
     assert "npm is not on PATH after installer; dashboard cannot start" in dashboard
+
+
+def test_backend_service_skips_local_start_for_remote_reflexio_url() -> None:
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+    lib = (REPO_ROOT / "plugin" / "scripts" / "_lib.sh").read_text()
+
+    assert "claude_smart_source_reflexio_env" in backend
+    assert "claude_smart_reflexio_url_is_remote()" in lib
+    assert "remote REFLEXIO_URL configured; skipping local backend start" in backend
+    assert "remote configured at $REFLEXIO_URL" in backend
+
+
+def test_smart_install_keeps_local_flags_local_mode_only() -> None:
+    script = (REPO_ROOT / "plugin" / "scripts" / "smart-install.sh").read_text()
+
+    assert 'if [ -z "${REFLEXIO_API_KEY:-}" ]; then' in script
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in script
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in script
+    assert "claude_smart_source_reflexio_env" in script
+
+
+def test_node_installer_supports_managed_reflexio_setup() -> None:
+    installer = NODE_INSTALLER.read_text()
+
+    assert 'const MANAGED_REFLEXIO_URL = "https://www.reflexio.ai/";' in installer
+    assert 'parseOptionalArg(args, "--api-key")' in installer
+    assert 'parseOptionalArg(args, "--reflexio-url")' in installer
+    assert "REFLEXIO_API_KEY" in installer
+    assert "configureReflexioSetup(args)" in installer
+    assert "maskSecret(apiKey)" in installer
+
+
+def test_dashboard_service_loads_reflexio_env_for_managed_proxy() -> None:
+    dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
+
+    assert "claude_smart_source_reflexio_env" in dashboard
 
 
 def test_dashboard_health_exposes_plugin_identity_for_stale_process_detection() -> None:
@@ -263,8 +313,8 @@ def test_dashboard_service_restarts_stale_claude_smart_dashboard() -> None:
     assert "normalize_identity_path()" in dashboard
     assert "cygpath -u" in dashboard
     assert 'expected_root="$(normalize_identity_path ' in dashboard
-    assert "actual_root=\"$(normalize_identity_path \"$actual_root\")\"" in dashboard
-    assert "[ \"$actual_root\" = \"$expected_root\" ]" in dashboard
+    assert 'actual_root="$(normalize_identity_path "$actual_root")"' in dashboard
+    assert '[ "$actual_root" = "$expected_root" ]' in dashboard
     assert "stale claude-smart dashboard on port $PORT; restarting" in dashboard
     assert "stop_dashboard_listener" in dashboard
     assert "foreign app on 3001 is never killed" in dashboard
@@ -282,8 +332,13 @@ def test_installers_refresh_or_stop_dashboard_services() -> None:
     assert "timeout: PLUGIN_SERVICE_TIMEOUT_MS" in node_installer
     assert 'killSignal: "SIGTERM"' in node_installer
     assert 'result.error && result.error.code === "ETIMEDOUT"' in node_installer
-    assert 'runPluginService(pluginRoot, "dashboard-service.sh", "stop")' in node_installer
-    assert 'runPluginService(pluginRoot, "dashboard-service.sh", "start")' in node_installer
+    assert (
+        'runPluginService(pluginRoot, "dashboard-service.sh", "stop")' in node_installer
+    )
+    assert (
+        'runPluginService(pluginRoot, "dashboard-service.sh", "start")'
+        in node_installer
+    )
     assert "function stopClaudeSmartServices(pluginRoot)" in node_installer
     assert "Refreshed claude-smart dashboard service." in node_installer
 
@@ -324,7 +379,7 @@ def test_backend_service_configures_shared_embedding_daemon() -> None:
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
     assert 'EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"' in backend
-    assert 'REFLEXIO_EMBEDDING_PROVIDER:-local_service' in backend
+    assert "REFLEXIO_EMBEDDING_PROVIDER:-local_service" in backend
     assert "REFLEXIO_EMBEDDING_SERVICE_URL" in backend
 
 
@@ -348,11 +403,13 @@ def test_smart_install_waits_on_existing_lock() -> None:
     assert "set -C" in script
     assert 'remove_stale_install_lock "$lock_pid"' in script
     assert '[ "$(cat "$INSTALL_LOCK" 2>/dev/null || true)" = "$$" ]' in script
-    assert "kill -0 \"$lock_pid\"" in script
+    assert 'kill -0 "$lock_pid"' in script
 
 
 def test_smart_install_waits_on_portable_lock_without_flock(tmp_path: Path) -> None:
-    bin_dir = Path(_minimal_path(tmp_path, "dirname", "mkdir", "rm", "cat", "sleep", "sed", "awk"))
+    bin_dir = Path(
+        _minimal_path(tmp_path, "dirname", "mkdir", "rm", "cat", "sleep", "sed", "awk")
+    )
     for name, output in {"node": "v22.99.0", "npm": "10.9.0"}.items():
         executable = bin_dir / name
         executable.write_text(f"#!/bin/sh\nprintf '%s\\n' '{output}'\n")
@@ -395,7 +452,11 @@ def test_smart_install_waits_on_portable_lock_without_flock(tmp_path: Path) -> N
 
 
 def test_smart_install_reaps_stale_portable_lock_without_flock(tmp_path: Path) -> None:
-    bin_dir = Path(_minimal_path(tmp_path, "dirname", "mkdir", "rm", "rmdir", "cat", "sleep", "sed", "awk"))
+    bin_dir = Path(
+        _minimal_path(
+            tmp_path, "dirname", "mkdir", "rm", "rmdir", "cat", "sleep", "sed", "awk"
+        )
+    )
     for name, output in {"node": "v22.99.0", "npm": "10.9.0"}.items():
         executable = bin_dir / name
         executable.write_text(f"#!/bin/sh\nprintf '%s\\n' '{output}'\n")
@@ -445,11 +506,19 @@ def test_claude_code_install_hook_matches_session_start_modes() -> None:
 
 
 def test_codex_session_start_hook_has_install_recovery_budget() -> None:
-    hooks = json.loads((REPO_ROOT / "plugin" / "hooks" / "codex-hooks.json").read_text())
+    hooks = json.loads(
+        (REPO_ROOT / "plugin" / "hooks" / "codex-hooks.json").read_text()
+    )
     session_hooks = hooks["hooks"]["SessionStart"][0]["hooks"]
-    hook_entry = next(hook for hook in session_hooks if "hook_entry.sh" in hook["command"])
-    backend_hook = next(hook for hook in session_hooks if "backend-service.sh" in hook["command"])
-    dashboard_hook = next(hook for hook in session_hooks if "dashboard-service.sh" in hook["command"])
+    hook_entry = next(
+        hook for hook in session_hooks if "hook_entry.sh" in hook["command"]
+    )
+    backend_hook = next(
+        hook for hook in session_hooks if "backend-service.sh" in hook["command"]
+    )
+    dashboard_hook = next(
+        hook for hook in session_hooks if "dashboard-service.sh" in hook["command"]
+    )
 
     assert hook_entry["timeout"] == 300
     assert backend_hook["timeout"] == 300
@@ -459,7 +528,10 @@ def test_codex_session_start_hook_has_install_recovery_budget() -> None:
 def test_hook_entry_self_heals_missing_uv_without_cli_command() -> None:
     script = HOOK_ENTRY.read_text()
 
-    assert "CLAUDE_SMART_BOOTSTRAPPING=1 bash \"$PLUGIN_ROOT/scripts/smart-install.sh\"" in script
+    assert (
+        'CLAUDE_SMART_BOOTSTRAPPING=1 bash "$PLUGIN_ROOT/scripts/smart-install.sh"'
+        in script
+    )
     assert "claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1" in script
     assert 'bash "$HERE/backend-service.sh" start' in script
     assert 'bash "$HERE/dashboard-service.sh" start' in script
@@ -518,11 +590,38 @@ def test_node_installer_platform_preflight_messages() -> None:
         "console.log(installer.platformSupportError() || 'ok');"
     )
     cases = [
-        ({"CLAUDE_SMART_TEST_PLATFORM": "darwin", "CLAUDE_SMART_TEST_ARCH": "arm64", "CLAUDE_SMART_TEST_RELEASE": "23.0.0"}, "ok"),
-        ({"CLAUDE_SMART_TEST_PLATFORM": "darwin", "CLAUDE_SMART_TEST_ARCH": "x64", "CLAUDE_SMART_TEST_RELEASE": "23.0.0"}, "Intel Mac is not supported"),
-        ({"CLAUDE_SMART_TEST_PLATFORM": "darwin", "CLAUDE_SMART_TEST_ARCH": "arm64", "CLAUDE_SMART_TEST_RELEASE": "22.6.0"}, "macOS 13 and older are not supported"),
-        ({"CLAUDE_SMART_TEST_PLATFORM": "win32", "CLAUDE_SMART_TEST_ARCH": "arm64"}, "Windows ARM is not supported"),
-        ({"CLAUDE_SMART_TEST_PLATFORM": "win32", "CLAUDE_SMART_TEST_ARCH": "x64"}, "ok"),
+        (
+            {
+                "CLAUDE_SMART_TEST_PLATFORM": "darwin",
+                "CLAUDE_SMART_TEST_ARCH": "arm64",
+                "CLAUDE_SMART_TEST_RELEASE": "23.0.0",
+            },
+            "ok",
+        ),
+        (
+            {
+                "CLAUDE_SMART_TEST_PLATFORM": "darwin",
+                "CLAUDE_SMART_TEST_ARCH": "x64",
+                "CLAUDE_SMART_TEST_RELEASE": "23.0.0",
+            },
+            "Intel Mac is not supported",
+        ),
+        (
+            {
+                "CLAUDE_SMART_TEST_PLATFORM": "darwin",
+                "CLAUDE_SMART_TEST_ARCH": "arm64",
+                "CLAUDE_SMART_TEST_RELEASE": "22.6.0",
+            },
+            "macOS 13 and older are not supported",
+        ),
+        (
+            {"CLAUDE_SMART_TEST_PLATFORM": "win32", "CLAUDE_SMART_TEST_ARCH": "arm64"},
+            "Windows ARM is not supported",
+        ),
+        (
+            {"CLAUDE_SMART_TEST_PLATFORM": "win32", "CLAUDE_SMART_TEST_ARCH": "x64"},
+            "ok",
+        ),
     ]
     for overrides, expected in cases:
         env = os.environ.copy()
@@ -622,7 +721,9 @@ def test_node_installer_does_not_treat_global_node_as_private_runtime(
     assert "Intel Mac is not supported" in result.stdout
 
 
-def test_node_installer_bootstraps_runtime_with_private_node_and_uv(tmp_path: Path) -> None:
+def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
+    tmp_path: Path,
+) -> None:
     node = shutil.which("node")
     if not node:
         pytest.skip("node is required for installer wrapper tests")
@@ -649,16 +750,48 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(tmp_path: Pa
                         {
                             "hooks": [
                                 {"command": 'bash "$_R/scripts/smart-install.sh"'},
-                                {"command": 'bash "$_R/scripts/ensure-plugin-root.sh" "$_R"'},
-                                {"command": 'bash "$_R/scripts/backend-service.sh" start'},
-                                {"command": 'bash "$_R/scripts/dashboard-service.sh" start'},
-                                {"command": 'bash "$_R/scripts/hook_entry.sh" codex session-start'},
+                                {
+                                    "command": 'bash "$_R/scripts/ensure-plugin-root.sh" "$_R"'
+                                },
+                                {
+                                    "command": 'bash "$_R/scripts/backend-service.sh" start'
+                                },
+                                {
+                                    "command": 'bash "$_R/scripts/dashboard-service.sh" start'
+                                },
+                                {
+                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex session-start'
+                                },
                             ]
                         }
                     ],
-                    "UserPromptSubmit": [{"hooks": [{"command": 'bash "$_R/scripts/hook_entry.sh" codex user-prompt'}]}],
-                    "PostToolUse": [{"hooks": [{"command": 'bash "$_R/scripts/hook_entry.sh" codex post-tool'}]}],
-                    "Stop": [{"hooks": [{"command": 'bash "$_R/scripts/hook_entry.sh" codex stop'}]}],
+                    "UserPromptSubmit": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex user-prompt'
+                                }
+                            ]
+                        }
+                    ],
+                    "PostToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex post-tool'
+                                }
+                            ]
+                        }
+                    ],
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex stop'
+                                }
+                            ]
+                        }
+                    ],
                 }
             }
         )
@@ -666,10 +799,10 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(tmp_path: Pa
     )
     (private_node / "node").write_text("#!/bin/sh\nexit 0\n")
     (private_node / "npm").write_text(
-        "#!/bin/sh\nprintf 'npm %s\\n' \"$*\" >> \"$HOME/npm.log\"\nexit 0\n"
+        '#!/bin/sh\nprintf \'npm %s\\n\' "$*" >> "$HOME/npm.log"\nexit 0\n'
     )
     (uv_bin / "uv").write_text(
-        "#!/bin/sh\nprintf 'uv %s\\n' \"$*\" >> \"$HOME/uv.log\"\nexit 0\n"
+        '#!/bin/sh\nprintf \'uv %s\\n\' "$*" >> "$HOME/uv.log"\nexit 0\n'
     )
     for executable in [private_node / "node", private_node / "npm", uv_bin / "uv"]:
         executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
@@ -712,7 +845,12 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(tmp_path: Pa
     # the right codex-hook.js subcommand and references the private node.
     # Each arg is independently shell-quoted, so the sub-event appears as
     # `"hook" "session-start"` rather than `hook session-start`.
-    expected_subs = [["ensure-root"], ["backend"], ["dashboard"], ["hook", "session-start"]]
+    expected_subs = [
+        ["ensure-root"],
+        ["backend"],
+        ["dashboard"],
+        ["hook", "session-start"],
+    ]
     for idx, sub_tokens in enumerate(expected_subs, start=1):
         cmd = session_hooks[idx]["command"]
         assert str(private_node / "node") in cmd, f"index {idx}: {cmd}"
@@ -772,14 +910,14 @@ def test_codex_claude_compat_translates_claude_contract(tmp_path: Path) -> None:
     codex = tmp_path / "codex"
     codex.write_text(
         "#!/bin/sh\n"
-        "while [ \"$#\" -gt 0 ]; do\n"
-        "  if [ \"$1\" = \"--output-last-message\" ]; then\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  if [ "$1" = "--output-last-message" ]; then\n'
         "    shift\n"
-        "    out=\"$1\"\n"
+        '    out="$1"\n'
         "  fi\n"
         "  shift || exit 1\n"
         "done\n"
-        "cat > \"$out.prompt\"\n"
+        'cat > "$out.prompt"\n'
         "printf 'codex reply' > \"$out\"\n"
     )
     codex.chmod(codex.stat().st_mode | stat.S_IXUSR)
@@ -818,10 +956,10 @@ def test_codex_claude_compat_accepts_stream_json_flags(tmp_path: Path) -> None:
     codex = tmp_path / "codex"
     codex.write_text(
         "#!/bin/sh\n"
-        "while [ \"$#\" -gt 0 ]; do\n"
-        "  if [ \"$1\" = \"--output-last-message\" ]; then\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  if [ "$1" = "--output-last-message" ]; then\n'
         "    shift\n"
-        "    out=\"$1\"\n"
+        '    out="$1"\n'
         "  fi\n"
         "  shift || exit 1\n"
         "done\n"
@@ -955,8 +1093,7 @@ def test_codex_hook_normalizer_removes_suppress_output_for_hooks(
     bin_dir.mkdir()
     uv = bin_dir / "uv"
     uv.write_text(
-        "#!/bin/sh\n"
-        "printf '%s\\n' '{\"continue\":true,\"suppressOutput\":true}'\n"
+        "#!/bin/sh\nprintf '%s\\n' '{\"continue\":true,\"suppressOutput\":true}'\n"
     )
     uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
 
@@ -1036,8 +1173,7 @@ def test_install_fingerprint_hash_tracks_lib_changes(tmp_path: Path) -> None:
         "openssl",
     )
     command = (
-        f'. "{LIB}"; '
-        f'claude_smart_install_fingerprint_hash "{plugin_root}" "{scripts}"'
+        f'. "{LIB}"; claude_smart_install_fingerprint_hash "{plugin_root}" "{scripts}"'
     )
     before = subprocess.run(
         ["/bin/bash", "--noprofile", "--norc", "-c", command],
@@ -1073,7 +1209,9 @@ def test_install_private_node_installs_from_verified_archive(tmp_path: Path) -> 
     assert not (tmp_path / ".claude-smart" / "install-failed").exists()
 
 
-def test_install_private_node_checksum_failure_is_dashboard_only(tmp_path: Path) -> None:
+def test_install_private_node_checksum_failure_is_dashboard_only(
+    tmp_path: Path,
+) -> None:
     dist = _fake_node_dist(tmp_path, bad_checksum=True)
     result = _run_private_node_install(tmp_path, f"file://{dist}")
 
@@ -1084,7 +1222,9 @@ def test_install_private_node_checksum_failure_is_dashboard_only(tmp_path: Path)
     assert not (tmp_path / ".claude-smart" / "install-failed").exists()
 
 
-def test_install_private_node_download_failure_is_dashboard_only(tmp_path: Path) -> None:
+def test_install_private_node_download_failure_is_dashboard_only(
+    tmp_path: Path,
+) -> None:
     missing_dist = tmp_path / "missing-node-dist"
     result = _run_private_node_install(tmp_path, f"file://{missing_dist}")
 


### PR DESCRIPTION
## Summary

- Adds opt-in **managed Reflexio mode**: passing `--api-key` to `claude-smart install` (Claude Code or Codex) writes `REFLEXIO_URL` + `REFLEXIO_API_KEY` to `~/.reflexio/.env` and points hooks at `https://www.reflexio.ai/` instead of the local backend. Omitting the flag keeps the existing local-only flow unchanged.
- Caps every Reflexio HTTP call from a hook at **5s** via a new `_HTTP_TIMEOUT_SECONDS` constant in the adapter, with a `TypeError` fallback so older `ReflexioClient` builds (no `timeout` kwarg) still construct. This stops a hung remote/local backend from stalling a Claude Code / Codex prompt.
- Dashboard now surfaces `REFLEXIO_URL` / `REFLEXIO_API_KEY` on the Environment page (masked previews) and the `/api/reflexio/*` proxy forwards `Authorization: Bearer ...` only when the target origin matches the configured `REFLEXIO_URL`.
- `backend-service.sh` skips starting the local process when a non-localhost `REFLEXIO_URL` is configured; `status` reports the remote endpoint instead.

## Caveats

- The 5s cap covers reads/connect after `socket.connect()` returns, but a TCP SYN silently dropped by the network (no RST, no ICMP) can still block until the OS-level connect timeout fires. The `TypeError` fallback also runs against the client's default (300s) — older pinned clients won't get the 5s cap. Both are noted in code comments.
- Switching to managed mode requires restarting Claude Code / Codex so hooks reload `~/.reflexio/.env`.

## Changes

**Plugin (Python)**
- `plugin/src/claude_smart/env_config.py` *(new)* — shared `~/.reflexio/.env` parser/writer (mode 0600, preserves comments) and `mask_secret` helper.
- `plugin/src/claude_smart/reflexio_adapter.py` — pass `api_key` + `timeout=5` to `ReflexioClient`; `TypeError` fallback for legacy clients; load `~/.reflexio/.env` on adapter init.
- `plugin/src/claude_smart/cli.py` — accept `--api-key` / `--reflexio-url`; new `show` subcommand for env diagnostics.
- `plugin/src/claude_smart/context_format.py` — citation links resolve against the configured (local vs managed) base URL.

**Plugin (Node / shell)**
- `bin/claude-smart.js` — `--api-key` plumbed through install; writes managed env vars to `~/.reflexio/.env` (0600).
- `plugin/scripts/_lib.sh`, `backend-service.sh`, `cli.sh`, `dashboard-service.sh`, `hook_entry.sh`, `smart-install.sh`, `codex-hook.js` — detect managed mode and skip the local backend launch when a non-localhost `REFLEXIO_URL` is set.

**Dashboard**
- `app/api/reflexio/[...path]/route.ts` — proxy attaches bearer + `User-Agent: claude-smart` only when target origin matches the configured managed origin.
- `app/api/config/route.ts`, `app/configure/env/page.tsx`, `hooks/use-settings.tsx`, `lib/config-file.ts`, `lib/types.ts` — env view/update UI with masked previews.

**Docs / tests**
- `MANAGED_REFLEXIO.md` *(new)* — when to use, install commands, troubleshooting, switch-back.
- New: `tests/test_cli_show.py`, `tests/test_dashboard_managed_reflexio.py`; expanded `test_adapter.py` (timeout kwarg + legacy fallback), `test_cli_install.py`, `test_install_scripts.py`, `test_context_format.py`, `test_codex_support.py`, `test_cli_clear_user.py`, `conftest.py`.

## Test Plan

- [x] `pytest tests` — 382 passed locally (pre-commit hook).
- [ ] Install with no key — confirm local mode unchanged (`backend-service.sh status` reports local 8071).
- [ ] `REFLEXIO_API_KEY=... npx claude-smart install --api-key "$REFLEXIO_API_KEY"` — confirm `~/.reflexio/.env` gets `REFLEXIO_URL` + `REFLEXIO_API_KEY` at 0600 and backend status reports the remote URL.
- [ ] `curl -fsS -H "Authorization: Bearer $REFLEXIO_API_KEY" https://www.reflexio.ai/api/whoami` returns 200.
- [ ] Dashboard Environment page reads/writes the managed values; `/api/reflexio/*` proxy attaches bearer for the managed origin only.
- [ ] Simulate hung backend (e.g., `nc -l 8071` without responding) — confirm hooks fail within ~5s instead of hanging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed Reflexio mode supporting remote service connectivity via API key configuration
  * Dashboard now includes API key configuration UI with secure password-style input
  * Installation supports both local and managed Reflexio setup modes

* **Bug Fixes**
  * Improved error reporting when reading skills/preferences fails, displaying specific error details
  * Better handling of remote Reflexio URLs in citation links and dashboard navigation

* **Documentation**
  * Added comprehensive guide for running in managed mode against remote Reflexio service

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->