### PR TITLE
[codex] fix dashboard Reflexio URL initialization

### DIFF
--- a/plugin/dashboard/app/configure/env/page.tsx
+++ b/plugin/dashboard/app/configure/env/page.tsx
@@ -134,7 +134,8 @@ export default function ConfigureEnvPage() {
           <div>
             <h2 className="text-sm font-semibold">Dashboard</h2>
             <p className="text-xs text-muted-foreground">
-              Stored in browser localStorage — only affects this UI.
+              Session-only override — defaults to REFLEXIO_URL below; clears on
+              page refresh.
             </p>
           </div>
           <div className="space-y-2">

--- a/plugin/dashboard/hooks/use-settings.tsx
+++ b/plugin/dashboard/hooks/use-settings.tsx
@@ -5,113 +5,61 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
-  useSyncExternalStore,
+  useRef,
+  useState,
   ReactNode,
 } from "react";
 
-interface Settings {
+interface SettingsContextValue {
   reflexioUrl: string;
-}
-
-interface SettingsContextValue extends Settings {
   setReflexioUrl: (url: string) => void;
 }
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 
-const STORAGE_KEY = "claude-smart-dashboard-settings";
-const DEFAULT_URL = "http://localhost:8071";
-const DEFAULTS: Settings = { reflexioUrl: DEFAULT_URL };
-const DEFAULT_JSON = JSON.stringify(DEFAULTS);
-
-type Listener = () => void;
-const listeners = new Set<Listener>();
-
-function readStorage(): string {
-  if (typeof window === "undefined") return DEFAULT_JSON;
-  try {
-    return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_JSON;
-  } catch {
-    return DEFAULT_JSON;
-  }
-}
-
-function subscribe(listener: Listener): () => void {
-  listeners.add(listener);
-  const onStorage = (ev: StorageEvent) => {
-    if (ev.key === STORAGE_KEY) listener();
-  };
-  window.addEventListener("storage", onStorage);
-  return () => {
-    listeners.delete(listener);
-    window.removeEventListener("storage", onStorage);
-  };
-}
-
-function writeStorage(settings: Settings): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-  } catch {
-    // ignore
-  }
-  for (const l of listeners) l();
-}
-
-function parse(json: string): Settings {
-  try {
-    const parsed = JSON.parse(json);
-    return { ...DEFAULTS, ...parsed };
-  } catch {
-    return DEFAULTS;
-  }
-}
-
-function isLocalUrl(raw: string): boolean {
-  try {
-    const url = new URL(raw);
-    return ["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(url.hostname);
-  } catch {
-    return false;
-  }
-}
+// Fallback only — used when ~/.reflexio/.env has no REFLEXIO_URL and the
+// /api/config probe fails to return one. The source of truth is the env file.
+const FALLBACK_URL = "http://localhost:8071";
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const raw = useSyncExternalStore(subscribe, readStorage, () => DEFAULT_JSON);
-  const settings = useMemo(() => parse(raw), [raw]);
+  const [reflexioUrl, setReflexioUrlState] = useState<string>("");
+  // Once the user edits the input in this session, stop syncing from .env so
+  // the override holds until page refresh.
+  const overriddenRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
-    async function syncManagedUrl() {
+    (async () => {
       try {
         const res = await fetch("/api/config", { cache: "no-store" });
-        if (!res.ok) return;
-        const config = (await res.json()) as { REFLEXIO_URL?: string };
-        const configuredUrl = config.REFLEXIO_URL;
-        if (
-          !cancelled &&
-          configuredUrl &&
-          !isLocalUrl(configuredUrl) &&
-          isLocalUrl(settings.reflexioUrl)
-        ) {
-          writeStorage({ reflexioUrl: configuredUrl });
+        if (!res.ok) {
+          if (!cancelled && !overriddenRef.current) {
+            setReflexioUrlState(FALLBACK_URL);
+          }
+          return;
         }
+        const config = (await res.json()) as { REFLEXIO_URL?: string };
+        if (cancelled || overriddenRef.current) return;
+        const fromEnv = (config.REFLEXIO_URL ?? "").trim();
+        setReflexioUrlState(fromEnv || FALLBACK_URL);
       } catch {
-        // Keep the dashboard on its local default when config cannot be read.
+        if (!cancelled && !overriddenRef.current) {
+          setReflexioUrlState(FALLBACK_URL);
+        }
       }
-    }
-    void syncManagedUrl();
+    })();
     return () => {
       cancelled = true;
     };
-  }, [settings.reflexioUrl]);
+  }, []);
 
   const setReflexioUrl = useCallback((url: string) => {
-    writeStorage({ reflexioUrl: url });
+    overriddenRef.current = true;
+    setReflexioUrlState(url);
   }, []);
 
   return (
-    <SettingsContext.Provider value={{ ...settings, setReflexioUrl }}>
+    <SettingsContext.Provider value={{ reflexioUrl, setReflexioUrl }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/plugin/dashboard/hooks/use-stall-state.ts
+++ b/plugin/dashboard/hooks/use-stall-state.ts
@@ -30,6 +30,7 @@ export function useStallState(): StallState | null {
 
   useEffect(() => {
     let cancelled = false;
+    if (!reflexioUrl) return;
     const base = reflexioUrl.replace(/\/$/, "");
 
     const tick = async () => {

--- a/tests/test_dashboard_managed_reflexio.py
+++ b/tests/test_dashboard_managed_reflexio.py
@@ -58,14 +58,16 @@ def test_dashboard_proxy_forwards_bearer_auth_without_client_auth() -> None:
     assert 'apiKey: configuredBase ? apiKey : ""' in route
 
 
-def test_dashboard_settings_adopt_managed_reflexio_url() -> None:
+def test_dashboard_settings_loads_config_before_fallback() -> None:
     settings = (
         REPO_ROOT / "plugin" / "dashboard" / "hooks" / "use-settings.tsx"
     ).read_text()
 
     assert 'fetch("/api/config", { cache: "no-store" })' in settings
     assert "REFLEXIO_URL?: string" in settings
-    assert "function isLocalUrl" in settings
-    assert "!isLocalUrl(configuredUrl)" in settings
-    assert "isLocalUrl(settings.reflexioUrl)" in settings
-    assert "writeStorage({ reflexioUrl: configuredUrl })" in settings
+    assert 'useState<string>("")' in settings
+    assert "setReflexioUrlState(fromEnv || FALLBACK_URL)" in settings
+    assert "if (!res.ok)" in settings
+    assert "setReflexioUrlState(FALLBACK_URL)" in settings
+    assert "function isLocalUrl" not in settings
+    assert "writeStorage" not in settings


### PR DESCRIPTION
## Summary
- remove persisted browser localStorage settings for the dashboard Reflexio URL
- load the URL from /api/config before exposing a client-side override
- fall back to http://localhost:8071 only when config is unavailable or empty
- skip direct stall-state polling until a Reflexio URL is known
- update the reflexio submodule pointer to the AI agent integration guide docs commit

## Root cause
The settings provider initialized reflexioUrl to the local fallback immediately. Dashboard consumers that include x-reflexio-url could issue their first requests to http://localhost:8071 before /api/config finished loading the configured REFLEXIO_URL.

## Validation
- npm run lint
- npx tsc --noEmit
- npm run build
- uv run --project plugin pytest tests/test_dashboard_managed_reflexio.py
- pre-commit hook: uv run --project plugin pytest tests/ (382 passed)
- browser check with temporary HOME config REFLEXIO_URL=http://localhost:8072/ showed the dashboard input rendering http://localhost:8072/

## Companion
- Reflexio docs PR: https://github.com/ReflexioAI/reflexio/pull/83