### PR TITLE
fix: handle Claude Desktop hook publishing

### DIFF
--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -101,7 +101,6 @@ claude_smart_is_internal_invocation_env() {
     ""|"cli"|"claude-desktop") return 1 ;;
     *) return 0 ;;
   esac
-  return 1
 }
 
 claude_smart_emit_continue() {

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -97,9 +97,10 @@ claude_smart_is_internal_invocation_env() {
   if [ "${CLAUDE_SMART_INTERNAL:-}" = "1" ]; then
     return 0
   fi
-  if [ -n "${CLAUDE_CODE_ENTRYPOINT:-}" ] && [ "${CLAUDE_CODE_ENTRYPOINT:-}" != "cli" ]; then
-    return 0
-  fi
+  case "${CLAUDE_CODE_ENTRYPOINT:-}" in
+    ""|"cli"|"claude-desktop") return 1 ;;
+    *) return 0 ;;
+  esac
   return 1
 }
 

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -9,7 +9,15 @@ import time
 from pathlib import Path
 from typing import Any
 
-from claude_smart import cs_cite, env_config, ids, internal_call, publish, runtime, state
+from claude_smart import (
+    cs_cite,
+    env_config,
+    ids,
+    internal_call,
+    publish,
+    runtime,
+    state,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -362,9 +370,7 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
         if path.is_file():
             entries = _load_transcript_with_retry(path)
 
-    prompt = payload.get("prompt") or (
-        _scan_transcript_for_user_text(entries) if runtime.is_codex() else ""
-    )
+    prompt = payload.get("prompt") or _scan_transcript_for_user_text(entries)
     if runtime.is_codex() and internal_call.is_codex_internal_prompt(prompt):
         return None
 
@@ -393,13 +399,24 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
     plan_decisions = _scan_transcript_for_plan_decisions(entries)
 
     now = int(time.time())
-    for decision_text in plan_decisions:
+    if plan_decisions:
+        for decision_text in plan_decisions:
+            state.append(
+                session_id,
+                {
+                    "ts": now,
+                    "role": "User",
+                    "content": decision_text,
+                    "user_id": project_id,
+                },
+            )
+    elif prompt and not _has_unpublished_user_turn(session_id):
         state.append(
             session_id,
             {
                 "ts": now,
                 "role": "User",
-                "content": decision_text,
+                "content": prompt,
                 "user_id": project_id,
             },
         )

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -68,7 +68,26 @@ def _read_stdin_json() -> dict[str, Any]:
     except json.JSONDecodeError as exc:
         _LOGGER.debug("stdin JSON decode failed: %s", exc)
         return {}
-    return parsed if isinstance(parsed, dict) else {}
+    return _normalize_payload_keys(parsed) if isinstance(parsed, dict) else {}
+
+
+def _normalize_payload_keys(payload: dict[str, Any]) -> dict[str, Any]:
+    """Accept both classic Claude Code and Desktop/Cowork hook key shapes."""
+    aliases = {
+        "sessionId": "session_id",
+        "transcriptPath": "transcript_path",
+        "toolName": "tool_name",
+        "toolInput": "tool_input",
+        "toolResponse": "tool_response",
+        "lastAssistantMessage": "last_assistant_message",
+        "workingDirectory": "cwd",
+        "currentWorkingDirectory": "cwd",
+    }
+    normalized = dict(payload)
+    for source, target in aliases.items():
+        if target not in normalized and source in normalized:
+            normalized[target] = normalized[source]
+    return normalized
 
 
 def emit_continue() -> None:

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -163,8 +163,8 @@ def log_path() -> Path:
 
     Resolution order:
 
-    1. ``CLAUDE_SMART_HOOK_LOG`` env var — escape hatch for tests and
-       advanced users who want the log elsewhere.
+    1. ``CLAUDE_SMART_HOOK_LOG`` env var — boolean-like values enable the
+       default log, while path-like values redirect it.
     2. ``_LOG_PATH`` module attribute — what monkeypatched tests override.
     3. ``~/.claude-smart/hook.log`` — the default.
 
@@ -173,6 +173,8 @@ def log_path() -> Path:
     """
     override = os.environ.get("CLAUDE_SMART_HOOK_LOG")
     if override:
+        if override.strip().lower() in {"1", "true", "yes", "on"}:
+            return _LOG_PATH
         return Path(override)
     return _LOG_PATH
 

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -173,7 +173,10 @@ def log_path() -> Path:
     """
     override = os.environ.get("CLAUDE_SMART_HOOK_LOG")
     if override:
-        if override.strip().lower() in {"1", "true", "yes", "on"}:
+        override = override.strip()
+        if not override:
+            return _LOG_PATH
+        if override.lower() in {"1", "true", "yes", "on"}:
             return _LOG_PATH
         return Path(override)
     return _LOG_PATH

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -19,10 +19,10 @@ Two distinct sources of unwanted hook fires:
    tool..."`` into reflexio as a fake user interaction.
 
 Detection signals, OR'd:
-  - ``CLAUDE_CODE_ENTRYPOINT`` is anything other than ``"cli"`` —
-    the interactive REPL sets ``cli``; headless ``claude -p`` sets
-    ``sdk-cli`` (and the SDKs may set other values). This catches
-    case (2) for any third-party tool, not just claude-mem.
+  - ``CLAUDE_CODE_ENTRYPOINT`` is anything other than an interactive entrypoint
+    (``"cli"`` or Claude Desktop's ``"claude-desktop"``). Headless
+    ``claude -p`` sets ``sdk-cli`` (and the SDKs may set other values). This
+    catches case (2) for any third-party tool, not just claude-mem.
   - Env var ``CLAUDE_SMART_INTERNAL=1``, set by reflexio's provider
     before spawning ``claude``. Belt-and-suspenders for case (1) in
     case the entrypoint check ever misses a future SDK variant.
@@ -46,7 +46,7 @@ from typing import Any
 from claude_smart import runtime
 
 _ENTRYPOINT_VAR = "CLAUDE_CODE_ENTRYPOINT"
-_INTERACTIVE_ENTRYPOINT = "cli"
+_INTERACTIVE_ENTRYPOINTS = frozenset({"cli", "claude-desktop"})
 _CODEX_TITLE_PROMPT_PREFIX = (
     "You are a helpful assistant. You will be presented with a user prompt, "
     "and your job is to provide a short title for a task"
@@ -92,7 +92,7 @@ def is_internal_invocation(payload: dict[str, Any]) -> bool:
     if runtime.is_internal_invocation_env():
         return True
     entrypoint = os.environ.get(_ENTRYPOINT_VAR)
-    if entrypoint and entrypoint != _INTERACTIVE_ENTRYPOINT:
+    if entrypoint and entrypoint not in _INTERACTIVE_ENTRYPOINTS:
         return True
     if runtime.is_codex() and is_codex_internal_prompt(payload.get("prompt")):
         return True

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -13,11 +13,13 @@
 #      ~/.reflexio/.env so reflexio runs without any external API key.
 #   6. For Claude Code (default): prepare and register the local marketplace
 #      (user scope) so `claude-smart@reflexioai-local` is available everywhere.
-#   7. For Claude Code: wire this repo's .claude/settings.local.json to enable
+#   7. For Claude Code: disable the published claude-smart plugin at user scope
+#      so Desktop/other projects don't load both plugins side by side.
+#   8. For Claude Code: wire this repo's .claude/settings.local.json to enable
 #      the local plugin and shadow the remote one for this project.
-#   8. With `--read-only`, write CLAUDE_SMART_READ_ONLY=1 so local hooks
+#   9. With `--read-only`, write CLAUDE_SMART_READ_ONLY=1 so local hooks
 #      buffer but do not publish interactions to Reflexio.
-#   9. For Codex (`--host codex` or `--host both`): run the maintained
+#   10. For Codex (`--host codex` or `--host both`): run the maintained
 #      Node install wrapper so Codex hooks are patched through the JSON-safe
 #      codex-hook.js adapter.
 #
@@ -292,6 +294,46 @@ PY
         exit 1
       fi
     fi
+
+    # `claude plugin disable -s user claude-smart@reflexioai` can be ambiguous
+    # when both local and published marketplaces provide a plugin named
+    # `claude-smart`. Write the user-scope enable map directly so Desktop and
+    # non-repo Claude Code sessions don't load both copies.
+    USER_SETTINGS_FILE="$HOME/.claude/settings.json"
+    python3 - "$USER_SETTINGS_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+data: dict = {}
+if settings_path.is_file():
+    try:
+        data = json.loads(settings_path.read_text() or "{}")
+    except json.JSONDecodeError:
+        print(
+            f"[setup-local-dev] ERROR: {settings_path} is not valid JSON; "
+            "refusing to overwrite",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+if not isinstance(data, dict):
+    print(
+        f"[setup-local-dev] ERROR: {settings_path} top-level is not a JSON object",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+enabled = data.setdefault("enabledPlugins", {})
+enabled["claude-smart@reflexioai-local"] = True
+enabled["claude-smart@reflexioai"] = False
+
+settings_path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+    log "wrote $USER_SETTINGS_FILE (user-scope local enabled, @reflexioai disabled)"
   else
     log "WARNING: 'claude' CLI not on PATH — skipping marketplace registration."
     log "  Run it later: claude plugin marketplace add $LOCAL_MKT_DIR"

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -327,7 +327,10 @@ if not isinstance(data, dict):
     )
     sys.exit(1)
 
-enabled = data.setdefault("enabledPlugins", {})
+enabled = data.get("enabledPlugins")
+if not isinstance(enabled, dict):
+    data["enabledPlugins"] = {}
+    enabled = data["enabledPlugins"]
 enabled["claude-smart@reflexioai-local"] = True
 enabled["claude-smart@reflexioai"] = False
 
@@ -372,7 +375,10 @@ if not isinstance(data, dict):
     )
     sys.exit(1)
 
-enabled = data.setdefault("enabledPlugins", {})
+enabled = data.get("enabledPlugins")
+if not isinstance(enabled, dict):
+    data["enabledPlugins"] = {}
+    enabled = data["enabledPlugins"]
 enabled["claude-smart@reflexioai-local"] = True
 # Shadow the remote so both don't load side-by-side in this repo.
 enabled["claude-smart@reflexioai"] = False

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -235,6 +235,60 @@ def test_stop_appends_assistant_text_from_transcript(
     assert records[-1]["content"] == "hello there"
 
 
+def test_stop_recovers_user_turn_when_prompt_hook_did_not_fire(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {"type": "user", "message": {"content": "remember I prefer km"}},
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "Noted."}]},
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished",
+        lambda **_: ("nothing", 0),
+    )
+    stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
+    records = state.read_all("s1")
+    assert [record["role"] for record in records] == ["User", "Assistant"]
+    assert records[0]["content"] == "remember I prefer km"
+    assert records[1]["content"] == "Noted."
+
+
+def test_stop_does_not_duplicate_existing_unpublished_user_turn(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    state.append(
+        "s1",
+        {
+            "role": "User",
+            "content": "already buffered",
+            "user_id": "project",
+        },
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {"type": "user", "message": {"content": "already buffered"}},
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "Done."}]},
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished",
+        lambda **_: ("nothing", 0),
+    )
+    stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
+    records = state.read_all("s1")
+    assert [record["role"] for record in records] == ["User", "Assistant"]
+
+
 def test_stop_concatenates_text_across_multi_entry_assistant_turn(
     session_dir, tmp_path, monkeypatch
 ) -> None:
