### PR TITLE
[codex] Fix Windows CP932 backend startup

### DIFF
--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -233,6 +233,7 @@ case "$CMD" in
     workers="${CLAUDE_SMART_BACKEND_WORKERS:-1}"
     claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
       "$LOG_FILE" "$LOG_MAX_BYTES" -- \
+      env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
       uv run --project "$PLUGIN_ROOT" --quiet \
       reflexio services start --only backend --no-reload --workers "$workers"
     svc_pid=$!

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -236,6 +236,12 @@ def test_backend_service_uses_capped_logging() -> None:
     assert '>>"$LOG_FILE"' not in service
 
 
+def test_backend_service_forces_utf8_stdio_for_managed_backend() -> None:
+    service = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+
+    assert 'env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"' in service
+
+
 def test_service_start_scripts_recover_missing_dependencies_without_cli_command() -> (
     None
 ):


### PR DESCRIPTION
## Summary

- Force UTF-8 stdio for the managed reflexio backend process by setting `PYTHONIOENCODING` only on the spawned backend command.
- Preserve explicit user overrides by using the existing environment value when present.
- Add a regression assertion covering the backend service wrapper.

## Root Cause

On Windows systems using a Japanese CP932 default code page, reflexio backend startup can crash when Python prints non-CP932 characters to stdout. Because claude-smart captures backend output through the managed service wrapper, the backend process needs UTF-8 stdio defaults even when the host locale is not UTF-8.

Closes #50

## Validation

- `bash -n plugin/scripts/backend-service.sh`
- `git diff --check`
- `uv run --project plugin pytest tests/test_install_scripts.py` — 62 passed
- `uv run --project plugin pytest` — 430 passed
