### PR TITLE
[codex] Refresh local-dev marketplace registration

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -311,11 +311,12 @@ Idempotent. This single script handles the shared local-dev prep for every host 
 2. Uncomments `[tool.uv.sources]` in `plugin/pyproject.toml` (absolute path to the submodule) and hides the divergence with `git update-index --skip-worktree`.
 3. `uv sync` in `plugin/`.
 4. Appends `CLAUDE_SMART_USE_LOCAL_CLI=1` and `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` to `~/.reflexio/.env`.
-5. For `--host claude-code` (the default), prepares and registers the local marketplace (`local-marketplace/`, manifest name `reflexioai-local`) at user scope via `claude plugin marketplace add`.
+5. For `--host claude-code` (the default), prepares and refreshes the local marketplace (`local-marketplace/`, manifest name `reflexioai-local`) at user scope by replacing any stale `reflexioai-local` registration before running `claude plugin marketplace add`.
 6. For `--host claude-code`, writes `.claude/settings.local.json` → enable `claude-smart@reflexioai-local`, disable `claude-smart@reflexioai`.
 7. For `--host claude-code`, force-sets `~/.reflexio/plugin-root` → `plugin/` so slash commands resolve to editable in-repo sources.
 8. For `--host codex`, runs `node bin/claude-smart.js install --host codex` so the installed Codex hooks are patched through the JSON-safe `scripts/codex-hook.js` adapter.
-9. Refreshes the local dashboard process. The dashboard health endpoint exposes the serving plugin root, so setup can stop a stale claude-smart dashboard from an older cache while leaving a foreign app on port `3001` alone.
+9. For `--host both`, force-sets `~/.reflexio/plugin-root` back to editable `plugin/` after the Codex install step, since the Codex installer may point it at the copied cache.
+10. Refreshes the local dashboard process. The dashboard health endpoint exposes the serving plugin root, so setup can stop a stale claude-smart dashboard from an older cache while leaving a foreign app on port `3001` alone.
 
 Then restart the target host. In a new Claude Code session, `/plugin` should show `claude-smart@reflexioai-local` and should not also show the published `claude-smart@reflexioai`. In Codex, `/plugins` should show `claude-smart` installed from the **ReflexioAI** marketplace.
 

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -102,6 +102,16 @@ refresh_local_dashboard() {
   bash "$PLUGIN_ROOT/scripts/dashboard-service.sh" start >/dev/null 2>&1 || true
 }
 
