### PR TITLE
Fix Windows subprocess resolution

### DIFF
--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -30,6 +30,7 @@ import shutil
 import subprocess
 import sys
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -82,6 +83,7 @@ _LOCAL_DATA_NOTICE = (
     "  rm -rf ~/.claude-smart ~/.reflexio\n"
 )
 _INSTALL_FAILURE_MARKER = _STATE_DIR / "install-failed"
+_SERVICE_STATUS_PROBE_FAILED = "probe_failed"
 _DEFAULT_STORAGE_ROOT = _REFLEXIO_DIR / "data"
 _REFLEXIO_CONFIG_PATH = _REFLEXIO_DIR / "configs" / "config_self-host-org.json"
 _LOCAL_STORAGE_ENV = "LOCAL_STORAGE_PATH"
@@ -106,6 +108,94 @@ _COPYTREE_IGNORE = shutil.ignore_patterns(
     ".next",
     "node_modules",
 )
+
+
+def _windows_path_text(path: str) -> str:
+    """Normalize slashes/case for Windows path checks."""
+    return path.replace("/", "\\").lower()
+
+
+_WINDOWS_SYSTEM_BASH_SUFFIXES = (
+    "\\windows\\system32\\bash.exe",
+    "\\windows\\sysnative\\bash.exe",
+    "\\windows\\syswow64\\bash.exe",
+)
+
+
+def _is_windows_system_bash(path: str) -> bool:
+    normalized = _windows_path_text(path)
+    return normalized.endswith(_WINDOWS_SYSTEM_BASH_SUFFIXES)
+
+
+def _resolve_candidate(candidate: str) -> str | None:
+    expanded = os.path.expandvars(os.path.expanduser(candidate))
+    if os.path.isfile(expanded):
+        return expanded
+    return shutil.which(expanded)
+
+
+def _iter_path_candidates(names: tuple[str, ...]) -> list[str]:
+    found: list[str] = []
+    for raw_dir in os.environ.get("PATH", "").split(os.pathsep):
+        if not raw_dir:
+            continue
+        directory = os.path.expandvars(os.path.expanduser(raw_dir))
+        for name in names:
+            candidate = os.path.join(directory, name)
+            if os.path.isfile(candidate):
+                found.append(candidate)
+    return found
+
+
+def _first_non_system_bash(candidates: Iterable[str]) -> str | None:
+    for candidate in candidates:
+        resolved = _resolve_candidate(candidate)
+        if resolved and not _is_windows_system_bash(resolved):
+            return resolved
+    return None
+
+
+def _resolve_bash() -> str | None:
+    """Resolve a bash executable suitable for running bundled shell scripts.
+
+    Returns:
+        Absolute path to a usable bash, or None when none is available.
+        On Windows, the WSL stub under ``\\Windows\\System32`` (and the
+        ``Sysnative`` / ``SysWOW64`` redirectors) is rejected so that bundled
+        ``*.sh`` scripts run under Git-Bash instead.
+    """
+    if os.name != "nt":
+        return shutil.which("bash")
+
+    sources: list[Iterable[str]] = []
+    bash_env = os.environ.get("BASH", "").strip()
+    if bash_env:
+        sources.append((bash_env,))
+    sources.append(
+        (
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        )
+    )
+    sources.append(_iter_path_candidates(("bash.exe", "bash")))
+    sources.append(("bash.exe", "bash"))
+
+    for source in sources:
+        resolved = _first_non_system_bash(source)
+        if resolved:
+            return resolved
+    return None
+
+
+def _resolve_npm() -> str | None:
+    """Resolve npm, accounting for Windows .cmd/.exe shims."""
+    if os.name == "nt":
+        for candidate in ("npm.cmd", "npm.exe", "npm"):
+            resolved = shutil.which(candidate)
+            if resolved:
+                return resolved
+        return None
+    return shutil.which("npm")
 
 
 def _latest_session_id() -> str | None:
@@ -201,7 +291,7 @@ def _bootstrap_claude_code_install() -> tuple[bool, str]:
         _force_plugin_root(plugin_root)
     except OSError as exc:
         return False, str(exc)
