### PR TITLE
[codex] Use single backend URL in dashboard

### DIFF
--- a/plugin/dashboard/app/api/reflexio/[...path]/route.ts
+++ b/plugin/dashboard/app/api/reflexio/[...path]/route.ts
@@ -6,33 +6,12 @@ export const dynamic = "force-dynamic";
 
 const DEFAULT_URL = "http://localhost:8071";
 
-function isLocalUrl(raw: string | null): boolean {
-  if (!raw) return false;
-  try {
-    const url = new URL(raw);
-    return ["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(url.hostname);
-  } catch {
-    return false;
-  }
-}
-
-async function reflexioConfig(req: Request): Promise<{ base: string; apiKey: string }> {
+async function reflexioConfig(): Promise<{ base: string; apiKey: string }> {
   const config = await readConfig();
-  const header = req.headers.get("x-reflexio-url");
-  const fromHeader = header ? originOnly(header) : null;
   const apiKey = config.REFLEXIO_API_KEY || process.env.REFLEXIO_API_KEY || "";
   const fromEnv = originOnly(process.env.REFLEXIO_URL ?? "");
   const fromConfig = originOnly(config.REFLEXIO_URL ?? "");
   const configuredBase = fromEnv ?? fromConfig;
-  if (
-    fromHeader &&
-    !(isLocalUrl(fromHeader) && configuredBase && !isLocalUrl(configuredBase))
-  ) {
-    return {
-      base: fromHeader,
-      apiKey: fromHeader === configuredBase ? apiKey : "",
-    };
-  }
   return {
     base: configuredBase ?? DEFAULT_URL,
     apiKey: configuredBase ? apiKey : "",
@@ -46,12 +25,11 @@ async function proxy(
   const { path } = await context.params;
   const targetPath = path.join("/");
   const url = new URL(req.url);
-  const { base, apiKey } = await reflexioConfig(req);
+  const { base, apiKey } = await reflexioConfig();
   const target = `${base}/${targetPath}${url.search}`;
 
   const headers = new Headers(req.headers);
   headers.delete("host");
-  headers.delete("x-reflexio-url");
   headers.delete("connection");
   headers.delete("authorization");
   headers.set("user-agent", "claude-smart");

--- a/plugin/dashboard/app/configure/env/page.tsx
+++ b/plugin/dashboard/app/configure/env/page.tsx
@@ -8,11 +8,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
-import { useSettings } from "@/hooks/use-settings";
+import { SETTINGS_CHANGED_EVENT } from "@/hooks/use-settings";
 import type { ClaudeCodeHookConfig, ClaudeSmartConfig } from "@/lib/types";
 
 export default function ConfigureEnvPage() {
-  const { reflexioUrl, setReflexioUrl } = useSettings();
   const [config, setConfig] = useState<ClaudeSmartConfig | null>(null);
   const [hookConfig, setHookConfig] = useState<ClaudeCodeHookConfig | null>(null);
   const [hookDirty, setHookDirty] = useState(false);
@@ -94,6 +93,7 @@ export default function ConfigureEnvPage() {
       const updatedHook: ClaudeCodeHookConfig = await hookRes.json();
       setConfig(updated);
       setHookConfig(updatedHook);
+      window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT));
       setHookDirty(false);
       setApiKeyDirty(false);
       setSaved(true);
@@ -129,26 +129,6 @@ export default function ConfigureEnvPage() {
             Saved to ~/.reflexio/.env and Claude Code settings
           </div>
         )}
-
-        <section className="space-y-4 rounded-lg border border-border bg-card/92 p-5 shadow-sm">
-          <div>
-            <h2 className="text-sm font-semibold">Dashboard</h2>
-            <p className="text-xs text-muted-foreground">
-              Stored in browser localStorage — only affects this UI.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label>Reflexio endpoint (dashboard)</Label>
-            <Input
-              value={reflexioUrl}
-              onChange={(e) => setReflexioUrl(e.target.value)}
-              className="font-mono text-xs bg-background/80"
-              placeholder="http://localhost:8071"
-            />
-          </div>
-        </section>
-
-        <Separator />
 
         <section className="space-y-4 rounded-lg border border-border bg-card/92 p-5 shadow-sm">
           <div>

--- a/plugin/dashboard/app/configure/server/page.tsx
+++ b/plugin/dashboard/app/configure/server/page.tsx
@@ -6,7 +6,6 @@ import { PageHeader } from "@/components/common/page-header";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useSettings } from "@/hooks/use-settings";
 import type { ReflexioConfig } from "@/lib/types";
 
 type ExtractorField =
@@ -14,7 +13,6 @@ type ExtractorField =
   | "user_playbook_extractor_configs";
 
 export default function ConfigureServerPage() {
-  const { reflexioUrl } = useSettings();
   const [srvConfig, setSrvConfig] = useState<ReflexioConfig | null>(null);
   const [srvError, setSrvError] = useState<string | null>(null);
   const [srvSaved, setSrvSaved] = useState(false);
@@ -22,11 +20,8 @@ export default function ConfigureServerPage() {
   const [srvLoading, setSrvLoading] = useState(true);
 
   const fetchSrvConfig = useCallback(async (): Promise<ReflexioConfig> => {
-    const headers: HeadersInit = {};
-    if (reflexioUrl) headers["x-reflexio-url"] = reflexioUrl;
     const res = await fetch("/api/reflexio/api/get_config", {
       cache: "no-store",
-      headers,
     });
     if (!res.ok) {
       const body = await res.json().catch(() => null);
@@ -36,7 +31,7 @@ export default function ConfigureServerPage() {
       throw new Error(detail);
     }
     return (await res.json()) as ReflexioConfig;
-  }, [reflexioUrl]);
+  }, []);
 
   useEffect(() => {
     let alive = true;
@@ -84,7 +79,6 @@ export default function ConfigureServerPage() {
     setSrvError(null);
     try {
       const headers: HeadersInit = { "content-type": "application/json" };
-      if (reflexioUrl) headers["x-reflexio-url"] = reflexioUrl;
       const res = await fetch("/api/reflexio/api/set_config", {
         method: "POST",
         headers,

--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -16,7 +16,6 @@ import { StatCard } from "@/components/common/stat-card";
 import { EmptyState } from "@/components/common/empty-state";
 import { Badge } from "@/components/ui/badge";
 import { reflexio } from "@/lib/reflexio-client";
-import { useSettings } from "@/hooks/use-settings";
 import { formatRelative, truncate, truncateId } from "@/lib/format";
 import { agentPlaybookStatusLabel } from "@/lib/status";
 import type {
@@ -39,7 +38,6 @@ interface RecentLearning {
 }
 
 export default function DashboardPage() {
-  const { reflexioUrl } = useSettings();
   const [sessions, setSessions] = useState<SessionSummary[] | null>(null);
   const [projectSkills, setProjectSkills] = useState<UserPlaybook[] | null>(null);
   const [sharedSkills, setSharedSkills] = useState<AgentPlaybook[] | null>(null);
@@ -57,13 +55,13 @@ export default function DashboardPage() {
         const [sRes, projectRes, sharedRes, prefRes, statsRes] = await Promise.all([
           fetch("/api/sessions", { cache: "no-store" }).then((r) => r.json()),
           reflexio
-            .getUserPlaybooks({ reflexioUrl })
+            .getUserPlaybooks({})
             .catch(() => ({ user_playbooks: [] as UserPlaybook[] })),
           reflexio
-            .getAgentPlaybooks({ reflexioUrl })
+            .getAgentPlaybooks({})
             .catch(() => ({ agent_playbooks: [] as AgentPlaybook[] })),
           reflexio
-            .getAllProfiles({ reflexioUrl, limit: 100 })
+            .getAllProfiles({ limit: 100 })
             .catch(() => ({ user_profiles: [] as UserProfile[] })),
           fetch("/api/rules/applied?daysBack=30&limit=200", {
             cache: "no-store",
@@ -89,7 +87,7 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [reflexioUrl]);
+  }, []);
 
   // CURRENT project-specific skills arrive as `status: null` (response_model_exclude_none
   // strips the field). Anything else (e.g. "archived", "pending") is excluded.

--- a/plugin/dashboard/app/preferences/[id]/page.tsx
+++ b/plugin/dashboard/app/preferences/[id]/page.tsx
@@ -28,7 +28,6 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { reflexio } from "@/lib/reflexio-client";
-import { useSettings } from "@/hooks/use-settings";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { statusLabel as status } from "@/lib/status";
@@ -42,7 +41,6 @@ export default function PreferenceDetailPage({
   const { id: rawId } = use(params);
   const id = decodeURIComponent(rawId);
   const router = useRouter();
-  const { reflexioUrl } = useSettings();
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [notFound, setNotFound] = useState(false);
@@ -55,7 +53,7 @@ export default function PreferenceDetailPage({
   useEffect(() => {
     let cancelled = false;
     reflexio
-      .getAllProfiles({ reflexioUrl, limit: 500 })
+      .getAllProfiles({ limit: 500 })
       .then((res) => {
         if (cancelled) return;
         const found = (res.user_profiles ?? []).find(
@@ -74,7 +72,7 @@ export default function PreferenceDetailPage({
     return () => {
       cancelled = true;
     };
-  }, [id, reflexioUrl]);
+  }, [id]);
 
   const dirty = useMemo(
     () => !!profile && profile.content !== content,
@@ -92,7 +90,6 @@ export default function PreferenceDetailPage({
           profile_id: profile.profile_id,
           content,
         },
-        reflexioUrl,
       );
       setProfile({ ...profile, content });
       setEditing(false);
@@ -109,7 +106,6 @@ export default function PreferenceDetailPage({
     try {
       await reflexio.deleteUserProfile(
         { user_id: profile.user_id, profile_id: profile.profile_id },
-        reflexioUrl,
       );
       router.push("/preferences");
     } catch (e) {

--- a/plugin/dashboard/app/preferences/page.tsx
+++ b/plugin/dashboard/app/preferences/page.tsx
@@ -16,7 +16,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { reflexio } from "@/lib/reflexio-client";
-import { useSettings } from "@/hooks/use-settings";
 import { formatRelative, truncateId } from "@/lib/format";
 import type { PlaybookApplicationStat, UserProfile } from "@/lib/types";
 
@@ -27,7 +26,6 @@ function profileStatKey(profile: UserProfile): string {
 }
 
 export default function PreferencesPage() {
-  const { reflexioUrl } = useSettings();
   const [profiles, setProfiles] = useState<UserProfile[] | null>(null);
   const [appStats, setAppStats] = useState<PlaybookApplicationStat[] | null>(
     null,
@@ -41,7 +39,7 @@ export default function PreferencesPage() {
     async function load() {
       try {
         const [profileRes, statsRes] = await Promise.all([
-          reflexio.getAllProfiles({ reflexioUrl }),
+          reflexio.getAllProfiles(),
           fetch("/api/rules/applied?daysBack=30&limit=200", {
             cache: "no-store",
           })
@@ -65,7 +63,7 @@ export default function PreferencesPage() {
     return () => {
       cancelled = true;
     };
-  }, [reflexioUrl]);
+  }, []);
 
   const statsByProfile = useMemo(() => {
     const map = new Map<string, PlaybookApplicationStat>();
@@ -129,7 +127,7 @@ export default function PreferencesPage() {
               confirmMessage={`Delete ALL ${profiles?.length ?? 0} preferences? Preferences regenerate from fresh interactions, but this cannot be undone.`}
               disabled={!profiles || profiles.length === 0}
               onConfirm={async () => {
-                await reflexio.deleteAllProfiles(reflexioUrl);
+                await reflexio.deleteAllProfiles();
                 setProfiles([]);
               }}
             />
@@ -140,7 +138,7 @@ export default function PreferencesPage() {
       <div className="p-6">
         {error && (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm mb-4">
-            {error}. Is reflexio running on the URL in the top bar?
+            {error}. Is reflexio running on the configured backend URL?
           </div>
         )}
 

--- a/plugin/dashboard/app/skills/page.tsx
+++ b/plugin/dashboard/app/skills/page.tsx
@@ -17,7 +17,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { reflexio } from "@/lib/reflexio-client";
-import { useSettings } from "@/hooks/use-settings";
 import { formatRelative } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import {
@@ -100,7 +99,6 @@ function skillStatKey(skill: SkillCard): string {
 }
 
 export default function SkillsPage() {
-  const { reflexioUrl } = useSettings();
   const [projectSkills, setProjectSkills] = useState<UserPlaybook[] | null>(null);
   const [sharedSkills, setSharedSkills] = useState<AgentPlaybook[] | null>(null);
   const [appStats, setAppStats] = useState<PlaybookApplicationStat[] | null>(
@@ -119,12 +117,10 @@ export default function SkillsPage() {
       try {
         const [projectRes, sharedRes, statsRes] = await Promise.all([
           reflexio.getUserPlaybooks({
-            reflexioUrl,
             limit: 500,
             statusFilter: ALL_LIFECYCLE_STATUSES,
           }),
           reflexio.getAgentPlaybooks({
-            reflexioUrl,
             limit: 500,
             statusFilter: ALL_LIFECYCLE_STATUSES,
           }),
@@ -150,7 +146,7 @@ export default function SkillsPage() {
     return () => {
       cancelled = true;
     };
-  }, [reflexioUrl]);
+  }, []);
 
   const statsByRule = useMemo(() => {
     const map = new Map<string, PlaybookApplicationStat>();
@@ -302,10 +298,10 @@ export default function SkillsPage() {
               disabled={activeCount === 0}
               onConfirm={async () => {
                 if (activeKind === "project") {
-                  await reflexio.deleteAllUserPlaybooks(reflexioUrl);
+                  await reflexio.deleteAllUserPlaybooks();
                   setProjectSkills([]);
                 } else {
-                  await reflexio.deleteAllAgentPlaybooks(reflexioUrl);
+                  await reflexio.deleteAllAgentPlaybooks();
                   setSharedSkills([]);
                 }
               }}
@@ -338,7 +334,7 @@ export default function SkillsPage() {
 
         {error && (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm">
-            {error}. Is reflexio running on the URL in the top bar?
+            {error}. Is reflexio running on the configured backend URL?
           </div>
         )}
 

--- a/plugin/dashboard/app/skills/project/[id]/page.tsx
+++ b/plugin/dashboard/app/skills/project/[id]/page.tsx
@@ -25,7 +25,6 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { reflexio } from "@/lib/reflexio-client";
-import { useSettings } from "@/hooks/use-settings";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { statusLabel } from "@/lib/status";
@@ -54,7 +53,6 @@ export default function ProjectSkillDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
-  const { reflexioUrl } = useSettings();
 
   const [playbook, setPlaybook] = useState<UserPlaybook | null>(null);
   const [notFound, setNotFound] = useState(false);
@@ -71,7 +69,7 @@ export default function ProjectSkillDetailPage({
   useEffect(() => {
     let cancelled = false;
     reflexio
-      .getUserPlaybooks({ reflexioUrl })
+      .getUserPlaybooks({})
       .then((res) => {
         if (cancelled) return;
         const found = (res.user_playbooks ?? []).find(
@@ -90,7 +88,7 @@ export default function ProjectSkillDetailPage({
     return () => {
       cancelled = true;
     };
-  }, [id, reflexioUrl]);
+  }, [id]);
 
   const dirty = useMemo(() => {
     if (!playbook) return false;
@@ -114,7 +112,6 @@ export default function ProjectSkillDetailPage({
           trigger: form.trigger || null,
           rationale: form.rationale || null,
         },
-        reflexioUrl,
       );
       setPlaybook({
         ...playbook,
@@ -134,7 +131,7 @@ export default function ProjectSkillDetailPage({
     if (!playbook) return;
     setDeleting(true);
     try {
-      await reflexio.deleteUserPlaybook(playbook.user_playbook_id, reflexioUrl);
+      await reflexio.deleteUserPlaybook(playbook.user_playbook_id);
       router.push("/skills");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/plugin/dashboard/app/skills/shared/[id]/page.tsx
+++ b/plugin/dashboard/app/skills/shared/[id]/page.tsx
@@ -32,7 +32,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { reflexio } from "@/lib/reflexio-client";
-import { useSettings } from "@/hooks/use-settings";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { agentPlaybookStatusLabel, statusLabel } from "@/lib/status";
@@ -85,7 +84,6 @@ export default function SharedSkillDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
-  const { reflexioUrl } = useSettings();
 
   const [playbook, setPlaybook] = useState<AgentPlaybook | null>(null);
   const [notFound, setNotFound] = useState(false);
@@ -105,7 +103,7 @@ export default function SharedSkillDetailPage({
   useEffect(() => {
     let cancelled = false;
     reflexio
-      .getAgentPlaybooks({ reflexioUrl })
+      .getAgentPlaybooks({})
       .then((res) => {
         if (cancelled) return;
         const found = (res.agent_playbooks ?? []).find(
@@ -124,7 +122,7 @@ export default function SharedSkillDetailPage({
     return () => {
       cancelled = true;
     };
-  }, [id, reflexioUrl]);
+  }, [id]);
 
   const dirty = useMemo(() => {
     if (!playbook) return false;
@@ -150,7 +148,6 @@ export default function SharedSkillDetailPage({
           rationale: form.rationale || null,
           playbook_status: form.playbookStatus,
         },
-        reflexioUrl,
       );
       setPlaybook({
         ...playbook,
@@ -186,7 +183,6 @@ export default function SharedSkillDetailPage({
           agent_playbook_id: playbook.agent_playbook_id,
           playbook_status: nextStatus,
         },
-        reflexioUrl,
       );
       setPlaybook((current) =>
         current ? { ...current, playbook_status: nextStatus } : current,
@@ -203,7 +199,7 @@ export default function SharedSkillDetailPage({
     if (!playbook) return;
     setDeleting(true);
     try {
-      await reflexio.deleteAgentPlaybook(playbook.agent_playbook_id, reflexioUrl);
+      await reflexio.deleteAgentPlaybook(playbook.agent_playbook_id);
       router.push("/skills");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/plugin/dashboard/components/layout/top-bar.tsx
+++ b/plugin/dashboard/components/layout/top-bar.tsx
@@ -3,14 +3,13 @@
 import { useTheme } from "next-themes";
 import Image from "next/image";
 import { Link2, Menu, Moon, Sun } from "lucide-react";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useSettings } from "@/hooks/use-settings";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Sidebar } from "./sidebar";
 
 export function TopBar() {
-  const { reflexioUrl, setReflexioUrl } = useSettings();
+  const { reflexioUrl } = useSettings();
   const { theme, setTheme } = useTheme();
 
   return (
@@ -41,30 +40,23 @@ export function TopBar() {
           <div className="text-sm font-semibold leading-5">Claude-Smart</div>
         </div>
         <div className="mx-2 h-8 w-px bg-border hidden md:block" />
-        <label
-          htmlFor="reflexio-url"
-          className="hidden items-center gap-1.5 rounded-md border border-border bg-background/70 px-2 py-1 text-xs text-muted-foreground md:flex"
-        >
+        <div className="hidden items-center gap-1.5 rounded-md border border-border bg-background/70 px-2 py-1 text-xs text-muted-foreground md:flex">
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_0_3px_oklch(0.72_0.14_148/0.16)]" />
           Reflexio
-        </label>
+        </div>
         <div
           className="relative max-w-md flex-1 sm:flex-none sm:w-[22rem]"
           suppressHydrationWarning
         >
           <Link2 className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input
+          <div
             id="reflexio-url"
-            value={reflexioUrl}
-            onChange={(e) => setReflexioUrl(e.target.value)}
-            placeholder="http://localhost:8071"
-            className="h-9 pl-8 text-xs font-mono bg-background/80"
+            className="flex h-9 items-center rounded-md border border-input bg-background/80 pl-8 pr-3 text-xs font-mono text-muted-foreground"
             aria-label="Reflexio endpoint URL"
-            autoComplete="off"
-            data-1p-ignore
-            data-form-type="other"
-            data-lpignore="true"
-          />
+            title={reflexioUrl}
+          >
+            <span className="truncate">{reflexioUrl}</span>
+          </div>
         </div>
       </div>
 

--- a/plugin/dashboard/hooks/use-settings.tsx
+++ b/plugin/dashboard/hooks/use-settings.tsx
@@ -2,11 +2,9 @@
 
 import {
   createContext,
-  useCallback,
   useContext,
   useEffect,
-  useMemo,
-  useSyncExternalStore,
+  useState,
   ReactNode,
 } from "react";
 
@@ -14,107 +12,42 @@ interface Settings {
   reflexioUrl: string;
 }
 
-interface SettingsContextValue extends Settings {
-  setReflexioUrl: (url: string) => void;
-}
+type SettingsContextValue = Settings;
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 
-const STORAGE_KEY = "claude-smart-dashboard-settings";
 const DEFAULT_URL = "http://localhost:8071";
-const DEFAULTS: Settings = { reflexioUrl: DEFAULT_URL };
-const DEFAULT_JSON = JSON.stringify(DEFAULTS);
-
-type Listener = () => void;
-const listeners = new Set<Listener>();
-
-function readStorage(): string {
-  if (typeof window === "undefined") return DEFAULT_JSON;
-  try {
-    return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_JSON;
-  } catch {
-    return DEFAULT_JSON;
-  }
-}
-
-function subscribe(listener: Listener): () => void {
-  listeners.add(listener);
-  const onStorage = (ev: StorageEvent) => {
-    if (ev.key === STORAGE_KEY) listener();
-  };
-  window.addEventListener("storage", onStorage);
-  return () => {
-    listeners.delete(listener);
-    window.removeEventListener("storage", onStorage);
-  };
-}
-
-function writeStorage(settings: Settings): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-  } catch {
-    // ignore
-  }
-  for (const l of listeners) l();
-}
-
-function parse(json: string): Settings {
-  try {
-    const parsed = JSON.parse(json);
-    return { ...DEFAULTS, ...parsed };
-  } catch {
-    return DEFAULTS;
-  }
-}
-
-function isLocalUrl(raw: string): boolean {
-  try {
-    const url = new URL(raw);
-    return ["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(url.hostname);
-  } catch {
-    return false;
-  }
-}
+export const SETTINGS_CHANGED_EVENT = "claude-smart-settings-changed";
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const raw = useSyncExternalStore(subscribe, readStorage, () => DEFAULT_JSON);
-  const settings = useMemo(() => parse(raw), [raw]);
+  const [settings, setSettings] = useState<Settings>({ reflexioUrl: DEFAULT_URL });
 
   useEffect(() => {
     let cancelled = false;
-    async function syncManagedUrl() {
+    async function loadSettings() {
       try {
         const res = await fetch("/api/config", { cache: "no-store" });
         if (!res.ok) return;
         const config = (await res.json()) as { REFLEXIO_URL?: string };
-        const configuredUrl = config.REFLEXIO_URL;
-        if (
-          !cancelled &&
-          configuredUrl &&
-          !isLocalUrl(configuredUrl) &&
-          isLocalUrl(settings.reflexioUrl)
-        ) {
-          writeStorage({ reflexioUrl: configuredUrl });
+        if (!cancelled) {
+          setSettings({ reflexioUrl: config.REFLEXIO_URL || DEFAULT_URL });
         }
       } catch {
         // Keep the dashboard on its local default when config cannot be read.
       }
     }
-    void syncManagedUrl();
+    void loadSettings();
+    const onSettingsChanged = () => {
+      void loadSettings();
+    };
+    window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged);
     return () => {
       cancelled = true;
+      window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged);
     };
-  }, [settings.reflexioUrl]);
-
-  const setReflexioUrl = useCallback((url: string) => {
-    writeStorage({ reflexioUrl: url });
   }, []);
 
-  return (
-    <SettingsContext.Provider value={{ ...settings, setReflexioUrl }}>
-      {children}
-    </SettingsContext.Provider>
-  );
+  return <SettingsContext.Provider value={settings}>{children}</SettingsContext.Provider>;
 }
 
 export function useSettings(): SettingsContextValue {

--- a/plugin/dashboard/hooks/use-stall-state.ts
+++ b/plugin/dashboard/hooks/use-stall-state.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSettings } from "@/hooks/use-settings";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -19,24 +18,21 @@ export interface StallState {
 /**
  * Polls reflexio's GET /stall_state every minute. Returns the latest
  * snapshot or `null` while still loading / when the server is unreachable.
- *
- * Reads the reflexio URL from the dashboard's settings context (the same
- * URL the user can override in the top bar) so the banner follows whatever
- * reflexio backend the rest of the dashboard is pointed at.
  */
 export function useStallState(): StallState | null {
-  const { reflexioUrl } = useSettings();
   const [state, setState] = useState<StallState | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    const base = reflexioUrl.replace(/\/$/, "");
 
     const tick = async () => {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 10_000);
       try {
-        const resp = await fetch(`${base}/stall_state`, { signal: controller.signal });
+        const resp = await fetch("/api/reflexio/stall_state", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
         if (!resp.ok) return;
         const body: StallState = await resp.json();
         if (!cancelled) setState(body);
@@ -53,7 +49,7 @@ export function useStallState(): StallState | null {
       cancelled = true;
       clearInterval(id);
     };
-  }, [reflexioUrl]);
+  }, []);
 
   return state;
 }

--- a/plugin/dashboard/lib/reflexio-client.ts
+++ b/plugin/dashboard/lib/reflexio-client.ts
@@ -1,9 +1,8 @@
 /**
  * Client-side wrapper for talking to reflexio through the Next.js proxy at
- * /api/reflexio/*. The proxy forwards to the reflexio URL the user picked in
- * Settings (see hooks/use-settings.tsx). Endpoint paths and request bodies
- * mirror reflexio/reflexio/server/api.py — every call below corresponds to a
- * FastAPI route mounted under the /api prefix.
+ * /api/reflexio/*. The proxy forwards to the configured reflexio backend URL.
+ * Endpoint paths and request bodies mirror reflexio/reflexio/server/api.py —
+ * every call below corresponds to a FastAPI route mounted under the /api prefix.
  */
 
 import type {
@@ -16,18 +15,12 @@ import type {
 
 type Json = Record<string, unknown>;
 
-interface Opts {
-  reflexioUrl?: string;
-}
-
 async function request<T>(
   path: string,
   init: RequestInit,
-  reflexioUrl: string | undefined,
 ): Promise<T> {
   const headers = new Headers(init.headers);
   headers.set("content-type", "application/json");
-  if (reflexioUrl) headers.set("x-reflexio-url", reflexioUrl);
 
   const res = await fetch(`/api/reflexio/api/${path.replace(/^\/+/, "")}`, {
     ...init,
@@ -41,18 +34,18 @@ async function request<T>(
   return res.json() as Promise<T>;
 }
 
-function post<T>(path: string, body: Json, reflexioUrl?: string): Promise<T> {
-  return request<T>(path, { method: "POST", body: JSON.stringify(body) }, reflexioUrl);
+function post<T>(path: string, body: Json): Promise<T> {
+  return request<T>(path, { method: "POST", body: JSON.stringify(body) });
 }
 
-function get<T>(path: string, reflexioUrl?: string): Promise<T> {
-  return request<T>(path, { method: "GET" }, reflexioUrl);
+function get<T>(path: string): Promise<T> {
+  return request<T>(path, { method: "GET" });
 }
 
 export const reflexio = {
   /** POST /api/get_user_playbooks — all filters are optional. */
   async getUserPlaybooks(
-    opts: Opts & {
+    opts: {
       userId?: string;
       agentVersion?: string;
       playbookName?: string;
@@ -65,12 +58,12 @@ export const reflexio = {
     if (opts.agentVersion) body.agent_version = opts.agentVersion;
     if (opts.playbookName) body.playbook_name = opts.playbookName;
     if (opts.statusFilter) body.status_filter = opts.statusFilter;
-    return post("get_user_playbooks", body, opts.reflexioUrl);
+    return post("get_user_playbooks", body);
   },
 
   /** POST /api/get_agent_playbooks — all filters are optional. */
   async getAgentPlaybooks(
-    opts: Opts & {
+    opts: {
       agentVersion?: string;
       playbookName?: string;
       statusFilter?: (string | null)[];
@@ -84,7 +77,7 @@ export const reflexio = {
     if (opts.statusFilter) body.status_filter = opts.statusFilter;
     if (opts.playbookStatusFilter)
       body.playbook_status_filter = opts.playbookStatusFilter;
-    return post("get_agent_playbooks", body, opts.reflexioUrl);
+    return post("get_agent_playbooks", body);
   },
 
   /**
@@ -92,21 +85,21 @@ export const reflexio = {
    * preferences across sessions, which is what the dashboard wants.
    */
   async getAllProfiles(
-    opts: Opts & { limit?: number; statusFilter?: string } = {},
+    opts: { limit?: number; statusFilter?: string } = {},
   ): Promise<{ user_profiles: UserProfile[] }> {
     const qs = new URLSearchParams();
     qs.set("limit", String(opts.limit ?? 200));
     if (opts.statusFilter) qs.set("status_filter", opts.statusFilter);
-    return get(`get_all_profiles?${qs.toString()}`, opts.reflexioUrl);
+    return get(`get_all_profiles?${qs.toString()}`);
   },
 
   /** GET /api/get_all_interactions — global, unfiltered. */
   async getAllInteractions(
-    opts: Opts & { limit?: number } = {},
+    opts: { limit?: number } = {},
   ): Promise<{ interactions: Interaction[] }> {
     const qs = new URLSearchParams();
     qs.set("limit", String(opts.limit ?? 100));
-    return get(`get_all_interactions?${qs.toString()}`, opts.reflexioUrl);
+    return get(`get_all_interactions?${qs.toString()}`);
   },
 
   /** PUT /api/update_user_playbook — partial update of one project-specific skill. */
@@ -118,12 +111,10 @@ export const reflexio = {
       trigger?: string | null;
       rationale?: string | null;
     },
-    reflexioUrl?: string,
   ): Promise<Json> {
     return request(
       "update_user_playbook",
       { method: "PUT", body: JSON.stringify(update) },
-      reflexioUrl,
     );
   },
 
@@ -137,42 +128,32 @@ export const reflexio = {
       rationale?: string | null;
       playbook_status?: AgentPlaybookStatus | null;
     },
-    reflexioUrl?: string,
   ): Promise<Json> {
     return request(
       "update_agent_playbook",
       { method: "PUT", body: JSON.stringify(update) },
-      reflexioUrl,
     );
   },
 
   /** DELETE /api/delete_user_playbook — body carries the id. */
-  async deleteUserPlaybook(
-    userPlaybookId: number,
-    reflexioUrl?: string,
-  ): Promise<Json> {
+  async deleteUserPlaybook(userPlaybookId: number): Promise<Json> {
     return request(
       "delete_user_playbook",
       {
         method: "DELETE",
         body: JSON.stringify({ user_playbook_id: userPlaybookId }),
       },
-      reflexioUrl,
     );
   },
 
   /** DELETE /api/delete_agent_playbook — body carries the id. */
-  async deleteAgentPlaybook(
-    agentPlaybookId: number,
-    reflexioUrl?: string,
-  ): Promise<Json> {
+  async deleteAgentPlaybook(agentPlaybookId: number): Promise<Json> {
     return request(
       "delete_agent_playbook",
       {
         method: "DELETE",
         body: JSON.stringify({ agent_playbook_id: agentPlaybookId }),
       },
-      reflexioUrl,
     );
   },
 
@@ -183,56 +164,49 @@ export const reflexio = {
       profile_id: string;
       content?: string | null;
     },
-    reflexioUrl?: string,
   ): Promise<Json> {
     return request(
       "update_user_profile",
       { method: "PUT", body: JSON.stringify(update) },
-      reflexioUrl,
     );
   },
 
   /** DELETE /api/delete_profile — needs both user_id and profile_id. */
   async deleteUserProfile(
     params: { user_id: string; profile_id: string },
-    reflexioUrl?: string,
   ): Promise<Json> {
     return request(
       "delete_profile",
       { method: "DELETE", body: JSON.stringify(params) },
-      reflexioUrl,
     );
   },
 
   /** DELETE /api/delete_all_interactions — org-wide purge. */
-  async deleteAllInteractions(reflexioUrl?: string): Promise<Json> {
+  async deleteAllInteractions(): Promise<Json> {
     return request(
       "delete_all_interactions",
       { method: "DELETE" },
-      reflexioUrl,
     );
   },
 
   /** DELETE /api/delete_all_profiles — org-wide purge. */
-  async deleteAllProfiles(reflexioUrl?: string): Promise<Json> {
-    return request("delete_all_profiles", { method: "DELETE" }, reflexioUrl);
+  async deleteAllProfiles(): Promise<Json> {
+    return request("delete_all_profiles", { method: "DELETE" });
   },
 
   /** DELETE /api/delete_all_user_playbooks — org-wide purge. */
-  async deleteAllUserPlaybooks(reflexioUrl?: string): Promise<Json> {
+  async deleteAllUserPlaybooks(): Promise<Json> {
     return request(
       "delete_all_user_playbooks",
       { method: "DELETE" },
-      reflexioUrl,
     );
   },
 
   /** DELETE /api/delete_all_agent_playbooks — org-wide shared skill purge. */
-  async deleteAllAgentPlaybooks(reflexioUrl?: string): Promise<Json> {
+  async deleteAllAgentPlaybooks(): Promise<Json> {
     return request(
       "delete_all_agent_playbooks",
       { method: "DELETE" },
-      reflexioUrl,
     );
   },
 

--- a/tests/test_dashboard_managed_reflexio.py
+++ b/tests/test_dashboard_managed_reflexio.py
@@ -52,20 +52,26 @@ def test_dashboard_proxy_forwards_bearer_auth_without_client_auth() -> None:
     assert 'headers.set("user-agent", "claude-smart")' in route
     assert 'headers.set("authorization", `Bearer ${apiKey}`)' in route
     assert "readConfig" in route
-    assert "function isLocalUrl" in route
     assert "configuredBase" in route
-    assert 'apiKey: fromHeader === configuredBase ? apiKey : ""' in route
     assert 'apiKey: configuredBase ? apiKey : ""' in route
+    assert "fromHeader" not in route
+    assert "x-reflexio-url" not in route
 
 
-def test_dashboard_settings_adopt_managed_reflexio_url() -> None:
+def test_dashboard_settings_read_configured_reflexio_url_only() -> None:
     settings = (
         REPO_ROOT / "plugin" / "dashboard" / "hooks" / "use-settings.tsx"
+    ).read_text()
+    page = (
+        REPO_ROOT / "plugin" / "dashboard" / "app" / "configure" / "env" / "page.tsx"
     ).read_text()
 
     assert 'fetch("/api/config", { cache: "no-store" })' in settings
     assert "REFLEXIO_URL?: string" in settings
-    assert "function isLocalUrl" in settings
-    assert "!isLocalUrl(configuredUrl)" in settings
-    assert "isLocalUrl(settings.reflexioUrl)" in settings
-    assert "writeStorage({ reflexioUrl: configuredUrl })" in settings
+    assert "localStorage" not in settings
+    assert "setReflexioUrl" not in settings
+    assert "claude-smart-dashboard-settings" not in settings
+    assert 'SETTINGS_CHANGED_EVENT = "claude-smart-settings-changed"' in settings
+    assert "window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))" in page
+    assert "Stored in browser localStorage" not in page
+    assert "Reflexio endpoint (dashboard)" not in page


### PR DESCRIPTION
## Summary
- Remove the dashboard-only localStorage Reflexio URL override from the Environment page and top bar.
- Make the dashboard proxy use the configured `REFLEXIO_URL` as the single backend source of truth.
- Update dashboard API calls, stall-state polling, and static tests to match the single backend URL model.

## Impact
Users now configure one Reflexio backend URL via `REFLEXIO_URL`; the dashboard no longer has a separate browser-local endpoint that can drift from backend configuration.

## Validation
- `npm run lint` in `plugin/dashboard`
- `npm run build` in `plugin/dashboard`
- `uv run --project plugin pytest tests/test_dashboard_managed_reflexio.py`
- pre-commit: `uv run --project plugin pytest tests/` (382 passed)
- Browser verification at `http://localhost:3002/configure/env`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Reflexio endpoint configuration is now managed server-side. The endpoint URL is displayed in the dashboard but no longer editable—configure via environment variables instead of client-side settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->