+force_plugin_root_to_checkout() {
+  # Force-point ~/.reflexio/plugin-root at this repo's plugin/ so slash
+  # commands resolve to editable in-repo sources (not a marketplace cache).
+  # SessionStart's non-force self-heal will respect this link.
+  if ! bash "$PLUGIN_ROOT/scripts/ensure-plugin-root.sh" "$PLUGIN_ROOT" --force; then
+    log "WARNING: ensure-plugin-root failed; rerun manually:"
+    log "  bash $PLUGIN_ROOT/scripts/ensure-plugin-root.sh $PLUGIN_ROOT --force"
+  fi
+}
+
 usage() {
   cat >&2 <<'EOF'
 Usage: scripts/setup-local-dev.sh [--host claude-code|codex|both] [--read-only]
@@ -266,18 +276,22 @@ PY
   ln -sfn "$PLUGIN_ROOT" "$LOCAL_MKT_DIR/plugin"
 
   if command -v claude >/dev/null 2>&1; then
-    log "registering local marketplace with Claude Code..."
-    marketplace_list="$(claude plugin marketplace list 2>/dev/null || true)"
-    if printf '%s\n' "$marketplace_list" | grep -Fq "reflexioai-local" || printf '%s\n' "$marketplace_list" | grep -Fq "$LOCAL_MKT_DIR"; then
-      log "  reflexioai-local already registered"
+    log "refreshing local marketplace registration with Claude Code..."
+    # Local-dev marketplaces are worktree-sensitive. Always replace the
+    # registration so rerunning setup from one worktree cannot keep a stale
+    # reflexioai-local source from another worktree.
+    if remove_output="$(claude plugin marketplace remove reflexioai-local 2>&1)"; then
+      log "  removed existing reflexioai-local marketplace"
     else
-      if add_output="$(claude plugin marketplace add "$LOCAL_MKT_DIR" 2>&1)"; then
-        log "  added reflexioai-local → $LOCAL_MKT_DIR"
-      else
-        log "ERROR: failed to register reflexioai-local marketplace"
-        log "  $add_output"
-        exit 1
-      fi
+      log "  no existing reflexioai-local marketplace to replace"
+      log "  remove output: $remove_output"
+    fi
+    if add_output="$(claude plugin marketplace add "$LOCAL_MKT_DIR" 2>&1)"; then
+      log "  added reflexioai-local → $LOCAL_MKT_DIR"
+    else
+      log "ERROR: failed to register reflexioai-local marketplace"
+      log "  $add_output"
+      exit 1
     fi
 
     log "installing/updating claude-smart@reflexioai-local for Claude Code..."
@@ -387,16 +401,10 @@ settings_path.write_text(json.dumps(data, indent=2) + "\n")
 PY
   log "wrote $SETTINGS_FILE (claude-smart@reflexioai-local enabled, @reflexioai shadowed off)"
 
-  # Force-point ~/.reflexio/plugin-root at this repo's plugin/ so slash
-  # commands resolve to editable in-repo sources (not the marketplace
-  # cache). SessionStart's non-force self-heal will respect this link.
   # Warn (don't abort) on failure — marketplace registration and settings
   # have already been committed by this point, so aborting would leave the
   # user in a half-configured state.
-  if ! bash "$PLUGIN_ROOT/scripts/ensure-plugin-root.sh" "$PLUGIN_ROOT" --force; then
-    log "WARNING: ensure-plugin-root failed; rerun manually:"
-    log "  bash $PLUGIN_ROOT/scripts/ensure-plugin-root.sh $PLUGIN_ROOT --force"
-  fi
+  force_plugin_root_to_checkout
 fi
 
 if [ "$SETUP_CODEX" = "1" ]; then
@@ -416,6 +424,11 @@ if [ "$SETUP_CODEX" = "1" ]; then
   else
     (cd "$REPO_ROOT" && node bin/claude-smart.js install --host codex)
   fi
+fi
+
+if [ "$SETUP_CLAUDE_CODE" = "1" ] && [ "$SETUP_CODEX" = "1" ]; then
+  log "restoring plugin-root to editable checkout after Codex install..."
+  force_plugin_root_to_checkout
 fi
 
 refresh_local_dashboard


### PR DESCRIPTION
## Summary
- refresh `reflexioai-local` marketplace registration on every local-dev Claude Code setup
- restore `~/.reflexio/plugin-root` back to the editable checkout after `--host both` runs the Codex installer
- document the updated local-dev behavior

## Why
`setup-local-dev.sh` treated a marketplace name match as sufficient. If `reflexioai-local` was already registered from another worktree, rerunning setup from the current worktree left Claude Code pointed at stale plugin sources.

With `--host both`, the Codex installer can also repoint `plugin-root` to the copied Codex cache. Local-dev Claude Code should finish with `plugin-root` resolving to the editable checkout.

## Validation
- `bash -n scripts/setup-local-dev.sh`
- `git diff --check`
- `bash open_source/claude-smart/scripts/setup-local-dev.sh --host both` from the enterprise worktree
- verified `reflexioai-local` source path, Codex hook files, and `~/.reflexio/plugin-root`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local development setup documentation with improved clarity on marketplace registration and plugin linking procedures.

* **Chores**
  * Improved setup script robustness by refining plugin registration strategy and ensuring proper plugin-root restoration across different installation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->