@@ -588,7 +642,8 @@ def test_stop_plan_decision_ignores_prior_turn(
     )
     stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
     records = state.read_all("s1")
-    assert [r["role"] for r in records] == ["Assistant"]
+    assert [r["role"] for r in records] == ["User", "Assistant"]
+    assert records[0]["content"] == "follow-up, no plan"
 
 
 def test_stop_plan_decision_ignores_non_exitplanmode_tool_result_with_marker_text(
@@ -638,8 +693,9 @@ def test_stop_plan_decision_ignores_non_exitplanmode_tool_result_with_marker_tex
     )
     stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
     records = state.read_all("s1")
-    # Only the Assistant record should be appended — no synthetic User turn.
-    assert [r["role"] for r in records] == ["Assistant"]
+    # No plan-decision record should be appended; only the recovered prompt.
+    assert [r["role"] for r in records] == ["User", "Assistant"]
+    assert records[0]["content"] == "do thing"
 
 
 def test_stop_exit_plan_mode_plan_interleaves_with_text_blocks_in_order(
@@ -755,7 +811,9 @@ def test_stop_read_only_marks_buffer_without_publishing(
 
     monkeypatch.setattr("claude_smart.publish.publish_unpublished", fail_publish)
 
-    result = stop.handle({"session_id": "s_read_only", "transcript_path": str(transcript)})
+    result = stop.handle(
+        {"session_id": "s_read_only", "transcript_path": str(transcript)}
+    )
 
     assert result == ("nothing", 0)
     records = state.read_all("s_read_only")
@@ -1156,8 +1214,7 @@ def test_stop_preserves_cited_item_source_kind(
                         {
                             "type": "text",
                             "text": (
-                                "Done.\n\n"
-                                "✨ 1 claude-smart learning applied [cs:s1-42]"
+                                "Done.\n\n✨ 1 claude-smart learning applied [cs:s1-42]"
                             ),
                         }
                     ]
@@ -1339,8 +1396,7 @@ def test_stop_citation_without_prior_registry_drops_all_ids(
                         {
                             "type": "text",
                             "text": (
-                                "Done.\n\n"
-                                "✨ 1 claude-smart learning applied [cs:s1-42]"
+                                "Done.\n\n✨ 1 claude-smart learning applied [cs:s1-42]"
                             ),
                         }
                     ]
@@ -1797,7 +1853,7 @@ def test_session_end_uses_force_extraction_for_final_flush(
     published_kwargs: dict[str, Any] = {}
     monkeypatch.setattr(
         "claude_smart.publish.publish_unpublished",
-        lambda **kwargs: (published_kwargs.update(kwargs) or ("ok", 1)),
+        lambda **kwargs: published_kwargs.update(kwargs) or ("ok", 1),
     )
     session_end.handle({"session_id": "s_force", "cwd": "/tmp/p"})
     assert published_kwargs["force_extraction"] is True

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -27,11 +27,7 @@ def hook_log_path(tmp_path, monkeypatch) -> Path:
 def _read_lines(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
-    return [
-        json.loads(line)
-        for line in path.read_text().splitlines()
-        if line.strip()
-    ]
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
 
 
 # -----------------------------------------------------------------------------
@@ -116,6 +112,12 @@ def test_log_path_honors_env_override(tmp_path, monkeypatch) -> None:
     assert _read_lines(target)[0]["event"] == "stop"
 
 
+def test_log_path_treats_boolean_env_as_default(hook_log_path, monkeypatch) -> None:
+    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", "1")
+    hook_log.log_event(event="stop", host="claude-code")
+    assert _read_lines(hook_log_path)[0]["event"] == "stop"
+
+
 # -----------------------------------------------------------------------------
 # hook.main dispatcher → log records
 # -----------------------------------------------------------------------------
@@ -182,6 +184,40 @@ def test_dispatcher_logs_publish_outcome_from_stop(
     assert rec["handler_status"] == "ok"
     assert rec["publish_status"] == "ok"
     assert rec["publish_count"] == 3
+
+
+def test_dispatcher_normalizes_desktop_payload_keys(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def stop_ok(payload: dict[str, Any]) -> tuple[str, int]:
+        seen.update(payload)
+        return ("ok", 1)
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_ok})
+    stdin_payload(
+        {
+            "sessionId": "s_desktop",
+            "transcriptPath": "/tmp/transcript.jsonl",
+            "toolName": "Bash",
+            "toolInput": {"command": "pytest"},
+            "toolResponse": {"ok": True},
+            "lastAssistantMessage": "done",
+            "workingDirectory": "/tmp/project",
+        }
+    )
+    hook.main(["claude-code", "stop"])
+
+    assert seen["session_id"] == "s_desktop"
+    assert seen["transcript_path"] == "/tmp/transcript.jsonl"
+    assert seen["tool_name"] == "Bash"
+    assert seen["tool_input"] == {"command": "pytest"}
+    assert seen["tool_response"] == {"ok": True}
+    assert seen["last_assistant_message"] == "done"
+    assert seen["cwd"] == "/tmp/project"
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["session_id"] == "s_desktop"
 
 
 def test_dispatcher_logs_nothing_publish_status(
@@ -333,9 +369,7 @@ def test_log_rotates_when_over_max_bytes(hook_log_path, monkeypatch) -> None:
     assert "sess-0000" not in session_ids
 
 
-def test_log_does_not_rotate_when_under_max_bytes(
-    hook_log_path, monkeypatch
-) -> None:
+def test_log_does_not_rotate_when_under_max_bytes(hook_log_path, monkeypatch) -> None:
     """A single small record never triggers rotation; bytes are byte-stable
     across subsequent reads."""
     monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", 5 * 1024 * 1024)
@@ -351,9 +385,7 @@ def test_log_does_not_rotate_when_under_max_bytes(
     assert _read_lines(hook_log_path) == snapshot_records
 
 
-def test_log_rotation_preserves_jsonl_framing(
-    hook_log_path, monkeypatch
-) -> None:
+def test_log_rotation_preserves_jsonl_framing(hook_log_path, monkeypatch) -> None:
     """After rotation, every surviving line parses as JSON — no record is
     split mid-byte by the cut."""
     monkeypatch.setattr(hook_log, "_MAX_LOG_BYTES", 400)
@@ -375,9 +407,7 @@ def test_log_rotation_preserves_jsonl_framing(
         assert parsed["event"] == "user-prompt"
 
 
-def test_log_rotation_tolerates_read_failure(
-    hook_log_path, monkeypatch
-) -> None:
+def test_log_rotation_tolerates_read_failure(hook_log_path, monkeypatch) -> None:
     """If the rotation read fails (disk error, EACCES, etc.) ``log_event``
     must still return cleanly — hook fires are never aborted by logging."""
     # Prime the file at the default (large) cap so the prime write itself

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from claude_smart import hook, hook_log
 
 
@@ -112,10 +111,21 @@ def test_log_path_honors_env_override(tmp_path, monkeypatch) -> None:
     assert _read_lines(target)[0]["event"] == "stop"
 
 
-def test_log_path_treats_boolean_env_as_default(hook_log_path, monkeypatch) -> None:
-    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", "1")
+@pytest.mark.parametrize("raw", ["1", "true", "TRUE", " yes ", "On", "  "])
+def test_log_path_treats_boolean_env_as_default(
+    hook_log_path, monkeypatch, raw: str
+) -> None:
+    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", raw)
     hook_log.log_event(event="stop", host="claude-code")
     assert _read_lines(hook_log_path)[0]["event"] == "stop"
+
+
+def test_log_path_trims_env_override_path(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "override.log"
+    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", f"  {target}  ")
+    hook_log.log_event(event="stop", host="claude-code")
+    assert target.is_file()
+    assert _read_lines(target)[0]["event"] == "stop"
 
 
 # -----------------------------------------------------------------------------
@@ -186,8 +196,9 @@ def test_dispatcher_logs_publish_outcome_from_stop(
     assert rec["publish_count"] == 3
 
 
+@pytest.mark.parametrize("cwd_key", ["workingDirectory", "currentWorkingDirectory"])
 def test_dispatcher_normalizes_desktop_payload_keys(
-    hook_log_path, stdin_payload, monkeypatch
+    hook_log_path, stdin_payload, monkeypatch, cwd_key: str
 ) -> None:
     seen: dict[str, Any] = {}
 
@@ -204,7 +215,7 @@ def test_dispatcher_normalizes_desktop_payload_keys(
             "toolInput": {"command": "pytest"},
             "toolResponse": {"ok": True},
             "lastAssistantMessage": "done",
-            "workingDirectory": "/tmp/project",
+            cwd_key: "/tmp/project",
         }
     )
     hook.main(["claude-code", "stop"])

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -594,6 +594,8 @@ def test_setup_local_dev_refreshes_claude_code_local_plugin() -> None:
     assert "CLAUDE_SMART_READ_ONLY" in script
     assert "node bin/claude-smart.js install --host codex --read-only" in script
     assert 'USER_SETTINGS_FILE="$HOME/.claude/settings.json"' in script
+    assert 'enabled = data.get("enabledPlugins")' in script
+    assert 'data["enabledPlugins"] = {}' in script
     assert 'enabled["claude-smart@reflexioai-local"] = True' in script
     assert 'enabled["claude-smart@reflexioai"] = False' in script
     assert "user-scope local enabled, @reflexioai disabled" in script

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -284,8 +284,7 @@ def test_reflexio_env_file_overrides_stale_managed_process_env(
     env_path = tmp_path / ".reflexio" / ".env"
     env_path.parent.mkdir()
     env_path.write_text(
-        'REFLEXIO_URL="https://www.reflexio.ai/"\n'
-        'REFLEXIO_API_KEY="rflx-file-secret"\n'
+        'REFLEXIO_URL="https://www.reflexio.ai/"\nREFLEXIO_API_KEY="rflx-file-secret"\n'
     )
 
     script = (
@@ -357,12 +356,7 @@ def test_node_install_api_key_writes_env_and_bootstraps_latest_cache(
         pytest.skip("node is required for Node installer test")
 
     cache_root = (
-        tmp_path
-        / ".claude"
-        / "plugins"
-        / "cache"
-        / "reflexioai"
-        / "claude-smart"
+        tmp_path / ".claude" / "plugins" / "cache" / "reflexioai" / "claude-smart"
     )
     for version in ("0.2.31", "0.2.32"):
         plugin_root = cache_root / version
@@ -374,7 +368,7 @@ def test_node_install_api_key_writes_env_and_bootstraps_latest_cache(
             "#!/bin/sh\n"
             '[ "$CLAUDE_SMART_MANAGED_SETUP" = "1" ] || exit 41\n'
             '[ "$REFLEXIO_API_KEY" = "rflx-test-secret" ] || exit 42\n'
-            'printf \'bootstrapped %s\\n\' "$PWD"\n'
+            "printf 'bootstrapped %s\\n' \"$PWD\"\n"
         )
         install.chmod(install.stat().st_mode | stat.S_IXUSR)
 
@@ -387,9 +381,7 @@ def test_node_install_api_key_writes_env_and_bootstraps_latest_cache(
     fake_bin.mkdir()
     claude = fake_bin / "claude"
     claude.write_text(
-        "#!/bin/sh\n"
-        "printf 'claude %s\\n' \"$*\" >> \"$HOME/claude.log\"\n"
-        "exit 0\n"
+        '#!/bin/sh\nprintf \'claude %s\\n\' "$*" >> "$HOME/claude.log"\nexit 0\n'
     )
     claude.chmod(claude.stat().st_mode | stat.S_IXUSR)
 
@@ -498,9 +490,7 @@ def test_node_update_api_key_writes_managed_env(tmp_path: Path) -> None:
     fake_bin.mkdir()
     claude = fake_bin / "claude"
     claude.write_text(
-        "#!/bin/sh\n"
-        "printf 'claude %s\\n' \"$*\" >> \"$HOME/claude.log\"\n"
-        "exit 0\n"
+        '#!/bin/sh\nprintf \'claude %s\\n\' "$*" >> "$HOME/claude.log"\nexit 0\n'
     )
     claude.chmod(claude.stat().st_mode | stat.S_IXUSR)
 
@@ -588,6 +578,7 @@ def test_service_start_scripts_guard_internal_invocations() -> None:
 
     assert "claude_smart_is_internal_invocation_env()" in lib
     assert "CLAUDE_CODE_ENTRYPOINT" in lib
+    assert '"cli"|"claude-desktop"' in lib
     assert "if claude_smart_is_internal_invocation_env; then" in hook_entry
     assert "if claude_smart_is_internal_invocation_env; then" in backend
     assert "if claude_smart_is_internal_invocation_env; then" in dashboard
@@ -602,6 +593,10 @@ def test_setup_local_dev_refreshes_claude_code_local_plugin() -> None:
     assert "--read-only" in script
     assert "CLAUDE_SMART_READ_ONLY" in script
     assert "node bin/claude-smart.js install --host codex --read-only" in script
+    assert 'USER_SETTINGS_FILE="$HOME/.claude/settings.json"' in script
+    assert 'enabled["claude-smart@reflexioai-local"] = True' in script
+    assert 'enabled["claude-smart@reflexioai"] = False' in script
+    assert "user-scope local enabled, @reflexioai disabled" in script
 
 
 def test_setup_local_dev_prefers_workspace_reflexio_checkout() -> None:

--- a/tests/test_internal_call.py
+++ b/tests/test_internal_call.py
@@ -95,6 +95,14 @@ def test_returns_false_for_interactive_entrypoint(
     assert is_internal_invocation({}) is False
 
 
+def test_returns_false_for_desktop_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CLAUDE_SMART_INTERNAL", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "claude-desktop")
+    assert is_internal_invocation({}) is False
+
+
 def test_returns_true_for_codex_title_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CLAUDE_SMART_INTERNAL", raising=False)
     runtime.set_host(runtime.HOST_CODEX)


### PR DESCRIPTION
## Summary
- Treat Claude Desktop hook payload keys and entrypoint as interactive so hooks are handled instead of skipped
- Recover the user prompt from Stop transcripts when UserPromptSubmit did not fire, without duplicating already-buffered user turns
- Make CLAUDE_SMART_HOOK_LOG=1 use the default hook log path and disable the published plugin in local-dev setup

## Validation
- uv run --project plugin ruff format --check plugin/src/claude_smart/events/stop.py plugin/src/claude_smart/hook.py plugin/src/claude_smart/hook_log.py plugin/src/claude_smart/internal_call.py tests/test_events.py tests/test_hook_log.py tests/test_install_scripts.py tests/test_internal_call.py
- uv run --project plugin pytest -c plugin/pyproject.toml tests/test_internal_call.py tests/test_install_scripts.py tests/test_hook_log.py tests/test_events.py -q

## Note
- Broad `uv run --project plugin ruff check plugin/src tests` currently reports existing repository-wide lint debt outside this patch scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader desktop/interactive entrypoint handling for improved compatibility

* **Bug Fixes**
  * Normalize incoming payload keys for consistent field mapping
  * Recover missing user prompts from transcripts to avoid dropped turns
  * Fix internal-invocation detection for desktop-style environments

* **Improvements**
  * Safer local development setup for enabling a local plugin without conflicts
  * More flexible logging configuration accepting boolean-like and path values

* **Tests**
  * Added and updated tests covering the above behaviors and regressions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->