-    bash = shutil.which("bash")
+    bash = _resolve_bash()
     if not bash:
         return False, "bash is required to bootstrap claude-smart dependencies"
     result = subprocess.run(
@@ -1251,8 +1341,12 @@ def _run_service(script: Path, subcmd: str) -> int:
     if not script.exists():
         sys.stderr.write(f"error: {script} not found\n")
         return 1
+    bash = _resolve_bash()
+    if not bash:
+        sys.stderr.write("error: bash is required to run claude-smart service scripts\n")
+        return 1
     try:
-        subprocess.run([str(script), subcmd], check=True)
+        subprocess.run([bash, str(script), subcmd], check=True)
         return 0
     except subprocess.CalledProcessError as exc:
         return exc.returncode or 1
@@ -1277,10 +1371,16 @@ def _service_status(script: Path, wait_ready_s: float = 3.0) -> str:
     """
     if not script.exists():
         return "script missing"
+    bash = _resolve_bash()
+    if not bash:
+        return _SERVICE_STATUS_PROBE_FAILED
     deadline = time.monotonic() + wait_ready_s
     while True:
         result = subprocess.run(
-            [str(script), "status"], capture_output=True, text=True, check=False
+            [bash, str(script), "status"],
+            capture_output=True,
+            text=True,
+            check=False,
         )
         status = result.stdout.strip() or "unknown"
         if status != "not running" or time.monotonic() >= deadline:
@@ -1303,6 +1403,10 @@ class _ClearAllTarget:
 
 def _is_running_status(status: str) -> bool:
     return status.startswith("running on ")
+
+
+def _is_confirmed_stopped_status(status: str) -> bool:
+    return status == "not running"
 
 
 def _read_dotenv_value(env_path: Path, key: str) -> str | None:
@@ -1536,15 +1640,15 @@ def cmd_restart(args: argparse.Namespace) -> int:
             sys.stderr.write(
                 f"warning: dashboard dir {_DASHBOARD_DIR} missing; skipping rebuild\n"
             )
-        elif not shutil.which("npm"):
+        elif not (npm := _resolve_npm()):
             sys.stderr.write("warning: npm not on PATH; serving previous build\n")
         else:
             next_bin = _DASHBOARD_DIR / "node_modules" / ".bin" / "next"
             if not next_bin.exists():
                 install_cmd = (
-                    ["npm", "ci", "--no-audit", "--no-fund"]
+                    [npm, "ci", "--no-audit", "--no-fund"]
                     if (_DASHBOARD_DIR / "package-lock.json").exists()
-                    else ["npm", "install", "--no-audit", "--no-fund"]
+                    else [npm, "install", "--no-audit", "--no-fund"]
                 )
                 install_label = " ".join(install_cmd)
                 sys.stdout.write(
@@ -1573,10 +1677,11 @@ def cmd_restart(args: argparse.Namespace) -> int:
                 "Rebuilding dashboard (npm run build, may take a minute)…\n"
             )
             try:
-                subprocess.run(["npm", "run", "build"], cwd=_DASHBOARD_DIR, check=True)
-            except subprocess.CalledProcessError as exc:
+                subprocess.run([npm, "run", "build"], cwd=_DASHBOARD_DIR, check=True)
+            except (subprocess.CalledProcessError, OSError) as exc:
+                returncode = getattr(exc, "returncode", 1) or 1
                 sys.stderr.write(
-                    f"error: dashboard build failed (exit {exc.returncode}); "
+                    f"error: dashboard build failed (exit {returncode}); "
                     "not starting dashboard.\n"
                 )
                 if do_backend:
@@ -1585,7 +1690,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
                     sys.stdout.write(
                         f"reflexio backend: {_service_status(_BACKEND_SCRIPT)}\n"
                     )
-                return exc.returncode or 1
+                return returncode
 
     start_rc = 0
     if do_backend:
@@ -1643,7 +1748,14 @@ def cmd_clear_all(args: argparse.Namespace) -> int:
         )
         return 1
 
-    was_running = _is_running_status(_service_status(_BACKEND_SCRIPT, wait_ready_s=0.0))
+    initial_status = _service_status(_BACKEND_SCRIPT, wait_ready_s=0.0)
+    was_running = _is_running_status(initial_status)
+    if not was_running and not _is_confirmed_stopped_status(initial_status):
+        sys.stderr.write(
+            "error: could not confirm reflexio backend is stopped "
+            f"({initial_status}); aborting without deleting data\n"
+        )
+        return 1
     if was_running:
         sys.stdout.write("Stopping reflexio backend…\n")
         stop_rc = _run_service(_BACKEND_SCRIPT, "stop")
@@ -1657,6 +1769,12 @@ def cmd_clear_all(args: argparse.Namespace) -> int:
             sys.stderr.write(
                 "error: reflexio backend is still running after stop; "
                 "aborting without deleting data\n"
+            )
+            return 1
+        if not _is_confirmed_stopped_status(stopped_status):
+            sys.stderr.write(
+                "error: could not confirm reflexio backend stopped "
+                f"({stopped_status}); aborting without deleting data\n"
             )
             return 1
 

--- a/tests/test_cli_clear_all.py
+++ b/tests/test_cli_clear_all.py
@@ -127,6 +127,34 @@ def test_clear_all_missing_storage_root_is_success(clear_all_harness, capsys) ->
     assert "nothing to wipe" in capsys.readouterr().out
 
 
+def test_service_status_returns_probe_failed_when_bash_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script = tmp_path / "backend-service.sh"
+    script.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cli, "_resolve_bash", lambda: None)
+
+    assert cli._service_status(script, wait_ready_s=0.0) == "probe_failed"
+
+
+def test_clear_all_aborts_when_initial_backend_status_probe_fails(
+    clear_all_harness, capsys
+) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    (root / "reflexio.db").write_text("db")
+    clear_all_harness["statuses"][:] = ["probe_failed"]
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 1
+    assert root.exists()
+    assert clear_all_harness["calls"] == []
+    err = capsys.readouterr().err
+    assert "could not confirm reflexio backend is stopped" in err
+    assert "probe_failed" in err
+
+
 def test_clear_all_stops_and_restarts_running_backend(clear_all_harness) -> None:
     root = clear_all_harness["storage_root"]
     root.mkdir(parents=True)
@@ -182,6 +210,27 @@ def test_clear_all_aborts_when_backend_still_running(clear_all_harness, capsys) 
     assert root.exists()
     assert clear_all_harness["calls"] == [("backend-service.sh", "stop")]
     assert "still running" in capsys.readouterr().err
+
+
+def test_clear_all_aborts_when_post_stop_status_probe_fails(
+    clear_all_harness, capsys
+) -> None:
+    root = clear_all_harness["storage_root"]
+    root.mkdir(parents=True)
+    (root / "reflexio.db").write_text("db")
+    clear_all_harness["statuses"][:] = [
+        "running on http://localhost:8071",
+        "probe_failed",
+    ]
+
+    rc = cli.cmd_clear_all(_args(yes=True))
+
+    assert rc == 1
+    assert root.exists()
+    assert clear_all_harness["calls"] == [("backend-service.sh", "stop")]
+    err = capsys.readouterr().err
+    assert "could not confirm reflexio backend stopped" in err
+    assert "probe_failed" in err
 
 
 def test_clear_all_reports_start_failure_after_wipe(

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -58,6 +58,33 @@ def test_bootstrap_claude_code_install_runs_installed_smart_install(
     assert (tmp_path / ".reflexio" / "plugin-root").resolve() == plugin_root
 
 
+def test_bootstrap_claude_code_install_runs_smart_install_via_resolved_bash(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plugin_root = _installed_plugin(tmp_path)
+    _isolate_home(monkeypatch, tmp_path)
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def fake_run(cmd, cwd=None):
+        calls.append(([str(part) for part in cmd], cwd))
+        return argparse.Namespace(returncode=0)
+
+    monkeypatch.setattr(cli, "_resolve_bash", lambda: "/bin/bash")
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    ok, message = cli._bootstrap_claude_code_install()
+
+    assert ok, message
+    assert message == str(plugin_root)
+    assert calls == [
+        (
+            ["/bin/bash", str(plugin_root / "scripts" / "smart-install.sh")],
+            plugin_root,
+        )
+    ]
+
+
 def test_bootstrap_claude_code_install_prefers_highest_cache_version(
     monkeypatch,
     tmp_path: Path,

--- a/tests/test_cli_restart.py
+++ b/tests/test_cli_restart.py
@@ -23,6 +23,67 @@ def _make_args(**overrides: Any) -> argparse.Namespace:
     return argparse.Namespace(**defaults)
 
 
+def test_resolve_bash_non_windows_uses_path_lookup(monkeypatch) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/bin/{name}")
+
+    assert cli._resolve_bash() == "/bin/bash"
+
+
+def test_resolve_npm_non_windows_uses_path_lookup(monkeypatch) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    assert cli._resolve_npm() == "/usr/bin/npm"
+
+
+def test_resolve_bash_windows_prefers_env_bash(monkeypatch, tmp_path) -> None:
+    bash = tmp_path / "Git" / "bin" / "bash.exe"
+    bash.parent.mkdir(parents=True)
+    bash.write_text("")
+    monkeypatch.setattr(cli.os, "name", "nt")
+    monkeypatch.setenv("BASH", str(bash))
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: None)
+
+    assert cli._resolve_bash() == str(bash)
+
+
+def test_resolve_bash_windows_skips_system32_bash(monkeypatch, tmp_path) -> None:
+    system32 = tmp_path / "Windows" / "System32"
+    git = tmp_path / "Git" / "bin"
+    system32.mkdir(parents=True)
+    git.mkdir(parents=True)
+    system_bash = system32 / "bash.exe"
+    git_bash = git / "bash.exe"
+    system_bash.write_text("")
+    git_bash.write_text("")
+    monkeypatch.setattr(cli.os, "name", "nt")
+    monkeypatch.delenv("BASH", raising=False)
+    monkeypatch.setenv("PATH", f"{system32}{cli.os.pathsep}{git}")
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        cli,
+        "_is_windows_system_bash",
+        lambda path: path == str(system_bash),
+    )
+
+    assert cli._resolve_bash() == str(git_bash)
+
+
+def test_resolve_npm_windows_prefers_cmd_shim(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_which(name: str) -> str | None:
+        calls.append(name)
+        return "C:/Program Files/nodejs/npm.cmd" if name == "npm.cmd" else None
+
+    monkeypatch.setattr(cli.os, "name", "nt")
+    monkeypatch.setattr(cli.shutil, "which", fake_which)
+
+    assert cli._resolve_npm() == "C:/Program Files/nodejs/npm.cmd"
+    assert calls == ["npm.cmd"]
+
+
 @pytest.fixture
 def fake_services(monkeypatch, tmp_path):
     """Stub the service scripts as existing on disk and track invocations.
@@ -49,19 +110,21 @@ def fake_services(monkeypatch, tmp_path):
 
     def fake_run(cmd, cwd=None, check=False, capture_output=False, text=False):
         argv = [str(c) for c in cmd]
-        if argv[0] == "npm":
+        if argv[0] == "/usr/bin/npm":
             build_calls.append(argv)
             return subprocess.CompletedProcess(argv, 0, "", "")
-        # Service script invocation: ``[script, subcmd]``.
-        name = argv[0].rsplit("/", 1)[-1]
-        service_calls.append((name, argv[1]))
+        # Service script invocation: ``[bash, script, subcmd]``.
+        assert argv[0] == "/bin/bash"
+        name = argv[1].rsplit("/", 1)[-1]
+        service_calls.append((name, argv[2]))
         # _service_status uses capture_output=True; return canned stdout.
         if capture_output:
             return subprocess.CompletedProcess(argv, 0, "running on http://x\n", "")
         return subprocess.CompletedProcess(argv, 0, "", "")
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
-    monkeypatch.setattr(cli.shutil, "which", lambda _name: "/usr/bin/npm")
+    monkeypatch.setattr(cli, "_resolve_bash", lambda: "/bin/bash")
+    monkeypatch.setattr(cli, "_resolve_npm", lambda: "/usr/bin/npm")
     return service_calls, build_calls
 
 
@@ -79,7 +142,7 @@ def test_restart_skips_rebuild_when_npm_missing(
 ) -> None:
     """Missing npm → log warning, skip build, still stop/start both services."""
     service_calls, build_calls = fake_services
-    monkeypatch.setattr(cli.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(cli, "_resolve_npm", lambda: None)
     rc = cli.cmd_restart(_make_args())
     assert rc == 0
     assert build_calls == []
@@ -99,14 +162,15 @@ def test_restart_starts_backend_even_when_dashboard_build_fails(
 
     def fake_run(cmd, cwd=None, check=False, capture_output=False, text=False):
         argv = [str(c) for c in cmd]
-        if argv[0] == "npm":
+        if argv[0] == "/usr/bin/npm":
             # Only the build step fails — install must succeed so we exercise
             # the build-failure recovery path, not the install-failure one.
             if argv[1:3] == ["run", "build"]:
                 raise subprocess.CalledProcessError(2, argv)
             return subprocess.CompletedProcess(argv, 0, "", "")
-        name = argv[0].rsplit("/", 1)[-1]
-        service_calls.append((name, argv[1]))
+        assert argv[0] == "/bin/bash"
+        name = argv[1].rsplit("/", 1)[-1]
+        service_calls.append((name, argv[2]))
         if capture_output:
             return subprocess.CompletedProcess(argv, 0, "running\n", "")
         return subprocess.CompletedProcess(argv, 0, "", "")
@@ -135,6 +199,47 @@ def test_restart_starts_backend_even_when_dashboard_build_fails(
     assert "reflexio backend:" in out.out
 
 
+def test_restart_starts_backend_when_dashboard_build_launch_fails(
+    fake_services, monkeypatch, capsys
+) -> None:
+    """OSError during npm launch follows the same recovery path as build failure."""
+    service_calls, _ = fake_services
+
+    def fake_run(cmd, cwd=None, check=False, capture_output=False, text=False):
+        argv = [str(c) for c in cmd]
+        if argv[0] == "/usr/bin/npm":
+            if argv[1:3] == ["run", "build"]:
+                raise OSError("npm is not executable")
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        assert argv[0] == "/bin/bash"
+        name = argv[1].rsplit("/", 1)[-1]
+        service_calls.append((name, argv[2]))
+        if capture_output:
+            return subprocess.CompletedProcess(argv, 0, "running\n", "")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    rc = cli.cmd_restart(_make_args())
+
+    assert rc == 1
+    subs = [
+        sub
+        for name, sub in service_calls
+        if name == "backend-service.sh" and sub != "status"
+    ]
+    dash_subs = [
+        sub
+        for name, sub in service_calls
+        if name == "dashboard-service.sh" and sub != "status"
+    ]
+    assert subs == ["stop", "start"]
+    assert dash_subs == ["stop"]
+    out = capsys.readouterr()
+    assert "dashboard build failed" in out.err
+    assert "reflexio backend:" in out.out
+
+
 def test_restart_no_rebuild_flag_skips_npm(fake_services) -> None:
     _, build_calls = fake_services
     rc = cli.cmd_restart(_make_args(no_rebuild=True))
@@ -147,5 +252,5 @@ def test_restart_uses_npm_ci_when_lockfile_exists(fake_services) -> None:
     (cli._DASHBOARD_DIR / "package-lock.json").write_text("{}\n")
     rc = cli.cmd_restart(_make_args())
     assert rc == 0
-    assert build_calls[0] == ["npm", "ci", "--no-audit", "--no-fund"]
-    assert build_calls[1] == ["npm", "run", "build"]
+    assert build_calls[0] == ["/usr/bin/npm", "ci", "--no-audit", "--no-fund"]
+    assert build_calls[1] == ["/usr/bin/npm", "run", "build"]


### PR DESCRIPTION
## Summary
- resolve bash explicitly before invoking bundled .sh scripts
- resolve npm.cmd/npm.exe on Windows and pass the executable path to subprocess.run
- add unit coverage for Windows resolver behavior and macOS/Linux path preservation

Closes #49

## Verification
- uv run --project plugin pytest tests/test_cli_restart.py tests/test_cli_install.py tests/test_cli_clear_all.py
- uv run --project plugin pytest tests
- uv run --project plugin claude-smart restart --no-rebuild
- uv run --project plugin claude-smart restart
- curl -fsS http://localhost:8071/health
- curl -fsSI http://localhost:3001/api/health

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform resolution of bash and npm so bundled scripts and dashboard builds run with appropriate executables on Windows and POSIX.
  * Windows now avoids System32-provided bash stubs and falls back to Git-Bash when available.
  * Clearer “bash is required” error and safer fallback when npm or build tools are missing or fail.

* **Tests**
  * Added/expanded tests covering executable resolution, install/restart flows, build failures, and recovery paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->