### PR TITLE
chore: replace nested reflexio submodule workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ benchmarks/memory_comparison/results
 # Local marketplace
 local-marketplace/
 
+# Generated release vendor bundle
+/plugin/vendor/
+
 # Scheduled tasks lock
 .claude/scheduled_tasks.lock
 .coverage

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "reflexio"]
-	path = reflexio
-	url = https://github.com/ReflexioAI/reflexio.git

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Technical reference for how `claude-smart` wires Claude Code's lifecycle hooks t
    - `Stop` — finalizes the assistant turn from the transcript, publishes to reflexio.
    - `SessionEnd` — flushes the remaining buffer with `force_extraction=True`.
 2. **Local state buffer** — JSONL per session at `~/.claude-smart/sessions/{session_id}.jsonl`. Offline-safe.
-3. **Reflexio backend** (`reflexio-ai` package, or a side-by-side editable checkout during local development) — SQLite storage, hybrid search, preference/skill extraction, dedup, status lifecycle (`CURRENT` → `ARCHIVED`). Runs on `localhost:8071`.
+3. **Reflexio backend** (`reflexio-ai` package, a side-by-side editable checkout during local development, or a generated `plugin/vendor/reflexio` bundle in fast npm releases) — SQLite storage, hybrid search, preference/skill extraction, dedup, status lifecycle (`CURRENT` → `ARCHIVED`). Runs on `localhost:8071`.
 4. **Local host LLM provider** — a LiteLLM custom provider registered inside reflexio. Every generation call (extraction, update, dedup, evaluation) subprocesses the active host CLI (`claude -p` under Claude Code, `codex exec` under Codex), so no OpenAI/Anthropic key is needed for the learning loop.
 
 ## Data flow

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Technical reference for how `claude-smart` wires Claude Code's lifecycle hooks t
    - `Stop` — finalizes the assistant turn from the transcript, publishes to reflexio.
    - `SessionEnd` — flushes the remaining buffer with `force_extraction=True`.
 2. **Local state buffer** — JSONL per session at `~/.claude-smart/sessions/{session_id}.jsonl`. Offline-safe.
-3. **Reflexio backend** (submodule at `reflexio/`) — SQLite storage, hybrid search, preference/skill extraction, dedup, status lifecycle (`CURRENT` → `ARCHIVED`). Runs on `localhost:8071`.
+3. **Reflexio backend** (`reflexio-ai` package, or a side-by-side editable checkout during local development) — SQLite storage, hybrid search, preference/skill extraction, dedup, status lifecycle (`CURRENT` → `ARCHIVED`). Runs on `localhost:8071`.
 4. **Local host LLM provider** — a LiteLLM custom provider registered inside reflexio. Every generation call (extraction, update, dedup, evaluation) subprocesses the active host CLI (`claude -p` under Claude Code, `codex exec` under Codex), so no OpenAI/Anthropic key is needed for the learning loop.
 
 ## Data flow

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -11,10 +11,11 @@ Internal notes for maintainers of `claude-smart`. End-user install instructions 
 | `plugin/pyproject.toml` | Python manifest — shipped to PyPI via `uv build --project plugin` |
 | `tests/` | Pytest suite for the Python package (run via `uv run --project plugin pytest tests/ -q` from repo root) |
 | `bin/claude-smart.js` | Node wrapper so `npx claude-smart install` works |
-| `package.json` | npm manifest — only ships `bin/`, `README.md`, `LICENSE` |
+| `package.json` | npm manifest — ships `bin/`, marketplace metadata, `plugin/`, `README.md`, and `LICENSE` |
 | `plugin/.claude-plugin/plugin.json` | Plugin metadata read by Claude Code |
 | `.claude-plugin/marketplace.json` | Marketplace entry — `claude plugin marketplace add` reads this |
-| `reflexio/` | Submodule — Apache 2.0, storage + search + extraction backend |
+| `reflexio.lock.json` | Reflexio provenance — records the PyPI baseline or generated vendor bundle commit |
+| `plugin/vendor/reflexio/` | Generated release-only Reflexio bundle for npm artifacts; gitignored, not committed |
 | `plugin/dashboard/` | Next.js management UI for interactions, preferences, skills, configuration |
 | `Makefile` | Release automation |
 
@@ -193,6 +194,11 @@ make release VERSION=0.1.1
 7. `publish-pypi` → `rm -rf dist/ && uv build && uv publish`.
 8. `git push --follow-tags`.
 
+For a vendor-mode Reflexio release, run `make release-npm VERSION=...` after
+`bash scripts/release-with-reflexio.sh`. The generated vendor bundle is only in
+the npm tarball; `make release` intentionally refuses to publish PyPI while
+`reflexio.lock.json` says `source=vendor`.
+
 Because publish happens **before** the push, a registry failure (e.g. auth expired) leaves the commit and tag local — you can fix the cause and re-run `make publish && git push --follow-tags` without re-bumping.
 
 ### Partial / advanced flows
@@ -210,6 +216,9 @@ git push --follow-tags
 # Only one registry (e.g. if the other published successfully and you're retrying).
 make publish-npm
 make publish-pypi
+
+# Vendor-mode Reflexio release (npm only).
+make release-npm VERSION=0.1.1
 
 # Preview without uploading anything.
 make publish-dry
@@ -234,7 +243,9 @@ Before running `make release`:
 - [ ] `README.md` reflects any user-visible changes.
 - [ ] Hook behavior, CLI flags, env vars are unchanged — or a migration note is in the README.
 - [ ] `plugin/hooks/hooks.json` and `plugin/commands/*.md` render correctly in a local Claude Code session (smoke test: install from a local `directory` marketplace, start a session, run `/show`).
-- [ ] If claude-smart needs new Reflexio behavior, `reflexio-ai` has already been published from a `v<version>` tag on Reflexio `origin/main`, and `bash scripts/release-with-reflexio.sh` has updated `plugin/pyproject.toml`, `plugin/uv.lock`, and `reflexio.lock.json`.
+- [ ] If claude-smart needs new Reflexio behavior, choose a Reflexio release mode:
+  - PyPI mode: `reflexio-ai` is published, then `REFLEXIO_RELEASE_SOURCE=pypi bash scripts/release-with-reflexio.sh` updates `plugin/pyproject.toml`, `plugin/uv.lock`, and `reflexio.lock.json`.
+  - Vendor mode: `bash scripts/release-with-reflexio.sh` generates `plugin/vendor/reflexio` and updates `reflexio.lock.json`; keep the generated vendor directory in place until npm publish completes.
 - [ ] `python scripts/check-reflexio-lock.py` passes.
 - [ ] `npm pack --dry-run --json` includes the root wrapper, marketplace metadata, plugin payload, dashboard sources, README, and LICENSE, and excludes `.venv`, `node_modules`, `.next/cache`, and Python caches.
 - [ ] If you touched `pyproject.toml` dependencies, `uv build` succeeds locally and the wheel's `METADATA` does not carry any local path dependency.
@@ -248,10 +259,16 @@ Usually means the version already exists. Check `npm view claude-smart versions`
 Same as above for PyPI. Bump and re-release.
 
 **`uv build` produces a wheel that fails to install with `No matching distribution found for reflexio-ai`.**
-The claude-smart package resolves `reflexio-ai` from PyPI in published installs. Publish the required Reflexio version first, then run:
+The committed `plugin/pyproject.toml` must resolve `reflexio-ai` from PyPI. If this release only needs Reflexio through the npm plugin artifact, use vendor mode instead of raising the PyPI dependency to an unpublished Reflexio version:
 
 ```bash
 bash scripts/release-with-reflexio.sh
+```
+
+If this release needs the PyPI package dependency itself to require a newer published Reflexio version, publish that Reflexio version first, then run:
+
+```bash
+REFLEXIO_RELEASE_SOURCE=pypi bash scripts/release-with-reflexio.sh
 ```
 
 For non-standard worktree layouts, point the helper at the intended Reflexio checkout:
@@ -260,7 +277,7 @@ For non-standard worktree layouts, point the helper at the intended Reflexio che
 REFLEXIO_PATH=/path/to/reflexio-main bash scripts/release-with-reflexio.sh
 ```
 
-The helper verifies that the Reflexio checkout is clean, matches `origin/main`, is tagged `v<version>`, and that `reflexio-ai==version` exists on PyPI.
+Vendor mode verifies that the Reflexio checkout is clean, exports the committed HEAD into `plugin/vendor/reflexio`, and records the commit in `reflexio.lock.json`. PyPI mode additionally verifies that the Reflexio checkout matches `origin/main`, is tagged `v<version>`, and that `reflexio-ai==version` exists on PyPI.
 
 Manual equivalent:
 
@@ -299,7 +316,7 @@ You can flip each axis independently — e.g. local plugin + PyPI Reflexio is a 
 | Axis | Local | Remote | Controlled by |
 | --- | --- | --- | --- |
 | **Plugin** — hooks, slash commands, Python package, dashboard | this repo's `plugin/` (marketplace `reflexioai-local`) | GitHub cache `~/.claude/plugins/cache/reflexioai/…` | `.claude/settings.local.json` → `enabledPlugins` |
-| **Reflexio** — backend, extraction, storage | side-by-side checkout, usually `../reflexio` (editable install) | PyPI wheel `reflexio-ai` | `scripts/use-local-reflexio.sh` for local dev; `reflexio.lock.json` + `plugin/pyproject.toml` for releases |
+| **Reflexio** — backend, extraction, storage | side-by-side checkout, usually `../reflexio` (editable install) | PyPI wheel `reflexio-ai`, or generated npm-only `plugin/vendor/reflexio` for fast releases | `scripts/use-local-reflexio.sh` for local dev; `reflexio.lock.json` + `plugin/pyproject.toml` for PyPI releases; `reflexio.lock.json` + generated vendor bundle for npm fast releases |
 
 Clone the repos side-by-side for local cross-repo development:
 
@@ -456,7 +473,7 @@ Optional: if you juggle local and remote across different repos on the same mach
 - `plugin/commands/*.md`, `plugin/hooks/hooks.json` — picked up on the next Claude Code session.
 - `plugin/dashboard/` — the dashboard runs `npm run start` against prebuilt `.next/`, long-lived across sessions. Rebuild + restart: `/claude-smart:restart` or `claude-smart restart`.
 
-### Switching axis 2 — Reflexio source (editable checkout ↔ PyPI)
+### Switching axis 2 — Reflexio source (editable checkout ↔ PyPI/vendor)
 
 Use the helper script for local Reflexio development. It installs the side-by-side checkout into `plugin/.venv` as editable without writing local paths into `plugin/pyproject.toml`:
 
@@ -482,13 +499,15 @@ uv run --project plugin --no-sync python -c "import reflexio, os; print(reflexio
 ```
 
 - Path into `workspace/reflexio/reflexio/` or another checkout → **editable local Reflexio**.
-- Path into `…/site-packages/reflexio/` → **PyPI**.
+- Path into `…/site-packages/reflexio/` → **PyPI** or an installed generated vendor copy.
+
+For installed npm releases, the setup wrapper runs `uv sync --locked` first. If the npm tarball contains `plugin/vendor/reflexio`, it then installs that bundled Reflexio source into the plugin environment. User installs do not clone GitHub.
 
 ### Release flow with Reflexio
 
 If claude-smart does not need new Reflexio behavior, release claude-smart only; do not change the `reflexio-ai` dependency.
 
-If claude-smart needs new Reflexio behavior, merge Reflexio, tag the release commit as `v<version>`, and publish `reflexio-ai` first. Then run:
+If claude-smart needs unpublished Reflexio behavior, use vendor mode. The committed package metadata still points at the PyPI baseline, but the npm artifact carries the exact Reflexio source snapshot:
 
 ```bash
 bash scripts/release-with-reflexio.sh
@@ -498,6 +517,24 @@ For non-standard worktree layouts:
 
 ```bash
 REFLEXIO_PATH=/path/to/reflexio-main bash scripts/release-with-reflexio.sh
+```
+
+Commit:
+
+```text
+reflexio.lock.json
+```
+
+Keep generated `plugin/vendor/reflexio` in place until npm publish completes; it is gitignored but included in the npm tarball. Then release claude-smart to npm:
+
+```bash
+make release-npm VERSION=<new-claude-smart-version>
+```
+
+If claude-smart needs a newer published Reflexio package dependency, merge Reflexio, tag the release commit as `v<version>`, publish `reflexio-ai`, then run:
+
+```bash
+REFLEXIO_RELEASE_SOURCE=pypi bash scripts/release-with-reflexio.sh
 ```
 
 Commit:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -234,12 +234,10 @@ Before running `make release`:
 - [ ] `README.md` reflects any user-visible changes.
 - [ ] Hook behavior, CLI flags, env vars are unchanged — or a migration note is in the README.
 - [ ] `plugin/hooks/hooks.json` and `plugin/commands/*.md` render correctly in a local Claude Code session (smoke test: install from a local `directory` marketplace, start a session, run `/show`).
-- [ ] `reflexio` submodule is at the pinned SHA you want to ship against. Bump it explicitly if needed:
-  ```bash
-  cd reflexio && git pull && cd .. && git add reflexio && git commit -m "Bump reflexio submodule"
-  ```
+- [ ] If claude-smart needs new Reflexio behavior, `reflexio-ai` has already been published from a `v<version>` tag on Reflexio `origin/main`, and `bash scripts/release-with-reflexio.sh` has updated `plugin/pyproject.toml`, `plugin/uv.lock`, and `reflexio.lock.json`.
+- [ ] `python scripts/check-reflexio-lock.py` passes.
 - [ ] `npm pack --dry-run --json` includes the root wrapper, marketplace metadata, plugin payload, dashboard sources, README, and LICENSE, and excludes `.venv`, `node_modules`, `.next/cache`, and Python caches.
-- [ ] If you touched `pyproject.toml` dependencies, `uv build` succeeds locally and the wheel's `METADATA` doesn't carry a `file://` path dep (common failure when `[tool.uv.sources]` leaks into the published wheel).
+- [ ] If you touched `pyproject.toml` dependencies, `uv build` succeeds locally and the wheel's `METADATA` does not carry any local path dependency.
 
 ## Common failures and fixes
 
@@ -250,11 +248,27 @@ Usually means the version already exists. Check `npm view claude-smart versions`
 Same as above for PyPI. Bump and re-release.
 
 **`uv build` produces a wheel that fails to install with `No matching distribution found for reflexio-ai`.**
-The `[tool.uv.sources]` override in `pyproject.toml` points `reflexio-ai` to a local path — fine for local dev, fatal for a published wheel. Either:
-1. Publish `reflexio-ai` to PyPI first, then remove the `[tool.uv.sources]` block before `make release`, or
-2. Drop `reflexio-ai` from the published package's `dependencies` and keep the install-time bootstrap (`plugin/scripts/smart-install.sh`) responsible for installing it inside the Claude Code plugin directory.
+The claude-smart package resolves `reflexio-ai` from PyPI in published installs. Publish the required Reflexio version first, then run:
 
-See README's "Step 1 — Install the plugin" section for the install flow that assumes option 2.
+```bash
+bash scripts/release-with-reflexio.sh
+```
+
+For non-standard worktree layouts, point the helper at the intended Reflexio checkout:
+
+```bash
+REFLEXIO_PATH=/path/to/reflexio-main bash scripts/release-with-reflexio.sh
+```
+
+The helper verifies that the Reflexio checkout is clean, matches `origin/main`, is tagged `v<version>`, and that `reflexio-ai==version` exists on PyPI.
+
+Manual equivalent:
+
+```bash
+python scripts/sync-reflexio-dep.py --write --check-pypi --release-checks
+uv lock --project plugin --upgrade-package reflexio-ai
+python scripts/check-reflexio-lock.py
+```
 
 **`make release` committed and tagged but `npm publish` failed after.**
 `publish` runs before `git push --follow-tags`, so nothing was pushed. Fix the cause (auth, network, registry), then:
@@ -276,27 +290,33 @@ rm -f package.json.bak pyproject.toml.bak .claude-plugin/*.bak
 
 ## Developing locally
 
-For iterating on claude-smart itself — editing hooks, the Python package, the dashboard, or the reflexio submodule — install from a clone and point the host at your working copy. End users don't need any of this; the `npx`/`uvx` install flow in the README covers them.
+For iterating on claude-smart itself — editing hooks, the Python package, the dashboard, or a side-by-side Reflexio checkout — install from a clone and point the host at your working copy. End users don't need any of this; the `npx`/`uvx` install flow in the README covers them.
 
 ### Local install overview
 
-You can flip each axis independently — e.g. local plugin + PyPI reflexio is a valid combination (you're touching hooks/slash commands/dashboard but not the backend), and so is remote plugin + local reflexio (smoke-test the shipped plugin against a patched backend).
+You can flip each axis independently — e.g. local plugin + PyPI Reflexio is a valid combination when you're touching hooks/slash commands/dashboard but not the backend. Local Reflexio development uses an editable install in the plugin virtualenv; the committed package metadata still resolves `reflexio-ai` from PyPI.
 
 | Axis | Local | Remote | Controlled by |
 | --- | --- | --- | --- |
 | **Plugin** — hooks, slash commands, Python package, dashboard | this repo's `plugin/` (marketplace `reflexioai-local`) | GitHub cache `~/.claude/plugins/cache/reflexioai/…` | `.claude/settings.local.json` → `enabledPlugins` |
-| **reflexio** — backend, extraction, storage | vendored submodule at `reflexio/` (editable) | PyPI wheel `reflexio-ai` | `plugin/pyproject.toml` → `[tool.uv.sources]` |
+| **Reflexio** — backend, extraction, storage | side-by-side checkout, usually `../reflexio` (editable install) | PyPI wheel `reflexio-ai` | `scripts/use-local-reflexio.sh` for local dev; `reflexio.lock.json` + `plugin/pyproject.toml` for releases |
 
-Start every local install from a clone:
+Clone the repos side-by-side for local cross-repo development:
 
 ```bash
-git clone --recurse-submodules https://github.com/ReflexioAI/claude-smart.git
+mkdir -p workspace
+cd workspace
+git clone https://github.com/ReflexioAI/reflexio.git
+git clone https://github.com/ReflexioAI/claude-smart.git
 cd claude-smart
+bash scripts/use-local-reflexio.sh
 ```
+
+Edit both repos as needed. Open one PR in `reflexio` and one PR in `claude-smart`, then link the Reflexio PR from the claude-smart PR.
 
 ### Local install
 
-Use the one-shot setup when developing the plugin, dashboard, or local `reflexio` submodule:
+Use the one-shot setup when developing the plugin, dashboard, or local Reflexio checkout:
 
 ```bash
 bash scripts/setup-local-dev.sh                         # Claude Code local setup
@@ -307,16 +327,14 @@ bash scripts/setup-local-dev.sh --read-only             # Local setup without pu
 
 Idempotent. This single script handles the shared local-dev prep for every host — see its header comment for the full list, but in summary it:
 
-1. Initializes the `reflexio/` submodule.
-2. Uncomments `[tool.uv.sources]` in `plugin/pyproject.toml` (absolute path to the submodule) and hides the divergence with `git update-index --skip-worktree`.
-3. `uv sync` in `plugin/`.
-4. Appends `CLAUDE_SMART_USE_LOCAL_CLI=1` and `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` to `~/.reflexio/.env`.
-5. For `--host claude-code` (the default), prepares and refreshes the local marketplace (`local-marketplace/`, manifest name `reflexioai-local`) at user scope by replacing any stale `reflexioai-local` registration before running `claude plugin marketplace add`.
-6. For `--host claude-code`, writes `.claude/settings.local.json` → enable `claude-smart@reflexioai-local`, disable `claude-smart@reflexioai`.
-7. For `--host claude-code`, force-sets `~/.reflexio/plugin-root` → `plugin/` so slash commands resolve to editable in-repo sources.
-8. For `--host codex`, runs `node bin/claude-smart.js install --host codex` so the installed Codex hooks are patched through the JSON-safe `scripts/codex-hook.js` adapter.
-9. For `--host both`, force-sets `~/.reflexio/plugin-root` back to editable `plugin/` after the Codex install step, since the Codex installer may point it at the copied cache.
-10. Refreshes the local dashboard process. The dashboard health endpoint exposes the serving plugin root, so setup can stop a stale claude-smart dashboard from an older cache while leaving a foreign app on port `3001` alone.
+1. Runs `scripts/use-local-reflexio.sh`, which syncs `plugin/` and installs the side-by-side Reflexio checkout as editable without changing committed dependency metadata.
+2. Appends `CLAUDE_SMART_USE_LOCAL_CLI=1` and `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` to `~/.reflexio/.env`.
+3. For `--host claude-code` (the default), prepares and refreshes the local marketplace (`local-marketplace/`, manifest name `reflexioai-local`) at user scope by replacing any stale `reflexioai-local` registration before running `claude plugin marketplace add`.
+4. For `--host claude-code`, writes `.claude/settings.local.json` → enable `claude-smart@reflexioai-local`, disable `claude-smart@reflexioai`.
+5. For `--host claude-code`, force-sets `~/.reflexio/plugin-root` → `plugin/` so slash commands resolve to editable in-repo sources.
+6. For `--host codex`, runs `node bin/claude-smart.js install --host codex` so the installed Codex hooks are patched through the JSON-safe `scripts/codex-hook.js` adapter.
+7. For `--host both`, force-sets `~/.reflexio/plugin-root` back to editable `plugin/` after the Codex install step, since the Codex installer may point it at the copied cache.
+8. Refreshes the local dashboard process. The dashboard health endpoint exposes the serving plugin root, so setup can stop a stale claude-smart dashboard from an older cache while leaving a foreign app on port `3001` alone.
 
 Then restart the target host. In a new Claude Code session, `/plugin` should show `claude-smart@reflexioai-local` and should not also show the published `claude-smart@reflexioai`. In Codex, `/plugins` should show `claude-smart` installed from the **ReflexioAI** marketplace.
 
@@ -438,62 +456,75 @@ Optional: if you juggle local and remote across different repos on the same mach
 - `plugin/commands/*.md`, `plugin/hooks/hooks.json` — picked up on the next Claude Code session.
 - `plugin/dashboard/` — the dashboard runs `npm run start` against prebuilt `.next/`, long-lived across sessions. Rebuild + restart: `/claude-smart:restart` or `claude-smart restart`.
 
-### Switching axis 2 — reflexio source (submodule ↔ PyPI)
+### Switching axis 2 — Reflexio source (editable checkout ↔ PyPI)
 
-Edit `plugin/pyproject.toml`. The `[tool.uv.sources]` block is what decides.
-
-```toml
-# local submodule (editable)
-[tool.uv.sources]
-reflexio-ai = { path = "/absolute/path/to/repo/reflexio", editable = true }
-```
-```toml
-# PyPI — just delete or comment out the block above
-# [tool.uv.sources]
-# reflexio-ai = { path = "/absolute/path/to/repo/reflexio", editable = true }
-```
-
-**Important — absolute path required.** `uv run --project <symlink>` resolves relative paths against the literal symlink, not its realpath. Since slash commands pass `~/.reflexio/plugin-root` as `--project`, a relative `../reflexio` would resolve to `$HOME/.reflexio/reflexio` (nonexistent). Always use the absolute path.
-
-**Note — git invisibility.** `setup-local-dev.sh` runs `git update-index --skip-worktree plugin/pyproject.toml plugin/uv.lock`, so edits to these files are **invisible** to `git status`. If you need to commit a genuine change:
+Use the helper script for local Reflexio development. It installs the side-by-side checkout into `plugin/.venv` as editable without writing local paths into `plugin/pyproject.toml`:
 
 ```bash
-git update-index --no-skip-worktree plugin/pyproject.toml plugin/uv.lock
-# stage hunks selectively, commit
-git update-index --skip-worktree plugin/pyproject.toml plugin/uv.lock
+bash scripts/use-local-reflexio.sh
+# or
+REFLEXIO_PATH=/absolute/path/to/reflexio bash scripts/use-local-reflexio.sh
 ```
 
-**Apply the change:**
+Return to the locked PyPI dependency by syncing the plugin environment:
 
 ```bash
-cd plugin && uv sync --quiet
+uv sync --project plugin --locked --reinstall-package reflexio-ai
 claude-smart restart                  # or /claude-smart:restart inside Claude Code
 ```
 
-`uv sync` re-resolves the dependency. The **backend service must be restarted** — it's a long-lived process on port 8071 with the old `reflexio-ai` already imported in memory, so editing `pyproject.toml` alone does nothing until the service reloads.
+The **backend service must be restarted** after switching sources — it's a long-lived process on port 8071 with the old `reflexio-ai` already imported in memory.
 
 Verify:
 
 ```bash
-uv run --project plugin python -c "import reflexio, os; print(reflexio.__version__); print(os.path.dirname(reflexio.__file__))"
+uv run --project plugin --no-sync python -c "import reflexio, os; print(reflexio.__version__); print(os.path.dirname(reflexio.__file__))"
 ```
 
-- Path into `reflexio/reflexio/` under this repo → **submodule** (editable).
+- Path into `workspace/reflexio/reflexio/` or another checkout → **editable local Reflexio**.
 - Path into `…/site-packages/reflexio/` → **PyPI**.
+
+### Release flow with Reflexio
+
+If claude-smart does not need new Reflexio behavior, release claude-smart only; do not change the `reflexio-ai` dependency.
+
+If claude-smart needs new Reflexio behavior, merge Reflexio, tag the release commit as `v<version>`, and publish `reflexio-ai` first. Then run:
+
+```bash
+bash scripts/release-with-reflexio.sh
+```
+
+For non-standard worktree layouts:
+
+```bash
+REFLEXIO_PATH=/path/to/reflexio-main bash scripts/release-with-reflexio.sh
+```
+
+Commit:
+
+```text
+plugin/pyproject.toml
+plugin/uv.lock
+reflexio.lock.json
+```
+
+Then release claude-smart.
 
 ### Manual setup (alternative to setup-local-dev.sh)
 
 If you want to understand the pieces or do a subset:
 
 ```bash
-# 1. Clone + submodule
-git clone --recurse-submodules https://github.com/ReflexioAI/claude-smart.git
+# 1. Clone repos side-by-side
+mkdir -p workspace
+cd workspace
+git clone https://github.com/ReflexioAI/reflexio.git
+git clone https://github.com/ReflexioAI/claude-smart.git
 cd claude-smart
-git submodule update --init --recursive    # if you forgot --recurse-submodules
 
 # 2. Python deps
-cd plugin && uv sync && cd ..
-# Creates plugin/.venv/ and registers claude-smart + claude-smart-hook scripts.
+bash scripts/use-local-reflexio.sh
+# Creates plugin/.venv/, syncs claude-smart, and installs ../reflexio editable.
 
 # 3. Local providers (no API key needed)
 mkdir -p ~/.reflexio
@@ -504,9 +535,9 @@ grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' ~/.reflexio/.env 2>/dev/null \
 # The backend starts one shared embedding daemon on 127.0.0.1:8072.
 
 # 4. (Optional) start the backend manually instead of letting SessionStart spawn it
-cd plugin && BACKEND_PORT=8071 EMBEDDING_PORT=8072 uv run reflexio services start --only backend --no-reload
+cd plugin && BACKEND_PORT=8071 EMBEDDING_PORT=8072 uv run --no-sync reflexio services start --only backend --no-reload
 # Health check: curl http://localhost:8071/health  →  {"status":"healthy"}
-# Stop:         uv run reflexio services stop
+# Stop:         uv run --no-sync reflexio services stop
 ```
 
 Expected backend log lines:
@@ -542,7 +573,7 @@ readlink ~/.reflexio/plugin-root
 # → $PWD/plugin  (local)   or   ~/.claude/plugins/cache/reflexioai/claude-smart/<ver>  (remote)
 
 # Axis 2 — reflexio source
-uv run --project plugin python -c "import reflexio, os; print(reflexio.__version__); print(os.path.dirname(reflexio.__file__))"
+uv run --project plugin --no-sync python -c "import reflexio, os; print(reflexio.__version__); print(os.path.dirname(reflexio.__file__))"
 ```
 
 ### Exercising the install CLIs against a local marketplace
@@ -550,9 +581,9 @@ uv run --project plugin python -c "import reflexio, os; print(reflexio.__version
 Useful when you're modifying the `install` subcommand itself and want to test without re-publishing:
 
 ```bash
-uv run --project plugin claude-smart install --source $PWD    # Python path
+uv run --project plugin --no-sync claude-smart install --source $PWD    # Python path
 node bin/claude-smart.js install --source $PWD                # Node path
-uv run --project plugin claude-smart install --host codex      # Codex repo-local path
+uv run --project plugin --no-sync claude-smart install --host codex      # Codex repo-local path
 node bin/claude-smart.js install --host codex                  # Codex packaged-marketplace path
 ```
 
@@ -561,8 +592,8 @@ The Claude Code install commands accept either a GitHub `owner/repo` ref or an a
 ## Tests
 
 ```bash
-uv run --project plugin pytest tests/ -q   # claude-smart package tests (from repo root)
-cd reflexio && uv run pytest tests/server/llm/ -q -o 'addopts='   # reflexio patch tests
+uv run --project plugin pytest --rootdir . -o addopts= tests/ -q   # claude-smart package tests (from repo root)
+cd ../reflexio && uv run pytest tests/server/llm/ -q -o 'addopts='   # reflexio patch tests
 ```
 
 Run both locally before `make release`. There's no CI gate today — the release flow trusts the maintainer.
@@ -573,7 +604,7 @@ Useful for debugging without a live Claude Code session:
 
 ```bash
 echo '{"session_id":"dev-1","source":"startup","cwd":"'"$PWD"'"}' \
-  | uv run --project plugin python -m claude_smart.hook session-start
+  | uv run --project plugin --no-sync python -m claude_smart.hook session-start
 ```
 
 ## Manual smoke tests — credit-stall notification

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -483,6 +483,16 @@ bash scripts/use-local-reflexio.sh
 REFLEXIO_PATH=/absolute/path/to/reflexio bash scripts/use-local-reflexio.sh
 ```
 
+If you cloned both repos and are unsure which Reflexio source claude-smart is
+actually importing, run:
+
+```bash
+make doctor-reflexio
+```
+
+If a sibling `../reflexio` checkout exists but the plugin environment is still
+using PyPI, the doctor exits non-zero and prints the fix command.
+
 Return to the locked PyPI dependency by syncing the plugin environment:
 
 ```bash

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -350,8 +350,9 @@ Idempotent. This single script handles the shared local-dev prep for every host 
 4. For `--host claude-code`, writes `.claude/settings.local.json` → enable `claude-smart@reflexioai-local`, disable `claude-smart@reflexioai`.
 5. For `--host claude-code`, force-sets `~/.reflexio/plugin-root` → `plugin/` so slash commands resolve to editable in-repo sources.
 6. For `--host codex`, runs `node bin/claude-smart.js install --host codex` so the installed Codex hooks are patched through the JSON-safe `scripts/codex-hook.js` adapter.
-7. For `--host both`, force-sets `~/.reflexio/plugin-root` back to editable `plugin/` after the Codex install step, since the Codex installer may point it at the copied cache.
-8. Refreshes the local dashboard process. The dashboard health endpoint exposes the serving plugin root, so setup can stop a stale claude-smart dashboard from an older cache while leaving a foreign app on port `3001` alone.
+7. For `--host codex`, writes a local-only `reflexio-ai` source override into the generated Codex marketplace/cache copies and installs the same side-by-side Reflexio checkout as editable into Codex's copied plugin cache venv, because Codex hooks run from `~/.codex/plugins/cache/...` instead of directly from this checkout.
+8. For `--host both`, force-sets `~/.reflexio/plugin-root` back to editable `plugin/` after the Codex install step, since the Codex installer may point it at the copied cache.
+9. Refreshes the local dashboard process. The dashboard health endpoint exposes the serving plugin root, so setup can stop a stale claude-smart dashboard from an older cache while leaving a foreign app on port `3001` alone.
 
 Then restart the target host. In a new Claude Code session, `/plugin` should show `claude-smart@reflexioai-local` and should not also show the published `claude-smart@reflexioai`. In Codex, `/plugins` should show `claude-smart` installed from the **ReflexioAI** marketplace.
 

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@
 #   - git (for the release flow)
 
 .PHONY: help bump release publish publish-npm publish-pypi publish-dry \
-        check-version check-clean check-npm-auth check-reflexio-pin \
+        check-version check-clean check-npm-auth check-reflexio-pin check-reflexio-lock \
         ensure-remote-reflexio unskip-worktree
 
 VERSION_FILES := package.json plugin/pyproject.toml \
                  plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json \
                  .claude-plugin/marketplace.json README.md
-LOCK_FILES    := plugin/uv.lock
+LOCK_FILES    := plugin/uv.lock reflexio.lock.json
 PYPROJECT     := plugin/pyproject.toml
 
 help:
@@ -50,6 +50,9 @@ check-reflexio-pin: ## Verify the reflexio-ai version pinned in plugin/pyproject
 	  fi; \
 	  echo "→ ok: reflexio-ai $$pin is on PyPI"
 
+check-reflexio-lock: ## Verify plugin/pyproject.toml matches reflexio.lock.json
+	@python3 scripts/check-reflexio-lock.py
+
 check-npm-auth: ## Verify npm auth via NPM_TOKEN or `npm whoami`; fail if neither is available
 	@if [ -n "$$NPM_TOKEN" ]; then \
 	  echo "→ npm: NPM_TOKEN is set"; \
@@ -64,15 +67,10 @@ unskip-worktree: ## Clear skip-worktree on plugin/pyproject.toml and plugin/uv.l
 	@echo "→ clearing skip-worktree on $(PYPROJECT) $(LOCK_FILES)"
 	@git update-index --no-skip-worktree $(PYPROJECT) $(LOCK_FILES) 2>/dev/null || true
 
-ensure-remote-reflexio: ## Ensure [tool.uv.sources] is commented out so published wheels resolve reflexio-ai from PyPI (see scripts/setup-local-dev.sh to re-enable for dev)
-	@echo "→ ensuring [tool.uv.sources] override is commented out in $(PYPROJECT)"
-	@sed -i.bak -E \
-	    -e 's|^\[tool\.uv\.sources\]$$|# [tool.uv.sources]|' \
-	    -e 's|^(reflexio-ai = \{ path = .*)$$|# \1|' \
-	    $(PYPROJECT)
-	@rm -f $(PYPROJECT).bak
-	@if grep -qE '^\[tool\.uv\.sources\]|^reflexio-ai = \{ path =' $(PYPROJECT); then \
-	  echo "error: [tool.uv.sources] block in $(PYPROJECT) is still active after sed" >&2; \
+ensure-remote-reflexio: ## Ensure published wheels resolve reflexio-ai from PyPI, not a local path
+	@echo "→ ensuring $(PYPROJECT) resolves reflexio-ai from PyPI"
+	@if grep -qE '^\[tool\.uv\.sources\]|reflexio-ai = \{ path =|file://' $(PYPROJECT); then \
+	  echo "error: local reflexio-ai source found in $(PYPROJECT); use scripts/use-local-reflexio.sh for editable local dev" >&2; \
 	  exit 1; \
 	fi
 
@@ -112,7 +110,7 @@ publish-dry: unskip-worktree ensure-remote-reflexio ## Show what would be publis
 
 publish: publish-npm publish-pypi ## Publish to both npm and PyPI
 
-release: check-version check-clean check-npm-auth check-reflexio-pin bump ## Bump + commit + tag + publish + push
+release: check-version check-clean check-npm-auth check-reflexio-lock check-reflexio-pin bump ## Bump + commit + tag + publish + push
 	@echo "→ committing release v$(VERSION)"
 	git add $(VERSION_FILES) $(LOCK_FILES)
 	git commit -m "Release v$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Usage:
 #   make bump VERSION=0.1.1          Update version in all release manifests
 #   make release VERSION=0.1.1       Bump, commit, tag v0.1.1, publish, push
+#   make release-npm VERSION=0.1.1   Bump, commit, tag, publish npm only
 #   make publish                     Publish current version to npm + PyPI
 #   make publish-npm                 npm publish only
 #   make publish-pypi                uv build + uv publish only
@@ -13,9 +14,10 @@
 #   - uv (UV_PUBLISH_TOKEN set for PyPI uploads)
 #   - git (for the release flow)
 
-.PHONY: help bump release publish publish-npm publish-pypi publish-dry \
+.PHONY: help bump release release-npm publish publish-npm publish-pypi publish-dry \
         check-version check-clean check-npm-auth check-reflexio-pin check-reflexio-lock \
-        ensure-remote-reflexio unskip-worktree
+        check-vendor-reflexio check-pypi-compatible-reflexio ensure-remote-reflexio \
+        unskip-worktree
 
 VERSION_FILES := package.json plugin/pyproject.toml \
                  plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json \
@@ -53,6 +55,12 @@ check-reflexio-pin: ## Verify the reflexio-ai version pinned in plugin/pyproject
 check-reflexio-lock: ## Verify plugin/pyproject.toml matches reflexio.lock.json
 	@python3 scripts/check-reflexio-lock.py
 
+check-vendor-reflexio: ## Verify generated Reflexio vendor bundle exists when the lock requires it
+	@python3 scripts/check-reflexio-lock.py --check-vendor
+
+check-pypi-compatible-reflexio: ## Refuse PyPI publish when this release relies on a generated vendor bundle
+	@python3 -c 'import json, pathlib, sys; p=pathlib.Path("reflexio.lock.json"); data=json.loads(p.read_text()) if p.exists() else {}; sys.exit("error: reflexio.lock.json uses source=vendor; publish npm only with `make release-npm VERSION=...`, or run `REFLEXIO_RELEASE_SOURCE=pypi bash scripts/release-with-reflexio.sh` first" if data.get("source") == "vendor" else 0)'
+
 check-npm-auth: ## Verify npm auth via NPM_TOKEN or `npm whoami`; fail if neither is available
 	@if [ -n "$$NPM_TOKEN" ]; then \
 	  echo "→ npm: NPM_TOKEN is set"; \
@@ -89,17 +97,17 @@ bump: check-version unskip-worktree ensure-remote-reflexio ## Rewrite version in
 	@echo "→ resulting versions:"
 	@grep -HE '("version"|^version)' $(VERSION_FILES)
 
-publish-npm: ## Publish the current version to npm
+publish-npm: check-vendor-reflexio ## Publish the current version to npm
 	@echo "→ npm publish"
 	npm publish --access public
 
-publish-pypi: unskip-worktree ensure-remote-reflexio ## Build and publish the current version to PyPI
+publish-pypi: check-pypi-compatible-reflexio unskip-worktree ensure-remote-reflexio ## Build and publish the current version to PyPI
 	@echo "→ uv build + uv publish"
 	rm -rf plugin/dist/
 	uv build --project plugin
 	uv publish --project plugin plugin/dist/*
 
-publish-dry: unskip-worktree ensure-remote-reflexio ## Show what would be published without uploading
+publish-dry: unskip-worktree ensure-remote-reflexio check-vendor-reflexio ## Show what would be published without uploading
 	@echo "→ npm publish --dry-run"
 	@npm publish --dry-run
 	@echo ""
@@ -108,9 +116,9 @@ publish-dry: unskip-worktree ensure-remote-reflexio ## Show what would be publis
 	uv build --project plugin
 	@ls -la plugin/dist/
 
-publish: publish-npm publish-pypi ## Publish to both npm and PyPI
+publish: check-pypi-compatible-reflexio publish-npm publish-pypi ## Publish to both npm and PyPI
 
-release: check-version check-clean check-npm-auth check-reflexio-lock check-reflexio-pin bump ## Bump + commit + tag + publish + push
+release: check-version check-clean check-npm-auth check-reflexio-lock check-reflexio-pin check-pypi-compatible-reflexio bump ## Bump + commit + tag + publish + push
 	@echo "→ committing release v$(VERSION)"
 	git add $(VERSION_FILES) $(LOCK_FILES)
 	git commit -m "Release v$(VERSION)"
@@ -119,3 +127,13 @@ release: check-version check-clean check-npm-auth check-reflexio-lock check-refl
 	@echo "→ pushing commit + tag"
 	git push --follow-tags
 	@echo "✓ released v$(VERSION)"
+
+release-npm: check-version check-clean check-npm-auth check-reflexio-lock check-reflexio-pin check-vendor-reflexio bump ## Bump + commit + tag + publish npm only
+	@echo "→ committing npm release v$(VERSION)"
+	git add $(VERSION_FILES) $(LOCK_FILES)
+	git commit -m "Release v$(VERSION)"
+	git tag -a v$(VERSION) -m "Release v$(VERSION)"
+	@$(MAKE) publish-npm
+	@echo "→ pushing commit + tag"
+	git push --follow-tags
+	@echo "✓ released npm v$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 .PHONY: help bump release release-npm publish publish-npm publish-pypi publish-dry \
         check-version check-clean check-npm-auth check-reflexio-pin check-reflexio-lock \
         check-vendor-reflexio check-pypi-compatible-reflexio ensure-remote-reflexio \
-        unskip-worktree
+        doctor-reflexio unskip-worktree
 
 VERSION_FILES := package.json plugin/pyproject.toml \
                  plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json \
@@ -60,6 +60,9 @@ check-vendor-reflexio: ## Verify generated Reflexio vendor bundle exists when th
 
 check-pypi-compatible-reflexio: ## Refuse PyPI publish when this release relies on a generated vendor bundle
 	@python3 -c 'import json, pathlib, sys; p=pathlib.Path("reflexio.lock.json"); data=json.loads(p.read_text()) if p.exists() else {}; sys.exit("error: reflexio.lock.json uses source=vendor; publish npm only with `make release-npm VERSION=...`, or run `REFLEXIO_RELEASE_SOURCE=pypi bash scripts/release-with-reflexio.sh` first" if data.get("source") == "vendor" else 0)'
+
+doctor-reflexio: ## Show whether plugin/.venv imports local, vendor, or PyPI Reflexio
+	@python3 scripts/doctor-reflexio.py
 
 check-npm-auth: ## Verify npm auth via NPM_TOKEN or `npm whoami`; fail if neither is available
 	@if [ -n "$$NPM_TOKEN" ]; then \

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ For troubleshooting, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
 
 ## License
 
-This project is licensed under the **Apache License 2.0**. The bundled `reflexio/` submodule is also Apache 2.0. Claude Code is Anthropic's and not covered by this license.
+This project is licensed under the **Apache License 2.0**. Reflexio is a separate Apache 2.0 project consumed as the `reflexio-ai` Python package. Claude Code is Anthropic's and not covered by this license.
 
 See the [LICENSE](LICENSE) file for details.
 

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -795,6 +795,36 @@ function ensurePluginRoot(pluginRoot) {
   }
 }
 
+async function installVendoredReflexio(pluginRoot, uv, env) {
+  const vendorRoot = join(pluginRoot, "vendor", "reflexio");
+  if (!existsSync(join(vendorRoot, "pyproject.toml"))) return;
+
+  const pythonPath = isWindows()
+    ? join(pluginRoot, ".venv", "Scripts", "python.exe")
+    : join(pluginRoot, ".venv", "bin", "python");
+  if (!existsSync(pythonPath)) {
+    throw new Error(`plugin Python was not created by uv sync: ${pythonPath}`);
+  }
+
+  process.stdout.write(`Installing bundled Reflexio source from ${vendorRoot}...\n`);
+  let code = await runChecked(
+    uv,
+    ["pip", "install", "--project", pluginRoot, "--python", pythonPath, "--quiet", "-e", vendorRoot],
+    { cwd: pluginRoot, env },
+  );
+  if (code !== 0) {
+    process.stderr.write(
+      `warning: quiet vendored Reflexio install failed in ${pluginRoot}; retrying with full output.\n`,
+    );
+    code = await runChecked(
+      uv,
+      ["pip", "install", "--project", pluginRoot, "--python", pythonPath, "-e", vendorRoot],
+      { cwd: pluginRoot, env },
+    );
+  }
+  if (code !== 0) throw new Error(`vendored Reflexio install failed in ${pluginRoot}`);
+}
+
 async function bootstrapPluginRuntime(pluginRoot, options = {}) {
   assertSupportedRuntimePlatform();
   process.stdout.write("Preparing claude-smart runtime for hooks...\n");
@@ -830,6 +860,7 @@ async function bootstrapPluginRuntime(pluginRoot, options = {}) {
     );
   }
   if (code !== 0) throw new Error(`uv sync failed in ${pluginRoot}`);
+  await installVendoredReflexio(pluginRoot, uv, env);
 
   const dashboardDir = join(pluginRoot, "dashboard");
   if (existsSync(dashboardDir)) {

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -5,9 +5,12 @@ description = "Self-improving Claude Code plugin — learns from corrections via
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    # Keep this Reflexio minimum in sync via scripts/sync-reflexio-dep.py.
+    # Core Reflexio client/backend package. This is the PyPI baseline used by
+    # normal installs; vendor releases may override it after uv sync by
+    # installing plugin/vendor/reflexio. Keep in sync via
+    # scripts/sync-reflexio-dep.py.
     "reflexio-ai>=0.2.22",
-    # Used by reflexio's local embedding provider (ONNXMiniLM_L6_V2).
+    # Needed when Reflexio runs the local embedding provider (ONNXMiniLM_L6_V2).
     # Pulls in onnxruntime + tokenizers; the ~80 MB ONNX model itself is
     # downloaded on first use, not at install time.
     "chromadb>=0.5",

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -5,6 +5,7 @@ description = "Self-improving Claude Code plugin — learns from corrections via
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    # Keep this Reflexio minimum in sync via scripts/sync-reflexio-dep.py.
     "reflexio-ai>=0.2.22",
     # Used by reflexio's local embedding provider (ONNXMiniLM_L6_V2).
     # Pulls in onnxruntime + tokenizers; the ~80 MB ONNX model itself is
@@ -17,14 +18,6 @@ dependencies = [
 claude-smart-hook = "claude_smart.hook:main"
 claude-smart = "claude_smart.cli:main"
 claude-smart-optimizer-assistant = "claude_smart.optimizer_assistant:main"
-
-# NOTE: LOCAL DEV ONLY — do not commit this block to main.
-# Published installs must resolve reflexio-ai from PyPI. This override
-# points at the vendored submodule so editable changes flow through.
-# `git update-index --skip-worktree plugin/pyproject.toml plugin/uv.lock`
-# hides the local divergence from `git status`.
-# [tool.uv.sources]
-# reflexio-ai = { path = "/Users/yilu/repos/claude-smart/reflexio", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -298,6 +298,8 @@ claude_smart_install_fingerprint() {
   printf 'lib=%s\n' "$(claude_smart_fingerprint_file "$script_dir/_lib.sh")"
   printf 'pyproject=%s\n' "$(claude_smart_fingerprint_file "$plugin_root/pyproject.toml")"
   printf 'uv_lock=%s\n' "$(claude_smart_fingerprint_file "$plugin_root/uv.lock")"
+  printf 'vendor_reflexio_pyproject=%s\n' \
+    "$(claude_smart_fingerprint_file "$plugin_root/vendor/reflexio/pyproject.toml")"
   # Resolved python interpreter — catches a system upgrade (3.12.4 → 3.12.5)
   # that would otherwise let install_complete return true against a venv
   # built against a now-deleted interpreter.

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -234,7 +234,7 @@ case "$CMD" in
     claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
       "$LOG_FILE" "$LOG_MAX_BYTES" -- \
       env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
-      uv run --project "$PLUGIN_ROOT" --quiet \
+      uv run --project "$PLUGIN_ROOT" --no-sync --quiet \
       reflexio services start --only backend --no-reload --workers "$workers"
     svc_pid=$!
     # Record the spawned pid, not a pgid sampled with ps. On POSIX,

--- a/plugin/scripts/cli.sh
+++ b/plugin/scripts/cli.sh
@@ -63,4 +63,4 @@ if ! command -v uv >/dev/null 2>&1; then
   fi
 fi
 
-exec uv run --project "$PLUGIN_ROOT" --quiet python -m claude_smart.cli "$@"
+exec uv run --project "$PLUGIN_ROOT" --no-sync --quiet python -m claude_smart.cli "$@"

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -3,7 +3,8 @@
 # CLAUDE_PLUGIN_ROOT points at the plugin dir (dev: <repo>/plugin;
 # installed: ~/.claude/plugins/cache/reflexioai/claude-smart/<version>),
 # which is also the Python project root with pyproject.toml + uv.lock.
-# We invoke via `uv run --project` so the pinned env from uv.lock is used.
+# We invoke via `uv run --project --no-sync` so the prepared env is used without
+# undoing editable Reflexio installs from local development.
 #
 # If the Setup hook recorded an install failure at
 # ~/.claude-smart/install-failed, short-circuit with a user-visible
@@ -114,4 +115,4 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 
 # Stdin is the hook payload JSON — stream it through to the Python CLI.
-exec uv run --project "$PLUGIN_ROOT" --quiet python -m claude_smart.hook "$HOST" "$EVENT"
+exec uv run --project "$PLUGIN_ROOT" --no-sync --quiet python -m claude_smart.hook "$HOST" "$EVENT"

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -111,6 +111,32 @@ install_complete() {
   return 0
 }
 
+install_vendored_reflexio() {
+  local VENDORED_REFLEXIO PLUGIN_PYTHON
+
+  VENDORED_REFLEXIO="$PLUGIN_ROOT/vendor/reflexio"
+  [ -f "$VENDORED_REFLEXIO/pyproject.toml" ] || return 0
+
+  if claude_smart_is_windows; then
+    PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/Scripts/python.exe"
+  else
+    PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/bin/python"
+  fi
+  if [ ! -x "$PLUGIN_PYTHON" ]; then
+    write_failure "plugin Python was not created by uv sync: $PLUGIN_PYTHON"
+  fi
+
+  echo "[claude-smart] installing bundled Reflexio source from $VENDORED_REFLEXIO" >&2
+  if uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" --quiet -e "$VENDORED_REFLEXIO" >&2; then
+    return 0
+  fi
+
+  echo "[claude-smart] warning: quiet vendored Reflexio install failed in $PLUGIN_ROOT; retrying with full output." >&2
+  if ! uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" -e "$VENDORED_REFLEXIO" >&2; then
+    write_failure "vendored Reflexio install failed in $PLUGIN_ROOT"
+  fi
+}
+
 write_success_marker() {
   install_fingerprint > "$SUCCESS_MARKER"
 }
@@ -409,6 +435,7 @@ echo "[claude-smart] running uv sync..." >&2
 if ! uv sync --locked --python 3.12 --quiet >&2; then
   write_failure "uv sync failed in $PLUGIN_ROOT — run 'uv sync --locked --python 3.12' there to diagnose"
 fi
+install_vendored_reflexio
 
 # Reflexio's CLI reads ~/.reflexio/.env (see reflexio/cli/env_loader.py);
 # append our two opt-in flags there so `reflexio services start` picks

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Run once on plugin install. Pulls the reflexio submodule, syncs the
-# Python env, and flips on the claude-code LiteLLM provider in reflexio's
-# .env so extraction works with no external API key.
+# Run once on plugin install. Syncs the Python env and flips on the
+# claude-code LiteLLM provider in reflexio's .env so extraction works with no
+# external API key.
 #
 # On failure, writes the reason to ~/.claude-smart/install-failed so
 # hook_entry.sh can short-circuit and surface a user-visible message
@@ -360,19 +360,6 @@ preflight_supported_runtime_platform
 if install_complete; then
   claude_smart_emit_continue
   exit 0
-fi
-
-# Dev-mode only: when running from a git checkout, pull the reflexio
-# submodule so tests/benchmarks can use its sources. In install mode the
-# plugin lives under ~/.claude/plugins/cache and reflexio-ai resolves
-# from PyPI instead. The guard checks for both `.git` and `.gitmodules`
-# at REPO_ROOT to distinguish a dev checkout from a marketplace cache
-# (where REPO_ROOT has neither).
-if [ -d "$REPO_ROOT/.git" ] && [ -f "$REPO_ROOT/.gitmodules" ]; then
-  echo "[claude-smart] initializing reflexio submodule..." >&2
-  if ! (cd "$REPO_ROOT" && git submodule update --init --recursive reflexio) >&2; then
-    echo "[claude-smart] WARNING: git submodule update failed; continuing with PyPI reflexio-ai" >&2
-  fi
 fi
 
 if ! command -v uv >/dev/null 2>&1; then

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -14,9 +14,8 @@ Exposes the following subcommands:
 - ``learn``: publish unpublished interactions and force reflexio
   extraction now over the active session buffer.
 - ``restart``: stop and restart the reflexio backend + dashboard services
-  (rebuilding the dashboard bundle) so local edits under the ``reflexio``
-  submodule or ``plugin/dashboard/`` take effect without restarting Claude
-  Code.
+  (rebuilding the dashboard bundle) so local Reflexio checkout edits or
+  ``plugin/dashboard/`` edits take effect without restarting Claude Code.
 """
 
 from __future__ import annotations
@@ -1611,7 +1610,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
     Stops both long-lived services, optionally rebuilds the dashboard's
     Next.js bundle so source edits under ``plugin/dashboard/`` take effect,
     then starts them again. Useful during local development when iterating
-    on the ``reflexio`` submodule or the dashboard.
+    on the local Reflexio checkout or the dashboard.
 
     Args:
         args (argparse.Namespace): Parsed CLI args. Honors ``args.skip_backend``,

--- a/plugin/src/claude_smart/hook_log.py
+++ b/plugin/src/claude_smart/hook_log.py
@@ -79,7 +79,7 @@ def log_event(
             fires against workspace directories.
         internal_skipped (bool): True when ``is_internal_invocation``
             short-circuited the dispatcher (reflexio-internal sub-claude
-            calls, or invocations from inside the reflexio submodule).
+            calls, or invocations from inside a Reflexio checkout).
         handler_status (str): ``"ok"`` for a clean return, ``"unknown_event"``
             when no handler is registered, or ``"raised:<ExcClass>: <msg>"``
             when the handler raised — formatted by ``hook.main``.

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -74,7 +74,7 @@ _CODEX_SUGGESTIONS_APPS_MARKER = (
 _THIS_DIR = Path(__file__).resolve().parent
 _REFLEXIO_DIR = Path(
     os.environ.get("CLAUDE_SMART_REFLEXIO_DIR") or _THIS_DIR.parents[3] / "reflexio"
-)
+).resolve()
 
 
 def is_internal_invocation(payload: dict[str, Any]) -> bool:

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -26,9 +26,9 @@ Detection signals, OR'd:
   - Env var ``CLAUDE_SMART_INTERNAL=1``, set by reflexio's provider
     before spawning ``claude``. Belt-and-suspenders for case (1) in
     case the entrypoint check ever misses a future SDK variant.
-  - ``payload.cwd`` resolves inside the reflexio submodule. Catches
-    direct interactive ``claude`` runs from inside reflexio (manual
-    debugging) that would otherwise pollute the corpus.
+  - ``payload.cwd`` resolves inside the side-by-side reflexio checkout. Catches
+    direct interactive ``claude`` runs from inside reflexio during local
+    debugging that would otherwise pollute the corpus.
   - Known Codex-internal prompt templates (title generation and home-screen
     suggestions). These are model calls made by Codex itself, not user
     coding turns, and must never be reflected into claude-smart memory.
@@ -61,11 +61,11 @@ _CODEX_SUGGESTIONS_APPS_MARKER = (
     "their connected apps."
 )
 
-# Reflexio submodule lives at <repo>/reflexio when this package runs from
-# a dev checkout (<repo>/plugin/src/claude_smart/internal_call.py); anchor
-# relative to this file so the check follows the real checkout if the
-# repo is relocated. In install mode the submodule is absent — the env
-# marker is the primary signal and this path never matches.
+# Reflexio usually lives next to claude-smart during local development:
+# <workspace>/claude-smart and <workspace>/reflexio. Anchor relative to this
+# file so the check follows the real checkout if the repo is relocated. In
+# install mode that sibling checkout is absent — the env marker is the primary
+# signal and this path never matches.
 #
 # The path computation is tightly coupled to the current layout: if this
 # module moves, ``_REFLEXIO_DIR`` silently stops matching and only the
@@ -73,7 +73,7 @@ _CODEX_SUGGESTIONS_APPS_MARKER = (
 # tests) override the path without touching the module.
 _THIS_DIR = Path(__file__).resolve().parent
 _REFLEXIO_DIR = Path(
-    os.environ.get("CLAUDE_SMART_REFLEXIO_DIR") or _THIS_DIR.parents[2] / "reflexio"
+    os.environ.get("CLAUDE_SMART_REFLEXIO_DIR") or _THIS_DIR.parents[3] / "reflexio"
 )
 
 
@@ -86,7 +86,7 @@ def is_internal_invocation(payload: dict[str, Any]) -> bool:
 
     Returns:
         bool: True when the env marker is set or ``cwd`` points inside
-            the reflexio submodule. False otherwise, including when
+            the Reflexio checkout. False otherwise, including when
             ``cwd`` is missing or unresolvable.
     """
     if runtime.is_internal_invocation_env():

--- a/reflexio.lock.json
+++ b/reflexio.lock.json
@@ -4,5 +4,6 @@
   "version": "0.2.22",
   "commit": "0d26da69ceb78cc093a89613769740e48bc64771",
   "dependency": "reflexio-ai>=0.2.22",
+  "source": "pypi",
   "updated_at": "2026-05-24T08:48:38Z"
 }

--- a/reflexio.lock.json
+++ b/reflexio.lock.json
@@ -1,0 +1,8 @@
+{
+  "package": "reflexio-ai",
+  "repo": "https://github.com/ReflexioAI/reflexio.git",
+  "version": "0.2.22",
+  "commit": "0d26da69ceb78cc093a89613769740e48bc64771",
+  "dependency": "reflexio-ai>=0.2.22",
+  "updated_at": "2026-05-24T08:48:38Z"
+}

--- a/scripts/check-reflexio-lock.py
+++ b/scripts/check-reflexio-lock.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Verify plugin/pyproject.toml matches reflexio.lock.json."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DEPENDENCY_RE = re.compile(r'"reflexio-ai[^"]*"')
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    lock_path = repo_root / "reflexio.lock.json"
+    pyproject_path = repo_root / "plugin" / "pyproject.toml"
+
+    if not lock_path.is_file():
+        fail("reflexio.lock.json is missing")
+    lock_data = json.loads(lock_path.read_text())
+    expected = lock_data.get("dependency")
+    if not isinstance(expected, str) or not expected:
+        fail("reflexio.lock.json is missing a non-empty dependency field")
+
+    pyproject_text = pyproject_path.read_text()
+    matches = [match.strip('"') for match in DEPENDENCY_RE.findall(pyproject_text)]
+    if len(matches) != 1:
+        fail(
+            f"expected exactly one quoted reflexio-ai dependency in {pyproject_path}, "
+            f"found {len(matches)}"
+        )
+    actual = matches[0]
+    if actual != expected:
+        fail(
+            "reflexio-ai dependency mismatch:\n"
+            f"  plugin/pyproject.toml: {actual}\n"
+            f"  reflexio.lock.json:   {expected}\n"
+            "Run: python scripts/sync-reflexio-dep.py --write"
+        )
+
+    print(f"OK: {actual}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-reflexio-lock.py
+++ b/scripts/check-reflexio-lock.py
@@ -7,9 +7,13 @@ import argparse
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 DEPENDENCY_RE = re.compile(r'"reflexio-ai[^"]*"')
+PACKAGE_NAME = "reflexio-ai"
+REPO_URL = "https://github.com/ReflexioAI/reflexio.git"
+VALID_SOURCES = {"pypi", "vendor"}
 
 
 def fail(message: str) -> None:
@@ -27,6 +31,38 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def require_str(payload: dict, key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"reflexio.lock.json is missing a non-empty {key!r} field")
+    return value
+
+
+def read_vendor_version(vendor: Path) -> str:
+    pyproject = vendor / "pyproject.toml"
+    if not pyproject.is_file():
+        fail(
+            f"reflexio.lock.json requires vendored Reflexio but {vendor} is missing; "
+            "run bash scripts/release-with-reflexio.sh before npm publish"
+        )
+    with pyproject.open("rb") as handle:
+        data = tomllib.load(handle)
+    project = data.get("project", {})
+    name = project.get("name")
+    version = project.get("version")
+    if name != PACKAGE_NAME:
+        fail(f"vendored Reflexio package name mismatch: expected {PACKAGE_NAME!r}, got {name!r}")
+    if not isinstance(version, str) or not version:
+        fail(f"vendored Reflexio is missing [project].version in {pyproject}")
+    return version
+
+
+def fix_command_for(source: str) -> str:
+    if source == "vendor":
+        return "Run: bash scripts/release-with-reflexio.sh"
+    return "Run: REFLEXIO_RELEASE_SOURCE=pypi bash scripts/release-with-reflexio.sh"
+
+
 def main() -> int:
     args = parse_args()
     repo_root = Path(__file__).resolve().parents[1]
@@ -36,9 +72,26 @@ def main() -> int:
     if not lock_path.is_file():
         fail("reflexio.lock.json is missing")
     lock_data = json.loads(lock_path.read_text())
-    expected = lock_data.get("dependency")
-    if not isinstance(expected, str) or not expected:
-        fail("reflexio.lock.json is missing a non-empty dependency field")
+    package = require_str(lock_data, "package")
+    repo = require_str(lock_data, "repo")
+    version = require_str(lock_data, "version")
+    commit = require_str(lock_data, "commit")
+    expected = require_str(lock_data, "dependency")
+    source = require_str(lock_data, "source")
+
+    if package != PACKAGE_NAME:
+        fail(f"reflexio.lock.json package mismatch: expected {PACKAGE_NAME!r}, got {package!r}")
+    if repo != REPO_URL:
+        fail(f"reflexio.lock.json repo mismatch: expected {REPO_URL!r}, got {repo!r}")
+    if source not in VALID_SOURCES:
+        fail(
+            f"reflexio.lock.json source must be one of {sorted(VALID_SOURCES)}, "
+            f"got {source!r}"
+        )
+    if len(commit) != 40 or not re.fullmatch(r"[0-9a-fA-F]+", commit):
+        fail(f"reflexio.lock.json commit must be a full git SHA, got {commit!r}")
+    if source == "pypi" and "vendor_path" in lock_data:
+        fail("reflexio.lock.json source=pypi must not include vendor_path")
 
     pyproject_text = pyproject_path.read_text()
     matches = [match.strip('"') for match in DEPENDENCY_RE.findall(pyproject_text)]
@@ -53,19 +106,24 @@ def main() -> int:
             "reflexio-ai dependency mismatch:\n"
             f"  plugin/pyproject.toml: {actual}\n"
             f"  reflexio.lock.json:   {expected}\n"
-            "Run: python scripts/sync-reflexio-dep.py --write"
+            f"{fix_command_for(source)}"
         )
 
-    if args.check_vendor and lock_data.get("source") == "vendor":
-        vendor = repo_root / str(lock_data.get("vendor_path") or "plugin/vendor/reflexio")
-        if not (vendor / "pyproject.toml").is_file():
-            fail(
-                f"reflexio.lock.json requires vendored Reflexio but {vendor} is missing; "
-                "run bash scripts/release-with-reflexio.sh before npm publish"
-            )
-        print(f"OK: vendored Reflexio bundle present at {vendor.relative_to(repo_root)}")
+    if source == "vendor":
+        vendor_path = require_str(lock_data, "vendor_path")
+        vendor = repo_root / vendor_path
+        if args.check_vendor:
+            vendor_version = read_vendor_version(vendor)
+            if vendor_version != version:
+                fail(
+                    "vendored Reflexio version mismatch:\n"
+                    f"  {vendor / 'pyproject.toml'}: {vendor_version}\n"
+                    f"  reflexio.lock.json:       {version}\n"
+                    "Run: bash scripts/release-with-reflexio.sh"
+                )
+            print(f"OK: vendored Reflexio bundle present at {vendor.relative_to(repo_root)}")
 
-    print(f"OK: {actual}")
+    print(f"OK: {actual} ({source})")
     return 0
 
 

--- a/scripts/check-reflexio-lock.py
+++ b/scripts/check-reflexio-lock.py
@@ -26,12 +26,25 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--check-vendor",
         action="store_true",
-        help="If reflexio.lock.json uses source=vendor, require the generated vendor bundle",
+        help=(
+            "If reflexio.lock.json uses source=vendor, require the generated "
+            "vendor bundle"
+        ),
     )
     return parser.parse_args()
 
 
-def require_str(payload: dict, key: str) -> str:
+def read_lock_file(lock_path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(lock_path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"reflexio.lock.json is not valid JSON: {exc}")
+    if not isinstance(payload, dict):
+        fail("reflexio.lock.json top-level value must be a JSON object")
+    return payload
+
+
+def require_str(payload: dict[str, object], key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value:
         fail(f"reflexio.lock.json is missing a non-empty {key!r} field")
@@ -51,7 +64,10 @@ def read_vendor_version(vendor: Path) -> str:
     name = project.get("name")
     version = project.get("version")
     if name != PACKAGE_NAME:
-        fail(f"vendored Reflexio package name mismatch: expected {PACKAGE_NAME!r}, got {name!r}")
+        fail(
+            "vendored Reflexio package name mismatch: "
+            f"expected {PACKAGE_NAME!r}, got {name!r}"
+        )
     if not isinstance(version, str) or not version:
         fail(f"vendored Reflexio is missing [project].version in {pyproject}")
     return version
@@ -65,13 +81,13 @@ def fix_command_for(source: str) -> str:
 
 def main() -> int:
     args = parse_args()
-    repo_root = Path(__file__).resolve().parents[1]
+    repo_root = Path(__file__).resolve().parents[1].resolve()
     lock_path = repo_root / "reflexio.lock.json"
     pyproject_path = repo_root / "plugin" / "pyproject.toml"
 
     if not lock_path.is_file():
         fail("reflexio.lock.json is missing")
-    lock_data = json.loads(lock_path.read_text())
+    lock_data = read_lock_file(lock_path)
     package = require_str(lock_data, "package")
     repo = require_str(lock_data, "repo")
     version = require_str(lock_data, "version")
@@ -80,7 +96,10 @@ def main() -> int:
     source = require_str(lock_data, "source")
 
     if package != PACKAGE_NAME:
-        fail(f"reflexio.lock.json package mismatch: expected {PACKAGE_NAME!r}, got {package!r}")
+        fail(
+            "reflexio.lock.json package mismatch: "
+            f"expected {PACKAGE_NAME!r}, got {package!r}"
+        )
     if repo != REPO_URL:
         fail(f"reflexio.lock.json repo mismatch: expected {REPO_URL!r}, got {repo!r}")
     if source not in VALID_SOURCES:
@@ -111,7 +130,11 @@ def main() -> int:
 
     if source == "vendor":
         vendor_path = require_str(lock_data, "vendor_path")
-        vendor = repo_root / vendor_path
+        vendor = (repo_root / vendor_path).resolve()
+        try:
+            vendor_display = vendor.relative_to(repo_root)
+        except ValueError:
+            fail(f"vendor_path must stay within repo root: {vendor}")
         if args.check_vendor:
             vendor_version = read_vendor_version(vendor)
             if vendor_version != version:
@@ -121,7 +144,7 @@ def main() -> int:
                     f"  reflexio.lock.json:       {version}\n"
                     "Run: bash scripts/release-with-reflexio.sh"
                 )
-            print(f"OK: vendored Reflexio bundle present at {vendor.relative_to(repo_root)}")
+            print(f"OK: vendored Reflexio bundle present at {vendor_display}")
 
     print(f"OK: {actual} ({source})")
     return 0

--- a/scripts/check-reflexio-lock.py
+++ b/scripts/check-reflexio-lock.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -16,7 +17,18 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check-vendor",
+        action="store_true",
+        help="If reflexio.lock.json uses source=vendor, require the generated vendor bundle",
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
+    args = parse_args()
     repo_root = Path(__file__).resolve().parents[1]
     lock_path = repo_root / "reflexio.lock.json"
     pyproject_path = repo_root / "plugin" / "pyproject.toml"
@@ -43,6 +55,15 @@ def main() -> int:
             f"  reflexio.lock.json:   {expected}\n"
             "Run: python scripts/sync-reflexio-dep.py --write"
         )
+
+    if args.check_vendor and lock_data.get("source") == "vendor":
+        vendor = repo_root / str(lock_data.get("vendor_path") or "plugin/vendor/reflexio")
+        if not (vendor / "pyproject.toml").is_file():
+            fail(
+                f"reflexio.lock.json requires vendored Reflexio but {vendor} is missing; "
+                "run bash scripts/release-with-reflexio.sh before npm publish"
+            )
+        print(f"OK: vendored Reflexio bundle present at {vendor.relative_to(repo_root)}")
 
     print(f"OK: {actual}")
     return 0

--- a/scripts/doctor-reflexio.py
+++ b/scripts/doctor-reflexio.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Diagnose whether claude-smart is using local, vendor, or PyPI Reflexio."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message: str, code: int = 1) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run_import_probe(repo_root: Path) -> dict[str, str]:
+    code = (
+        "import json, pathlib, reflexio; "
+        "print(json.dumps({"
+        "'file': str(pathlib.Path(reflexio.__file__).resolve()), "
+        "'version': str(getattr(reflexio, '__version__', 'unknown'))"
+        "}))"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "--project",
+                str(repo_root / "plugin"),
+                "--no-sync",
+                "python",
+                "-c",
+                code,
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        fail("uv is not on PATH; install uv or run scripts/setup-local-dev.sh")
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        fail(
+            "could not import reflexio from the claude-smart plugin environment. "
+            "Run `uv sync --project plugin` or `bash scripts/use-local-reflexio.sh`.\n"
+            f"{detail}"
+        )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        fail(f"unexpected import probe output: {result.stdout!r}")
+
+
+def classify_import(import_file: Path, repo_root: Path, reflexio_path: Path) -> str:
+    local_package = reflexio_path / "reflexio"
+    vendor_package = repo_root / "plugin" / "vendor" / "reflexio" / "reflexio"
+    if import_file.is_relative_to(local_package):
+        return "local"
+    if import_file.is_relative_to(vendor_package):
+        return "vendor"
+    if "site-packages" in import_file.parts:
+        return "pypi"
+    return "unknown"
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reflexio-path",
+        type=Path,
+        default=Path(os.environ.get("REFLEXIO_PATH", repo_root.parent / "reflexio")),
+        help="Expected local Reflexio checkout (default: REFLEXIO_PATH or ../reflexio)",
+    )
+    parser.add_argument(
+        "--allow-pypi",
+        action="store_true",
+        help="Exit 0 when the sibling Reflexio checkout exists but PyPI is active",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    reflexio_path = args.reflexio_path.expanduser()
+    reflexio_path = (
+        (repo_root / reflexio_path).resolve()
+        if not reflexio_path.is_absolute()
+        else reflexio_path.resolve()
+    )
+    probe = run_import_probe(repo_root)
+    import_file = Path(probe["file"]).resolve()
+    expected_file = reflexio_path / "reflexio" / "__init__.py"
+    checkout_exists = (reflexio_path / "pyproject.toml").is_file() and (
+        reflexio_path / "reflexio"
+    ).is_dir()
+    source = classify_import(import_file, repo_root, reflexio_path)
+
+    print(f"Reflexio import path: {import_file}", flush=True)
+    print(f"Reflexio version: {probe.get('version', 'unknown')}", flush=True)
+    print(f"Expected local checkout: {reflexio_path}", flush=True)
+    print(f"Expected local package: {expected_file}", flush=True)
+    print(f"Detected source: {source}", flush=True)
+
+    if source == "local":
+        print("Status: OK - claude-smart is using the local editable Reflexio checkout.")
+        return 0
+    if source == "vendor":
+        print("Status: OK - claude-smart is using the generated vendored Reflexio bundle.")
+        return 0
+    if checkout_exists and not args.allow_pypi:
+        print(
+            "Status: using PyPI/other Reflexio even though a local checkout exists."
+        )
+        print("Fix: bash scripts/use-local-reflexio.sh")
+        return 1
+    if checkout_exists:
+        print(
+            "Status: using PyPI/other Reflexio; local checkout exists but is not active."
+        )
+        print("Fix for cross-repo dev: bash scripts/use-local-reflexio.sh")
+    else:
+        print("Status: using PyPI/other Reflexio; no local sibling checkout was found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-with-reflexio.sh
+++ b/scripts/release-with-reflexio.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Prepare a claude-smart release that depends on a newly published Reflexio.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"
+
+cd "$REPO_ROOT"
+
+echo "Using Reflexio checkout: $REFLEXIO_PATH"
+python scripts/sync-reflexio-dep.py \
+  --reflexio-path "$REFLEXIO_PATH" \
+  --write \
+  --check-pypi \
+  --release-checks
+uv lock --project plugin --upgrade-package reflexio-ai
+uv sync --project plugin --locked
+(cd plugin && uv run --project . pytest --rootdir .. -o addopts= ../tests -q)
+npm pack --dry-run
+
+cat <<'EOF'
+
+Release checks passed.
+Review and commit:
+  plugin/pyproject.toml
+  plugin/uv.lock
+  reflexio.lock.json
+
+Then publish claude-smart with the existing release flow, for example:
+  make release VERSION=<new-claude-smart-version>
+EOF

--- a/scripts/release-with-reflexio.sh
+++ b/scripts/release-with-reflexio.sh
@@ -1,26 +1,67 @@
 #!/usr/bin/env bash
-# Prepare a claude-smart release that depends on a newly published Reflexio.
+# Prepare a claude-smart release that needs a specific Reflexio checkout.
+#
+# Default mode vendors Reflexio into plugin/vendor/reflexio for the npm tarball,
+# so user installs do not need GitHub or a freshly published reflexio-ai wheel.
+# Set REFLEXIO_RELEASE_SOURCE=pypi to use the strict PyPI-published flow.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"
+REFLEXIO_RELEASE_SOURCE="${REFLEXIO_RELEASE_SOURCE:-vendor}"
 
 cd "$REPO_ROOT"
 
 echo "Using Reflexio checkout: $REFLEXIO_PATH"
-python scripts/sync-reflexio-dep.py \
-  --reflexio-path "$REFLEXIO_PATH" \
-  --write \
-  --check-pypi \
-  --release-checks
-uv lock --project plugin --upgrade-package reflexio-ai
-uv sync --project plugin --locked
-(cd plugin && uv run --project . pytest --rootdir .. -o addopts= ../tests -q)
+
+case "$REFLEXIO_RELEASE_SOURCE" in
+  vendor)
+    python scripts/vendor-reflexio.py \
+      --reflexio-path "$REFLEXIO_PATH" \
+      --write
+    uv sync --project plugin --locked
+    PLUGIN_PYTHON="$REPO_ROOT/plugin/.venv/bin/python"
+    if [ ! -x "$PLUGIN_PYTHON" ]; then
+      echo "error: plugin Python was not created by uv sync: $PLUGIN_PYTHON" >&2
+      exit 1
+    fi
+    uv pip install --project plugin --python "$PLUGIN_PYTHON" -e plugin/vendor/reflexio
+    ;;
+  pypi)
+    python scripts/sync-reflexio-dep.py \
+      --reflexio-path "$REFLEXIO_PATH" \
+      --write \
+      --check-pypi \
+      --release-checks
+    uv lock --project plugin --upgrade-package reflexio-ai
+    uv sync --project plugin --locked
+    ;;
+  *)
+    echo "error: REFLEXIO_RELEASE_SOURCE must be 'vendor' or 'pypi'" >&2
+    exit 1
+    ;;
+esac
+
+(cd plugin && uv run --project . --no-sync pytest --rootdir .. -o addopts= ../tests -q)
 npm pack --dry-run
 
-cat <<'EOF'
+if [ "$REFLEXIO_RELEASE_SOURCE" = "vendor" ]; then
+  cat <<'EOF'
+
+Release checks passed.
+Review and commit:
+  reflexio.lock.json
+
+Keep generated plugin/vendor/reflexio in place until npm publish completes.
+It is gitignored but included in the npm tarball.
+
+Then publish the npm artifact only:
+  make release-npm VERSION=<new-claude-smart-version>
+EOF
+else
+  cat <<'EOF'
 
 Release checks passed.
 Review and commit:
@@ -31,3 +72,4 @@ Review and commit:
 Then publish claude-smart with the existing release flow, for example:
   make release VERSION=<new-claude-smart-version>
 EOF
+fi

--- a/scripts/release-with-reflexio.sh
+++ b/scripts/release-with-reflexio.sh
@@ -11,6 +11,38 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"
 REFLEXIO_RELEASE_SOURCE="${REFLEXIO_RELEASE_SOURCE:-vendor}"
+PYTHON_BIN="${PYTHON:-python3}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "error: Python interpreter not found: $PYTHON_BIN" >&2
+  echo "Set PYTHON=/path/to/python3 or install python3." >&2
+  exit 1
+fi
+
+verify_vendor_in_npm_pack() {
+  pack_json="$(mktemp "${TMPDIR:-/tmp}/claude-smart-pack.XXXXXX.json")"
+  npm pack --dry-run --json > "$pack_json"
+  "$PYTHON_BIN" - "$pack_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+files = {entry["path"] for package in payload for entry in package.get("files", [])}
+required = {
+    "plugin/vendor/reflexio/pyproject.toml",
+    "plugin/vendor/reflexio/reflexio/__init__.py",
+}
+missing = sorted(required.difference(files))
+if missing:
+    raise SystemExit(
+        "error: npm pack is missing vendored Reflexio files:\n  "
+        + "\n  ".join(missing)
+    )
+print("OK: npm tarball includes vendored Reflexio files")
+PY
+  rm -f "$pack_json"
+}
 
 cd "$REPO_ROOT"
 
@@ -18,7 +50,7 @@ echo "Using Reflexio checkout: $REFLEXIO_PATH"
 
 case "$REFLEXIO_RELEASE_SOURCE" in
   vendor)
-    python scripts/vendor-reflexio.py \
+    "$PYTHON_BIN" scripts/vendor-reflexio.py \
       --reflexio-path "$REFLEXIO_PATH" \
       --write
     uv sync --project plugin --locked
@@ -30,7 +62,7 @@ case "$REFLEXIO_RELEASE_SOURCE" in
     uv pip install --project plugin --python "$PLUGIN_PYTHON" -e plugin/vendor/reflexio
     ;;
   pypi)
-    python scripts/sync-reflexio-dep.py \
+    "$PYTHON_BIN" scripts/sync-reflexio-dep.py \
       --reflexio-path "$REFLEXIO_PATH" \
       --write \
       --check-pypi \
@@ -45,7 +77,11 @@ case "$REFLEXIO_RELEASE_SOURCE" in
 esac
 
 (cd plugin && uv run --project . --no-sync pytest --rootdir .. -o addopts= ../tests -q)
-npm pack --dry-run
+if [ "$REFLEXIO_RELEASE_SOURCE" = "vendor" ]; then
+  verify_vendor_in_npm_pack
+else
+  npm pack --dry-run
+fi
 
 if [ "$REFLEXIO_RELEASE_SOURCE" = "vendor" ]; then
   cat <<'EOF'

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -6,7 +6,7 @@
 #   1. Install a side-by-side Reflexio checkout into the plugin venv as editable.
 #   2. `uv sync` from plugin/.
 #   3. Append CLAUDE_SMART_USE_LOCAL_CLI=1 / _USE_LOCAL_EMBEDDING=1 to
-#      ~/.reflexio/.env so reflexio runs without any external API key.
+#      ~/.reflexio/.env so Reflexio runs without any external API key.
 #   4. For Claude Code (default): prepare and register the local marketplace
 #      (user scope) so `claude-smart@reflexioai-local` is available everywhere.
 #   5. For Claude Code: disable the published claude-smart plugin at user scope
@@ -26,8 +26,6 @@ set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HERE/.." && pwd)"
 PLUGIN_ROOT="$REPO_ROOT/plugin"
-PYPROJECT="$PLUGIN_ROOT/pyproject.toml"
-LOCKFILE="$PLUGIN_ROOT/uv.lock"
 
 log() { printf '[setup-local-dev] %s\n' "$*" >&2; }
 
@@ -200,7 +198,7 @@ if ! grep -q '^CLAUDE_SMART_USE_LOCAL_CLI=' "$REFLEXIO_ENV"; then
   log "appended CLAUDE_SMART_USE_LOCAL_CLI=1 to $REFLEXIO_ENV"
 fi
 if ! grep -q '^CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$REFLEXIO_ENV"; then
-  printf '# Use the in-process ONNX embedder (chromadb) — no API key for semantic search\nCLAUDE_SMART_USE_LOCAL_EMBEDDING=1\n' >> "$REFLEXIO_ENV"
+  printf '# Use Reflexio local embedding support — no API key for semantic search\nCLAUDE_SMART_USE_LOCAL_EMBEDDING=1\n' >> "$REFLEXIO_ENV"
   log "appended CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 to $REFLEXIO_ENV"
 fi
 python3 - "$REFLEXIO_ENV" "$READ_ONLY" <<'PY'

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -3,23 +3,19 @@
 #
 # Does what the published install wrapper does for end users, plus the
 # extra steps that only make sense when you're iterating on this repo:
-#   1. Initialize the reflexio submodule fallback.
-#   2. Uncomment the `[tool.uv.sources]` block in plugin/pyproject.toml so
-#      uv resolves reflexio-ai from a local Reflexio checkout (editable).
-#   3. `git update-index --skip-worktree` plugin/pyproject.toml + uv.lock
-#      so the local divergence is invisible to `git status`.
-#   4. `uv sync` from plugin/.
-#   5. Append CLAUDE_SMART_USE_LOCAL_CLI=1 / _USE_LOCAL_EMBEDDING=1 to
+#   1. Install a side-by-side Reflexio checkout into the plugin venv as editable.
+#   2. `uv sync` from plugin/.
+#   3. Append CLAUDE_SMART_USE_LOCAL_CLI=1 / _USE_LOCAL_EMBEDDING=1 to
 #      ~/.reflexio/.env so reflexio runs without any external API key.
-#   6. For Claude Code (default): prepare and register the local marketplace
+#   4. For Claude Code (default): prepare and register the local marketplace
 #      (user scope) so `claude-smart@reflexioai-local` is available everywhere.
-#   7. For Claude Code: disable the published claude-smart plugin at user scope
+#   5. For Claude Code: disable the published claude-smart plugin at user scope
 #      so Desktop/other projects don't load both plugins side by side.
-#   8. For Claude Code: wire this repo's .claude/settings.local.json to enable
+#   6. For Claude Code: wire this repo's .claude/settings.local.json to enable
 #      the local plugin and shadow the remote one for this project.
-#   9. With `--read-only`, write CLAUDE_SMART_READ_ONLY=1 so local hooks
+#   7. With `--read-only`, write CLAUDE_SMART_READ_ONLY=1 so local hooks
 #      buffer but do not publish interactions to Reflexio.
-#   10. For Codex (`--host codex` or `--host both`): run the maintained
+#   8. For Codex (`--host codex` or `--host both`): run the maintained
 #      Node install wrapper so Codex hooks are patched through the JSON-safe
 #      codex-hook.js adapter.
 #
@@ -49,28 +45,30 @@ resolve_reflexio_source() {
     exit 1
   fi
 
-  # In reflexio-enterprise worktrees, claude-smart and reflexio are sibling
-  # submodules under open_source/. Prefer that current workspace checkout over
-  # claude-smart's nested fallback so local-dev installs do not pin an older
-  # Reflexio client into ~/.reflexio/plugin-root.
+  if [ -n "${REFLEXIO_PATH:-}" ]; then
+    if is_reflexio_checkout "$REFLEXIO_PATH"; then
+      (cd "$REFLEXIO_PATH" && pwd)
+      return 0
+    fi
+    log "ERROR: REFLEXIO_PATH is not a Reflexio checkout: $REFLEXIO_PATH"
+    exit 1
+  fi
+
+  # In the standard development layout, claude-smart and reflexio are sibling
+  # repositories.
   sibling_reflexio="$REPO_ROOT/../reflexio"
   if is_reflexio_checkout "$sibling_reflexio"; then
     (cd "$sibling_reflexio" && pwd)
     return 0
   fi
 
-  bundled_reflexio="$REPO_ROOT/reflexio"
-  if is_reflexio_checkout "$bundled_reflexio"; then
-    (cd "$bundled_reflexio" && pwd)
-    return 0
-  fi
-
-  log "ERROR: could not find a Reflexio checkout at $sibling_reflexio or $bundled_reflexio"
+  log "ERROR: could not find a Reflexio checkout at $sibling_reflexio"
+  log "Set REFLEXIO_PATH=/path/to/reflexio or CLAUDE_SMART_LOCAL_REFLEXIO_PATH=/path/to/reflexio."
   exit 1
 }
 
 verify_reflexio_client() {
-  (cd "$PLUGIN_ROOT" && REFLEXIO_SOURCE_PATH="$REFLEXIO_ABS" uv run --quiet python - <<'PY'
+  (cd "$PLUGIN_ROOT" && REFLEXIO_SOURCE_PATH="$REFLEXIO_ABS" uv run --no-sync --quiet python - <<'PY'
 import inspect
 import os
 import sys
@@ -183,33 +181,15 @@ case "$HOST" in
     ;;
 esac
 
-log "initializing reflexio submodule fallback..."
-(cd "$REPO_ROOT" && git submodule update --init --recursive reflexio)
-
-log "enabling [tool.uv.sources] override in plugin/pyproject.toml..."
-# Use an absolute path for the Reflexio checkout. Relative paths like
-# "../reflexio" get resolved by uv against the literal --project path,
-# which breaks when slash commands pass the ~/.reflexio/plugin-root
-# symlink (uv does not canonicalize) — it would resolve to
-# $HOME/.reflexio/reflexio, which does not exist.
 REFLEXIO_ABS="$(resolve_reflexio_source)"
 log "using Reflexio source at $REFLEXIO_ABS"
-sed -i.bak -E \
-  -e 's|^# \[tool\.uv\.sources\]$|[tool.uv.sources]|' \
-  -e "s|^(# )?reflexio-ai = \\{ path = \"[^\"]*\", editable = true \\}\$|reflexio-ai = { path = \"$REFLEXIO_ABS\", editable = true }|" \
-  "$PYPROJECT"
-rm -f "$PYPROJECT.bak"
-
-# Hide local divergence in pyproject.toml + uv.lock from `git status`. See
-# DEVELOPER.md ("Developing locally") for the rationale.
-git -C "$REPO_ROOT" update-index --skip-worktree plugin/pyproject.toml plugin/uv.lock
 
 if ! command -v uv >/dev/null 2>&1; then
   log "ERROR: uv not found — install it from https://docs.astral.sh/uv/ first."
   exit 1
 fi
-log "running uv sync in plugin/ ..."
-(cd "$PLUGIN_ROOT" && uv sync --quiet)
+log "installing editable Reflexio into plugin environment..."
+REFLEXIO_PATH="$REFLEXIO_ABS" bash "$REPO_ROOT/scripts/use-local-reflexio.sh"
 verify_reflexio_client
 
 REFLEXIO_ENV="$HOME/.reflexio/.env"
@@ -437,7 +417,7 @@ elif [ "$SETUP_CODEX" = "1" ]; then
 else
   log "done. Restart Claude Code to pick up the local plugin."
 fi
-log "  pyproject.toml → editable reflexio-ai from $REFLEXIO_ABS"
+log "  plugin venv → editable reflexio-ai from $REFLEXIO_ABS"
 log "  ~/.reflexio/.env → local-CLI + local-embedding providers"
 if [ "$SETUP_CLAUDE_CODE" = "1" ]; then
   log "  Claude Code user marketplaces → reflexioai-local ($LOCAL_MKT_DIR)"

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -17,7 +17,8 @@
 #      buffer but do not publish interactions to Reflexio.
 #   8. For Codex (`--host codex` or `--host both`): run the maintained
 #      Node install wrapper so Codex hooks are patched through the JSON-safe
-#      codex-hook.js adapter.
+#      codex-hook.js adapter, then install the same editable Reflexio checkout
+#      into the Codex plugin cache venv used by those hooks.
 #   9. Print a Reflexio source diagnostic so local/PyPI mixups are visible.
 #
 # Idempotent: safe to re-run.
@@ -86,6 +87,111 @@ if "override_learning_stall" not in signature.parameters:
     sys.exit(1)
 PY
   )
+}
+
+codex_plugin_cache_root() {
+  python3 - "$REPO_ROOT/plugin/.codex-plugin/plugin.json" "$HOME/.codex/plugins/cache/reflexioai/claude-smart" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = Path(sys.argv[1])
+cache_root = Path(sys.argv[2])
+version = json.loads(manifest.read_text())["version"]
+print(cache_root / version)
+PY
+}
+
+write_local_reflexio_uv_source() {
+  project_root="$1"
+  pyproject="$project_root/pyproject.toml"
+  if [ ! -f "$pyproject" ]; then
+    log "ERROR: expected pyproject.toml at $pyproject"
+    exit 1
+  fi
+  python3 - "$pyproject" "$REFLEXIO_ABS" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+reflexio_path = sys.argv[2]
+entry = f"reflexio-ai = {{ path = {json.dumps(reflexio_path)}, editable = true }}"
+lines = path.read_text().splitlines()
+out: list[str] = []
+in_sources = False
+sources_seen = False
+entry_written = False
+
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        if in_sources and not entry_written:
+            out.append(entry)
+            entry_written = True
+        in_sources = stripped == "[tool.uv.sources]"
+        sources_seen = sources_seen or in_sources
+        out.append(line)
+        continue
+    if in_sources and stripped.startswith("reflexio-ai "):
+        continue
+    out.append(line)
+
+if in_sources and not entry_written:
+    out.append(entry)
+    entry_written = True
+
+if not sources_seen:
+    if out and out[-1] != "":
+        out.append("")
+    out.append("[tool.uv.sources]")
+    out.append(entry)
+
+path.write_text("\n".join(out) + "\n")
+PY
+}
+
+install_editable_reflexio_into_codex_cache() {
+  cache_root="$(codex_plugin_cache_root)"
+  if [ ! -d "$cache_root" ]; then
+    log "ERROR: Codex plugin cache was not created at $cache_root"
+    exit 1
+  fi
+
+  marketplace_plugin_root="$HOME/.claude/plugins/marketplaces/reflexioai/plugin"
+  log "writing local Reflexio source override into Codex marketplace snapshot..."
+  write_local_reflexio_uv_source "$marketplace_plugin_root"
+  write_local_reflexio_uv_source "$cache_root"
+
+  log "installing editable Reflexio into Codex plugin cache..."
+  uv sync --project "$cache_root"
+  cache_python="$cache_root/.venv/bin/python"
+  if [ ! -x "$cache_python" ]; then
+    log "ERROR: Codex plugin cache Python was not created by uv sync: $cache_python"
+    exit 1
+  fi
+  uv pip install --project "$cache_root" --python "$cache_python" -e "$REFLEXIO_ABS"
+  REFLEXIO_SOURCE_PATH="$REFLEXIO_ABS" "$cache_python" - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+import reflexio
+
+expected_package = Path(os.environ["REFLEXIO_SOURCE_PATH"]).resolve() / "reflexio"
+import_file = Path(reflexio.__file__).resolve()
+try:
+    import_file.relative_to(expected_package)
+except ValueError:
+    print(
+        "[setup-local-dev] ERROR: Codex plugin cache imports Reflexio from "
+        f"{import_file}, expected under {expected_package}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(f"[setup-local-dev] Codex cache Reflexio import path: {import_file}")
+PY
 }
 
 refresh_local_dashboard() {
@@ -399,6 +505,7 @@ if [ "$SETUP_CODEX" = "1" ]; then
   log "installing local claude-smart plugin for Codex..."
   rm -f "$HOME/plugins/claude-smart"
   (cd "$REPO_ROOT" && node bin/claude-smart.js install --host codex)
+  install_editable_reflexio_into_codex_cache
 fi
 
 if [ "$SETUP_CLAUDE_CODE" = "1" ] && [ "$SETUP_CODEX" = "1" ]; then
@@ -425,5 +532,6 @@ if [ "$SETUP_CLAUDE_CODE" = "1" ]; then
 fi
 if [ "$SETUP_CODEX" = "1" ]; then
   log "  Codex marketplace/cache/config → claude-smart@reflexioai"
+  log "  Codex cache venv → editable reflexio-ai from $REFLEXIO_ABS"
   log "  Codex hooks → patched through scripts/codex-hook.js"
 fi

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -35,22 +35,51 @@ is_reflexio_checkout() {
   [ -f "$1/pyproject.toml" ] && [ -d "$1/reflexio" ]
 }
 
+expand_user_path() {
+  case "$1" in
+    "~")
+      printf '%s\n' "$HOME"
+      ;;
+    "~/"*)
+      printf '%s/%s\n' "$HOME" "${1#"~/"}"
+      ;;
+    *)
+      printf '%s\n' "$1"
+      ;;
+  esac
+}
+
+resolve_venv_python() {
+  venv_root="$1/.venv"
+  if [ -x "$venv_root/bin/python" ]; then
+    printf '%s\n' "$venv_root/bin/python"
+    return 0
+  fi
+  if [ -x "$venv_root/Scripts/python.exe" ]; then
+    printf '%s\n' "$venv_root/Scripts/python.exe"
+    return 0
+  fi
+  return 1
+}
+
 resolve_reflexio_source() {
   if [ -n "${CLAUDE_SMART_LOCAL_REFLEXIO_PATH:-}" ]; then
-    if is_reflexio_checkout "$CLAUDE_SMART_LOCAL_REFLEXIO_PATH"; then
-      (cd "$CLAUDE_SMART_LOCAL_REFLEXIO_PATH" && pwd)
+    reflexio_env_path="$(expand_user_path "$CLAUDE_SMART_LOCAL_REFLEXIO_PATH")"
+    if is_reflexio_checkout "$reflexio_env_path"; then
+      (cd "$reflexio_env_path" && pwd)
       return 0
     fi
-    log "ERROR: CLAUDE_SMART_LOCAL_REFLEXIO_PATH is not a Reflexio checkout: $CLAUDE_SMART_LOCAL_REFLEXIO_PATH"
+    log "ERROR: CLAUDE_SMART_LOCAL_REFLEXIO_PATH is not a Reflexio checkout: $reflexio_env_path"
     exit 1
   fi
 
   if [ -n "${REFLEXIO_PATH:-}" ]; then
-    if is_reflexio_checkout "$REFLEXIO_PATH"; then
-      (cd "$REFLEXIO_PATH" && pwd)
+    reflexio_env_path="$(expand_user_path "$REFLEXIO_PATH")"
+    if is_reflexio_checkout "$reflexio_env_path"; then
+      (cd "$reflexio_env_path" && pwd)
       return 0
     fi
-    log "ERROR: REFLEXIO_PATH is not a Reflexio checkout: $REFLEXIO_PATH"
+    log "ERROR: REFLEXIO_PATH is not a Reflexio checkout: $reflexio_env_path"
     exit 1
   fi
 
@@ -165,9 +194,8 @@ install_editable_reflexio_into_codex_cache() {
 
   log "installing editable Reflexio into Codex plugin cache..."
   uv sync --project "$cache_root"
-  cache_python="$cache_root/.venv/bin/python"
-  if [ ! -x "$cache_python" ]; then
-    log "ERROR: Codex plugin cache Python was not created by uv sync: $cache_python"
+  if ! cache_python="$(resolve_venv_python "$cache_root")"; then
+    log "ERROR: Codex plugin cache Python was not created by uv sync under $cache_root/.venv"
     exit 1
   fi
   uv pip install --project "$cache_root" --python "$cache_python" -e "$REFLEXIO_ABS"

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -18,6 +18,7 @@
 #   8. For Codex (`--host codex` or `--host both`): run the maintained
 #      Node install wrapper so Codex hooks are patched through the JSON-safe
 #      codex-hook.js adapter.
+#   9. Print a Reflexio source diagnostic so local/PyPI mixups are visible.
 #
 # Idempotent: safe to re-run.
 
@@ -416,6 +417,7 @@ else
   log "done. Restart Claude Code to pick up the local plugin."
 fi
 log "  plugin venv → editable reflexio-ai from $REFLEXIO_ABS"
+log "  verify source → make doctor-reflexio"
 log "  ~/.reflexio/.env → local-CLI + local-embedding providers"
 if [ "$SETUP_CLAUDE_CODE" = "1" ]; then
   log "  Claude Code user marketplaces → reflexioai-local ($LOCAL_MKT_DIR)"

--- a/scripts/sync-reflexio-dep.py
+++ b/scripts/sync-reflexio-dep.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Synchronize claude-smart's reflexio-ai dependency from a Reflexio checkout."""
+"""Synchronize claude-smart's PyPI reflexio-ai dependency from Reflexio.
+
+Use this for the strict PyPI release path. For fast npm releases that need
+unpublished Reflexio changes, use scripts/vendor-reflexio.py via
+scripts/release-with-reflexio.sh.
+"""
 
 from __future__ import annotations
 
@@ -136,6 +141,7 @@ def current_lock_updated_at(
         "version": version,
         "commit": commit,
         "dependency": dependency,
+        "source": "pypi",
     }
     for key, value in expected.items():
         if payload.get(key) != value:
@@ -151,6 +157,7 @@ def build_lock(version: str, commit: str, dependency: str, updated_at: str | Non
         "version": version,
         "commit": commit,
         "dependency": dependency,
+        "source": "pypi",
         "updated_at": updated_at
         or datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
     }
@@ -220,7 +227,7 @@ def main() -> int:
     print(f"Reflexio package: {package}")
     print(f"Reflexio version: {version}")
     print(f"Reflexio commit: {commit}")
-    print(f"New dependency: {dependency}")
+    print(f"New PyPI dependency: {dependency}")
 
     if args.write:
         if pyproject_changed:

--- a/scripts/sync-reflexio-dep.py
+++ b/scripts/sync-reflexio-dep.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Synchronize claude-smart's reflexio-ai dependency from a Reflexio checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+PACKAGE_NAME = "reflexio-ai"
+REPO_URL = "https://github.com/ReflexioAI/reflexio.git"
+DEPENDENCY_RE = re.compile(r'"reflexio-ai[^"]*"')
+VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def run_git(repo: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        command = " ".join(("git", "-C", str(repo), *args))
+        detail = (exc.stderr or exc.stdout or "").strip()
+        fail(f"{command} failed: {detail or f'exit {exc.returncode}'}")
+    return result.stdout.strip()
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_project_metadata(reflexio_path: Path) -> tuple[str, str]:
+    pyproject = reflexio_path / "pyproject.toml"
+    if not pyproject.is_file():
+        fail(f"{reflexio_path} does not contain pyproject.toml")
+
+    with pyproject.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    project = data.get("project", {})
+    name = project.get("name")
+    version = project.get("version")
+    if name != PACKAGE_NAME:
+        fail(f"expected [project].name = {PACKAGE_NAME!r}, found {name!r}")
+    if not isinstance(version, str) or not version:
+        fail("missing [project].version in Reflexio pyproject.toml")
+    return name, version
+
+
+def dependency_for(version: str) -> str:
+    if not VERSION_RE.match(version):
+        fail(f"expected semantic version major.minor.patch, got {version!r}")
+    return f"{PACKAGE_NAME}>={version}"
+
+
+def check_pypi(version: str) -> None:
+    url = f"https://pypi.org/pypi/{PACKAGE_NAME}/{version}/json"
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "claude-smart-release"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            if response.status != 200:
+                fail(
+                    f"{PACKAGE_NAME}=={version} is not published on PyPI "
+                    f"(HTTP {response.status})"
+                )
+    except urllib.error.HTTPError as exc:
+        fail(f"{PACKAGE_NAME}=={version} is not published on PyPI (HTTP {exc.code})")
+    except urllib.error.URLError as exc:
+        fail(f"could not check PyPI for {PACKAGE_NAME}=={version}: {exc.reason}")
+
+
+def check_release_git_state(reflexio_path: Path, version: str, commit: str) -> None:
+    run_git(reflexio_path, "fetch", "origin", "main", "--tags")
+    origin_main = run_git(reflexio_path, "rev-parse", "origin/main")
+    if commit != origin_main:
+        fail(
+            "Reflexio checkout is not at origin/main:\n"
+            f"  checkout HEAD: {commit}\n"
+            f"  origin/main:   {origin_main}\n"
+            "Release sync must run against the published Reflexio main commit."
+        )
+
+    expected_tag = f"v{version}"
+    tags = set(run_git(reflexio_path, "tag", "--points-at", "HEAD").splitlines())
+    if expected_tag not in tags:
+        found = ", ".join(sorted(tags)) if tags else "none"
+        fail(
+            f"Reflexio HEAD is not tagged {expected_tag}. "
+            f"Tags at HEAD: {found}. "
+            "Tag the Reflexio release commit before syncing claude-smart."
+        )
+
+
+def updated_pyproject_text(pyproject: Path, dependency: str) -> tuple[str, bool]:
+    text = pyproject.read_text()
+    matches = DEPENDENCY_RE.findall(text)
+    if len(matches) != 1:
+        fail(
+            f"expected exactly one quoted {PACKAGE_NAME} dependency in {pyproject}, "
+            f"found {len(matches)}"
+        )
+    new_text = DEPENDENCY_RE.sub(f'"{dependency}"', text, count=1)
+    return new_text, new_text != text
+
+
+def current_lock_updated_at(
+    lock_file: Path,
+    version: str,
+    commit: str,
+    dependency: str,
+) -> str | None:
+    if not lock_file.is_file():
+        return None
+    try:
+        payload = json.loads(lock_file.read_text())
+    except json.JSONDecodeError:
+        return None
+    expected = {
+        "package": PACKAGE_NAME,
+        "repo": REPO_URL,
+        "version": version,
+        "commit": commit,
+        "dependency": dependency,
+    }
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            return None
+    updated_at = payload.get("updated_at")
+    return updated_at if isinstance(updated_at, str) and updated_at else None
+
+
+def build_lock(version: str, commit: str, dependency: str, updated_at: str | None) -> str:
+    payload = {
+        "package": PACKAGE_NAME,
+        "repo": REPO_URL,
+        "version": version,
+        "commit": commit,
+        "dependency": dependency,
+        "updated_at": updated_at
+        or datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reflexio-path",
+        type=Path,
+        default=repo_root.parent / "reflexio",
+        help="Path to Reflexio checkout (default: ../reflexio relative to claude-smart)",
+    )
+    parser.add_argument("--check-pypi", action="store_true", help="Verify version exists on PyPI")
+    parser.add_argument(
+        "--release-checks",
+        action="store_true",
+        help="Require Reflexio HEAD to equal origin/main and be tagged v<version>",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Allow uncommitted changes in the Reflexio checkout",
+    )
+    parser.add_argument("--write", action="store_true", help="Modify files instead of dry-run")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    reflexio_path = args.reflexio_path.expanduser()
+    if not reflexio_path.is_absolute():
+        reflexio_path = (repo_root / reflexio_path).resolve()
+    else:
+        reflexio_path = reflexio_path.resolve()
+
+    if not reflexio_path.exists():
+        fail(f"Reflexio path does not exist: {reflexio_path}")
+
+    package, version = read_project_metadata(reflexio_path)
+    if not args.allow_dirty:
+        dirty = run_git(reflexio_path, "status", "--porcelain")
+        if dirty:
+            fail(
+                f"Reflexio checkout has uncommitted changes at {reflexio_path}. "
+                "Commit/stash them or pass --allow-dirty."
+            )
+
+    commit = run_git(reflexio_path, "rev-parse", "HEAD")
+    dependency = dependency_for(version)
+    if args.release_checks:
+        check_release_git_state(reflexio_path, version, commit)
+    if args.check_pypi:
+        check_pypi(version)
+
+    pyproject = repo_root / "plugin" / "pyproject.toml"
+    lock_file = repo_root / "reflexio.lock.json"
+    new_pyproject, pyproject_changed = updated_pyproject_text(pyproject, dependency)
+    updated_at = current_lock_updated_at(lock_file, version, commit, dependency)
+    new_lock = build_lock(version, commit, dependency, updated_at)
+    lock_changed = not lock_file.exists() or lock_file.read_text() != new_lock
+
+    print(f"Reflexio path: {reflexio_path}")
+    print(f"Reflexio package: {package}")
+    print(f"Reflexio version: {version}")
+    print(f"Reflexio commit: {commit}")
+    print(f"New dependency: {dependency}")
+
+    if args.write:
+        if pyproject_changed:
+            pyproject.write_text(new_pyproject)
+            print(f"Updated: {pyproject.relative_to(repo_root)}")
+        else:
+            print(f"Unchanged: {pyproject.relative_to(repo_root)}")
+        if lock_changed:
+            lock_file.write_text(new_lock)
+            print(f"Updated: {lock_file.relative_to(repo_root)}")
+        else:
+            print(f"Unchanged: {lock_file.relative_to(repo_root)}")
+    else:
+        print("Dry run only; no files changed.")
+        print(
+            "Would update:"
+            f" {pyproject.relative_to(repo_root) if pyproject_changed else 'no pyproject change'},"
+            f" {lock_file.relative_to(repo_root) if lock_changed else 'no lock change'}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/use-local-reflexio.sh
+++ b/scripts/use-local-reflexio.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Install a side-by-side Reflexio checkout into the claude-smart plugin venv.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_ROOT="$REPO_ROOT/plugin"
+REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"
+
+if [ ! -d "$REFLEXIO_PATH" ]; then
+  echo "error: REFLEXIO_PATH does not exist: $REFLEXIO_PATH" >&2
+  exit 1
+fi
+if [ ! -f "$REFLEXIO_PATH/pyproject.toml" ]; then
+  echo "error: REFLEXIO_PATH does not contain pyproject.toml: $REFLEXIO_PATH" >&2
+  exit 1
+fi
+
+REFLEXIO_PATH="$(cd "$REFLEXIO_PATH" && pwd)"
+echo "Using Reflexio checkout: $REFLEXIO_PATH"
+
+uv sync --project "$PLUGIN_ROOT"
+PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/bin/python"
+if [ ! -x "$PLUGIN_PYTHON" ]; then
+  echo "error: plugin Python was not created by uv sync: $PLUGIN_PYTHON" >&2
+  exit 1
+fi
+uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" -e "$REFLEXIO_PATH"
+uv run --project "$PLUGIN_ROOT" --no-sync python -c 'import reflexio; print(reflexio.__file__)'

--- a/scripts/use-local-reflexio.sh
+++ b/scripts/use-local-reflexio.sh
@@ -27,4 +27,4 @@ if [ ! -x "$PLUGIN_PYTHON" ]; then
   exit 1
 fi
 uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" -e "$REFLEXIO_PATH"
-uv run --project "$PLUGIN_ROOT" --no-sync python -c 'import reflexio; print(reflexio.__file__)'
+REFLEXIO_PATH="$REFLEXIO_PATH" python3 "$REPO_ROOT/scripts/doctor-reflexio.py"

--- a/scripts/use-local-reflexio.sh
+++ b/scripts/use-local-reflexio.sh
@@ -8,6 +8,34 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PLUGIN_ROOT="$REPO_ROOT/plugin"
 REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"
 
+expand_user_path() {
+  case "$1" in
+    "~")
+      printf '%s\n' "$HOME"
+      ;;
+    "~/"*)
+      printf '%s/%s\n' "$HOME" "${1#"~/"}"
+      ;;
+    *)
+      printf '%s\n' "$1"
+      ;;
+  esac
+}
+
+resolve_venv_python() {
+  venv_root="$1/.venv"
+  if [ -x "$venv_root/bin/python" ]; then
+    printf '%s\n' "$venv_root/bin/python"
+    return 0
+  fi
+  if [ -x "$venv_root/Scripts/python.exe" ]; then
+    printf '%s\n' "$venv_root/Scripts/python.exe"
+    return 0
+  fi
+  return 1
+}
+
+REFLEXIO_PATH="$(expand_user_path "$REFLEXIO_PATH")"
 if [ ! -d "$REFLEXIO_PATH" ]; then
   echo "error: REFLEXIO_PATH does not exist: $REFLEXIO_PATH" >&2
   exit 1
@@ -21,9 +49,8 @@ REFLEXIO_PATH="$(cd "$REFLEXIO_PATH" && pwd)"
 echo "Using Reflexio checkout: $REFLEXIO_PATH"
 
 uv sync --project "$PLUGIN_ROOT"
-PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/bin/python"
-if [ ! -x "$PLUGIN_PYTHON" ]; then
-  echo "error: plugin Python was not created by uv sync: $PLUGIN_PYTHON" >&2
+if ! PLUGIN_PYTHON="$(resolve_venv_python "$PLUGIN_ROOT")"; then
+  echo "error: plugin Python was not created by uv sync under $PLUGIN_ROOT/.venv" >&2
   exit 1
 fi
 uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" -e "$REFLEXIO_PATH"

--- a/scripts/vendor-reflexio.py
+++ b/scripts/vendor-reflexio.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Vendor a Reflexio checkout into the npm release payload.
+
+This keeps claude-smart and Reflexio as independent repositories during normal
+development, while allowing a claude-smart npm release to carry an exact
+Reflexio source snapshot without requiring user machines to clone GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+
+PACKAGE_NAME = "reflexio-ai"
+REPO_URL = "https://github.com/ReflexioAI/reflexio.git"
+VENDOR_PATH = Path("plugin/vendor/reflexio")
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def run_git(repo: Path, *args: str, capture: bool = True) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            stdout=subprocess.PIPE if capture else None,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        command = " ".join(("git", "-C", str(repo), *args))
+        detail = (exc.stderr or exc.stdout or "").strip()
+        fail(f"{command} failed: {detail or f'exit {exc.returncode}'}")
+    return result.stdout.strip() if capture and result.stdout else ""
+
+
+def read_project_metadata(reflexio_path: Path) -> tuple[str, str]:
+    pyproject = reflexio_path / "pyproject.toml"
+    if not pyproject.is_file():
+        fail(f"{reflexio_path} does not contain pyproject.toml")
+    with pyproject.open("rb") as handle:
+        data = tomllib.load(handle)
+    project = data.get("project", {})
+    name = project.get("name")
+    version = project.get("version")
+    if name != PACKAGE_NAME:
+        fail(f"expected [project].name = {PACKAGE_NAME!r}, found {name!r}")
+    if not isinstance(version, str) or not version:
+        fail("missing [project].version in Reflexio pyproject.toml")
+    return name, version
+
+
+def current_dependency(repo_root: Path) -> str:
+    pyproject = repo_root / "plugin" / "pyproject.toml"
+    text = pyproject.read_text()
+    marker = '"reflexio-ai'
+    matches = [
+        line.strip().rstrip(",").strip('"')
+        for line in text.splitlines()
+        if line.strip().startswith(marker)
+    ]
+    if len(matches) != 1:
+        fail(f"expected exactly one {PACKAGE_NAME} dependency in {pyproject}")
+    dependency = matches[0]
+    if " @ " in dependency or "file:" in dependency:
+        fail(
+            "plugin/pyproject.toml must keep a PyPI-safe reflexio-ai dependency; "
+            "do not commit direct URL or local path dependencies"
+        )
+    return dependency
+
+
+def export_reflexio(reflexio_path: Path, commit: str, vendor_dest: Path) -> None:
+    files = ["pyproject.toml", "README.md", "LICENSE", ".env.example", "reflexio"]
+    with tempfile.TemporaryDirectory(prefix="claude-smart-reflexio-") as tmp:
+        archive = Path(tmp) / "reflexio.tar"
+        try:
+            with archive.open("wb") as handle:
+                subprocess.run(
+                    ["git", "-C", str(reflexio_path), "archive", "--format=tar", commit, *files],
+                    check=True,
+                    stdout=handle,
+                    stderr=subprocess.PIPE,
+                    text=False,
+                )
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or b"").decode(errors="replace").strip()
+            fail(f"git archive failed: {detail or f'exit {exc.returncode}'}")
+        if vendor_dest.exists():
+            shutil.rmtree(vendor_dest)
+        vendor_dest.mkdir(parents=True)
+        with tarfile.open(archive) as tar:
+            tar.extractall(vendor_dest)
+
+
+def existing_updated_at(lock_file: Path, payload: dict[str, str]) -> str | None:
+    if not lock_file.is_file():
+        return None
+    try:
+        current = json.loads(lock_file.read_text())
+    except json.JSONDecodeError:
+        return None
+    for key, value in payload.items():
+        if current.get(key) != value:
+            return None
+    updated_at = current.get("updated_at")
+    return updated_at if isinstance(updated_at, str) and updated_at else None
+
+
+def write_lock(
+    lock_file: Path,
+    version: str,
+    commit: str,
+    dependency: str,
+    *,
+    write: bool,
+) -> bool:
+    base_payload = {
+        "package": PACKAGE_NAME,
+        "repo": REPO_URL,
+        "version": version,
+        "commit": commit,
+        "dependency": dependency,
+        "source": "vendor",
+        "vendor_path": str(VENDOR_PATH),
+    }
+    updated_at = existing_updated_at(lock_file, base_payload)
+    payload = {
+        **base_payload,
+        "updated_at": updated_at
+        or datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+    }
+    new_text = json.dumps(payload, indent=2) + "\n"
+    changed = not lock_file.exists() or lock_file.read_text() != new_text
+    if write and changed:
+        lock_file.write_text(new_text)
+    return changed
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reflexio-path",
+        type=Path,
+        default=repo_root.parent / "reflexio",
+        help="Path to Reflexio checkout (default: ../reflexio relative to claude-smart)",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Allow uncommitted Reflexio changes. The committed HEAD is still what gets vendored.",
+    )
+    parser.add_argument(
+        "--require-origin-main",
+        action="store_true",
+        help="Fail unless Reflexio HEAD matches origin/main after fetching.",
+    )
+    parser.add_argument("--write", action="store_true", help="Create vendor files and update lock")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    reflexio_path = args.reflexio_path.expanduser()
+    reflexio_path = (
+        (repo_root / reflexio_path).resolve()
+        if not reflexio_path.is_absolute()
+        else reflexio_path.resolve()
+    )
+    if not reflexio_path.exists():
+        fail(f"Reflexio path does not exist: {reflexio_path}")
+
+    package, version = read_project_metadata(reflexio_path)
+    if not args.allow_dirty:
+        dirty = run_git(reflexio_path, "status", "--porcelain")
+        if dirty:
+            fail(
+                f"Reflexio checkout has uncommitted changes at {reflexio_path}. "
+                "Commit/stash them or pass --allow-dirty."
+            )
+    commit = run_git(reflexio_path, "rev-parse", "HEAD")
+    if args.require_origin_main:
+        run_git(reflexio_path, "fetch", "origin", "main", capture=False)
+        origin_main = run_git(reflexio_path, "rev-parse", "origin/main")
+        if commit != origin_main:
+            fail(
+                "Reflexio checkout is not at origin/main:\n"
+                f"  checkout HEAD: {commit}\n"
+                f"  origin/main:   {origin_main}"
+            )
+
+    dependency = current_dependency(repo_root)
+    vendor_dest = repo_root / VENDOR_PATH
+    lock_file = repo_root / "reflexio.lock.json"
+    lock_changed = write_lock(lock_file, version, commit, dependency, write=args.write)
+
+    print(f"Reflexio path: {reflexio_path}")
+    print(f"Reflexio package: {package}")
+    print(f"Reflexio version: {version}")
+    print(f"Reflexio commit: {commit}")
+    print(f"PyPI fallback dependency: {dependency}")
+    print(f"Vendor path: {VENDOR_PATH}")
+
+    if args.write:
+        export_reflexio(reflexio_path, commit, vendor_dest)
+        print(f"Updated: {VENDOR_PATH}")
+        print(f"{'Updated' if lock_changed else 'Unchanged'}: reflexio.lock.json")
+    else:
+        print("Dry run only; no files changed.")
+        print(f"Would update: {VENDOR_PATH}")
+        print(f"Would update: {'reflexio.lock.json' if lock_changed else 'no lock change'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vendor-reflexio.py
+++ b/scripts/vendor-reflexio.py
@@ -22,6 +22,7 @@ from pathlib import Path
 PACKAGE_NAME = "reflexio-ai"
 REPO_URL = "https://github.com/ReflexioAI/reflexio.git"
 VENDOR_PATH = Path("plugin/vendor/reflexio")
+DEFAULT_INCLUDE = ["pyproject.toml", "README.md", "LICENSE", ".env.example", "reflexio"]
 
 
 def fail(message: str) -> None:
@@ -61,6 +62,35 @@ def read_project_metadata(reflexio_path: Path) -> tuple[str, str]:
     return name, version
 
 
+def read_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def package_include_paths(reflexio_path: Path) -> list[str]:
+    pyproject = reflexio_path / "pyproject.toml"
+    data = read_toml(pyproject)
+    sdist = (
+        data.get("tool", {})
+        .get("hatch", {})
+        .get("build", {})
+        .get("targets", {})
+        .get("sdist", {})
+    )
+    include = sdist.get("only-include")
+    if not isinstance(include, list) or not all(isinstance(item, str) for item in include):
+        return DEFAULT_INCLUDE
+    required = {"pyproject.toml", "reflexio"}
+    merged = list(dict.fromkeys([*include, "README.md", "LICENSE", ".env.example"]))
+    missing_required = required.difference(merged)
+    if missing_required:
+        fail(
+            "Reflexio sdist include list does not contain required package paths: "
+            + ", ".join(sorted(missing_required))
+        )
+    return merged
+
+
 def current_dependency(repo_root: Path) -> str:
     pyproject = repo_root / "plugin" / "pyproject.toml"
     text = pyproject.read_text()
@@ -81,8 +111,12 @@ def current_dependency(repo_root: Path) -> str:
     return dependency
 
 
-def export_reflexio(reflexio_path: Path, commit: str, vendor_dest: Path) -> None:
-    files = ["pyproject.toml", "README.md", "LICENSE", ".env.example", "reflexio"]
+def export_reflexio(
+    reflexio_path: Path,
+    commit: str,
+    vendor_dest: Path,
+    files: list[str],
+) -> None:
     with tempfile.TemporaryDirectory(prefix="claude-smart-reflexio-") as tmp:
         archive = Path(tmp) / "reflexio.tar"
         try:
@@ -203,6 +237,7 @@ def main() -> int:
             )
 
     dependency = current_dependency(repo_root)
+    include_paths = package_include_paths(reflexio_path)
     vendor_dest = repo_root / VENDOR_PATH
     lock_file = repo_root / "reflexio.lock.json"
     lock_changed = write_lock(lock_file, version, commit, dependency, write=args.write)
@@ -213,9 +248,12 @@ def main() -> int:
     print(f"Reflexio commit: {commit}")
     print(f"PyPI fallback dependency: {dependency}")
     print(f"Vendor path: {VENDOR_PATH}")
+    print("Vendored paths:")
+    for include_path in include_paths:
+        print(f"  {include_path}")
 
     if args.write:
-        export_reflexio(reflexio_path, commit, vendor_dest)
+        export_reflexio(reflexio_path, commit, vendor_dest, include_paths)
         print(f"Updated: {VENDOR_PATH}")
         print(f"{'Updated' if lock_changed else 'Unchanged'}: reflexio.lock.json")
     else:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import tarfile
 import time
 from pathlib import Path
@@ -892,6 +893,12 @@ def test_setup_local_dev_prefers_workspace_reflexio_checkout() -> None:
 
     assert "CLAUDE_SMART_LOCAL_REFLEXIO_PATH" in script
     assert "REFLEXIO_PATH" in script
+    assert "expand_user_path()" in script
+    assert 'reflexio_env_path="$(expand_user_path "$REFLEXIO_PATH")"' in script
+    assert (
+        'reflexio_env_path="$(expand_user_path '
+        '"$CLAUDE_SMART_LOCAL_REFLEXIO_PATH")"'
+    ) in script
     assert 'sibling_reflexio="$REPO_ROOT/../reflexio"' in script
     assert 'bundled_reflexio="$REPO_ROOT/reflexio"' not in script
     assert "git submodule update --init --recursive reflexio" not in script
@@ -908,8 +915,11 @@ def test_use_local_reflexio_installs_into_plugin_venv() -> None:
     makefile = (REPO_ROOT / "Makefile").read_text()
 
     assert 'REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"' in script
+    assert 'REFLEXIO_PATH="$(expand_user_path "$REFLEXIO_PATH")"' in script
     assert 'uv sync --project "$PLUGIN_ROOT"' in script
-    assert 'PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/bin/python"' in script
+    assert 'resolve_venv_python()' in script
+    assert 'if ! PLUGIN_PYTHON="$(resolve_venv_python "$PLUGIN_ROOT")"; then' in script
+    assert '$venv_root/Scripts/python.exe' in script
     assert (
         'uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" '
         '-e "$REFLEXIO_PATH"'
@@ -968,6 +978,10 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     assert "VALID_SOURCES" in lock_script
     assert "source=pypi must not include vendor_path" in lock_script
     assert "vendored Reflexio version mismatch" in lock_script
+    assert "read_lock_file(lock_path)" in lock_script
+    assert "reflexio.lock.json is not valid JSON" in lock_script
+    assert "top-level value must be a JSON object" in lock_script
+    assert "vendor_path must stay within repo root" in lock_script
     assert "installVendoredReflexio(pluginRoot, uv, env)" in installer
     assert 'join(pluginRoot, "vendor", "reflexio")' in installer
     assert '"pip", "install", "--project", pluginRoot' in installer
@@ -980,6 +994,91 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     assert "install_vendored_reflexio" in smart_install
     assert "vendor_reflexio_pyproject" in lib
     assert "/plugin/vendor/" in gitignore
+
+
+def test_check_reflexio_lock_reports_invalid_json(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    plugin = tmp_path / "plugin"
+    scripts.mkdir()
+    plugin.mkdir()
+    shutil.copy2(CHECK_REFLEXIO_LOCK, scripts / "check-reflexio-lock.py")
+    (plugin / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["reflexio-ai>=0.2.22"]\n'
+    )
+    (tmp_path / "reflexio.lock.json").write_text("{broken")
+
+    result = subprocess.run(
+        [sys.executable, str(scripts / "check-reflexio-lock.py")],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "error: reflexio.lock.json is not valid JSON" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_check_reflexio_lock_requires_json_object(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    plugin = tmp_path / "plugin"
+    scripts.mkdir()
+    plugin.mkdir()
+    shutil.copy2(CHECK_REFLEXIO_LOCK, scripts / "check-reflexio-lock.py")
+    (plugin / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["reflexio-ai>=0.2.22"]\n'
+    )
+    (tmp_path / "reflexio.lock.json").write_text("[]\n")
+
+    result = subprocess.run(
+        [sys.executable, str(scripts / "check-reflexio-lock.py")],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "top-level value must be a JSON object" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_check_reflexio_lock_rejects_out_of_repo_vendor_path(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    plugin = tmp_path / "plugin"
+    outside_vendor = tmp_path.parent / "outside-reflexio"
+    scripts.mkdir()
+    plugin.mkdir()
+    outside_vendor.mkdir()
+    shutil.copy2(CHECK_REFLEXIO_LOCK, scripts / "check-reflexio-lock.py")
+    dependency = "reflexio-ai>=0.2.22"
+    (plugin / "pyproject.toml").write_text(
+        f'[project]\ndependencies = ["{dependency}"]\n'
+    )
+    (tmp_path / "reflexio.lock.json").write_text(
+        json.dumps(
+            {
+                "package": "reflexio-ai",
+                "repo": "https://github.com/ReflexioAI/reflexio.git",
+                "version": "0.2.22",
+                "commit": "a" * 40,
+                "dependency": dependency,
+                "source": "vendor",
+                "vendor_path": str(outside_vendor),
+                "updated_at": "2026-05-24T00:00:00Z",
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(scripts / "check-reflexio-lock.py"), "--check-vendor"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "error: vendor_path must stay within repo root" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_smart_install_installs_vendored_reflexio(tmp_path: Path) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -868,6 +868,14 @@ def test_setup_local_dev_refreshes_claude_code_local_plugin() -> None:
     assert 'enabled["claude-smart@reflexioai-local"] = True' in script
     assert 'enabled["claude-smart@reflexioai"] = False' in script
     assert "user-scope local enabled, @reflexioai disabled" in script
+    assert "install_editable_reflexio_into_codex_cache" in script
+    assert "write_local_reflexio_uv_source" in script
+    assert "[tool.uv.sources]" in script
+    assert 'reflexio-ai = {{ path = {json.dumps(reflexio_path)}, editable = true }}' in script
+    assert "writing local Reflexio source override into Codex marketplace snapshot" in script
+    assert 'uv pip install --project "$cache_root" --python "$cache_python" -e "$REFLEXIO_ABS"' in script
+    assert "Codex plugin cache imports Reflexio from" in script
+    assert "Codex cache venv → editable reflexio-ai from $REFLEXIO_ABS" in script
 
 
 def test_setup_local_dev_prefers_workspace_reflexio_checkout() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -18,6 +18,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 LIB = REPO_ROOT / "plugin" / "scripts" / "_lib.sh"
 SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
 SETUP_LOCAL_DEV = REPO_ROOT / "scripts" / "setup-local-dev.sh"
+USE_LOCAL_REFLEXIO = REPO_ROOT / "scripts" / "use-local-reflexio.sh"
+SYNC_REFLEXIO_DEP = REPO_ROOT / "scripts" / "sync-reflexio-dep.py"
+RELEASE_WITH_REFLEXIO = REPO_ROOT / "scripts" / "release-with-reflexio.sh"
 SETUP_CLAUDE_SMART = REPO_ROOT / "scripts" / "setup-claude-smart.sh"
 HOOK_ENTRY = REPO_ROOT / "plugin" / "scripts" / "hook_entry.sh"
 CODEX_COMPAT = REPO_ROOT / "plugin" / "scripts" / "codex-claude-compat"
@@ -868,11 +871,40 @@ def test_setup_local_dev_prefers_workspace_reflexio_checkout() -> None:
     script = SETUP_LOCAL_DEV.read_text()
 
     assert "CLAUDE_SMART_LOCAL_REFLEXIO_PATH" in script
+    assert "REFLEXIO_PATH" in script
     assert 'sibling_reflexio="$REPO_ROOT/../reflexio"' in script
-    assert 'bundled_reflexio="$REPO_ROOT/reflexio"' in script
+    assert 'bundled_reflexio="$REPO_ROOT/reflexio"' not in script
+    assert "git submodule update --init --recursive reflexio" not in script
+    assert 'bash "$REPO_ROOT/scripts/use-local-reflexio.sh"' in script
     assert "using Reflexio source at $REFLEXIO_ABS" in script
     assert "override_learning_stall" in script
     assert "selected Reflexio client does not support" in script
+
+
+def test_use_local_reflexio_installs_into_plugin_venv() -> None:
+    script = USE_LOCAL_REFLEXIO.read_text()
+
+    assert 'REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"' in script
+    assert 'uv sync --project "$PLUGIN_ROOT"' in script
+    assert 'PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/bin/python"' in script
+    assert 'uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" -e "$REFLEXIO_PATH"' in script
+    assert 'uv run --project "$PLUGIN_ROOT" --no-sync python' in script
+    assert "import reflexio; print(reflexio.__file__)" in script
+
+
+def test_reflexio_release_sync_has_strict_release_checks() -> None:
+    sync_script = SYNC_REFLEXIO_DEP.read_text()
+    release_script = RELEASE_WITH_REFLEXIO.read_text()
+
+    assert "--release-checks" in sync_script
+    assert "fetch\", \"origin\", \"main\", \"--tags" in sync_script
+    assert "rev-parse\", \"origin/main" in sync_script
+    assert "tag\", \"--points-at\", \"HEAD" in sync_script
+    assert "v{version}" in sync_script
+    assert 'REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"' in release_script
+    assert '--reflexio-path "$REFLEXIO_PATH"' in release_script
+    assert "--check-pypi" in release_script
+    assert "--release-checks" in release_script
 
 
 def test_backend_service_configures_shared_embedding_daemon() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -871,9 +871,18 @@ def test_setup_local_dev_refreshes_claude_code_local_plugin() -> None:
     assert "install_editable_reflexio_into_codex_cache" in script
     assert "write_local_reflexio_uv_source" in script
     assert "[tool.uv.sources]" in script
-    assert 'reflexio-ai = {{ path = {json.dumps(reflexio_path)}, editable = true }}' in script
-    assert "writing local Reflexio source override into Codex marketplace snapshot" in script
-    assert 'uv pip install --project "$cache_root" --python "$cache_python" -e "$REFLEXIO_ABS"' in script
+    assert (
+        'reflexio-ai = {{ path = {json.dumps(reflexio_path)}, editable = true }}'
+        in script
+    )
+    assert (
+        "writing local Reflexio source override into Codex marketplace snapshot"
+        in script
+    )
+    assert (
+        'uv pip install --project "$cache_root" --python "$cache_python" '
+        '-e "$REFLEXIO_ABS"'
+    ) in script
     assert "Codex plugin cache imports Reflexio from" in script
     assert "Codex cache venv → editable reflexio-ai from $REFLEXIO_ABS" in script
 
@@ -901,7 +910,10 @@ def test_use_local_reflexio_installs_into_plugin_venv() -> None:
     assert 'REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"' in script
     assert 'uv sync --project "$PLUGIN_ROOT"' in script
     assert 'PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/bin/python"' in script
-    assert 'uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" -e "$REFLEXIO_PATH"' in script
+    assert (
+        'uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" '
+        '-e "$REFLEXIO_PATH"'
+    ) in script
     assert 'python3 "$REPO_ROOT/scripts/doctor-reflexio.py"' in script
     assert "Detected source: {source}" in doctor
     assert "Fix: bash scripts/use-local-reflexio.sh" in doctor
@@ -942,7 +954,10 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     assert '"vendor_path": str(VENDOR_PATH)' in vendor_script
     assert "package_include_paths" in vendor_script
     assert "only-include" in vendor_script
-    assert 'REFLEXIO_RELEASE_SOURCE="${REFLEXIO_RELEASE_SOURCE:-vendor}"' in release_script
+    assert (
+        'REFLEXIO_RELEASE_SOURCE="${REFLEXIO_RELEASE_SOURCE:-vendor}"'
+        in release_script
+    )
     assert 'PYTHON_BIN="${PYTHON:-python3}"' in release_script
     assert '"$PYTHON_BIN" scripts/vendor-reflexio.py' in release_script
     assert "uv pip install --project plugin --python" in release_script
@@ -1312,12 +1327,15 @@ def test_node_installer_codex_marketplace_cache_uses_manifest_plugin_path(
         "const pluginRoot = installer.codexMarketplacePluginRoot(root);"
         "const fs = require('fs');"
         "const path = require('path');"
-        "const manifest = JSON.parse(fs.readFileSync(path.join(root, '.agents/plugins/marketplace.json'), 'utf8'));"
+        "const manifestPath = path.join(root, '.agents/plugins/marketplace.json');"
+        "const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));"
         "console.log(JSON.stringify({"
         "root,"
         "path: manifest.plugins[0].source.path,"
         "pluginRoot,"
-        "hasManifest: fs.existsSync(path.join(pluginRoot, '.codex-plugin/plugin.json')),"
+        "hasManifest: fs.existsSync(path.join("
+        "pluginRoot, '.codex-plugin/plugin.json'"
+        ")),"
         "legacyPathExists: fs.existsSync(path.join(root, 'plugins/claude-smart'))"
         "}));"
     )
@@ -1414,16 +1432,28 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
                             "hooks": [
                                 {"command": 'bash "$_R/scripts/smart-install.sh"'},
                                 {
-                                    "command": 'bash "$_R/scripts/ensure-plugin-root.sh" "$_R"'
+                                    "command": (
+                                        'bash "$_R/scripts/ensure-plugin-root.sh" '
+                                        '"$_R"'
+                                    )
                                 },
                                 {
-                                    "command": 'bash "$_R/scripts/backend-service.sh" start'
+                                    "command": (
+                                        'bash "$_R/scripts/backend-service.sh" '
+                                        "start"
+                                    )
                                 },
                                 {
-                                    "command": 'bash "$_R/scripts/dashboard-service.sh" start'
+                                    "command": (
+                                        'bash "$_R/scripts/dashboard-service.sh" '
+                                        "start"
+                                    )
                                 },
                                 {
-                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex session-start'
+                                    "command": (
+                                        'bash "$_R/scripts/hook_entry.sh" codex '
+                                        "session-start"
+                                    )
                                 },
                             ]
                         }
@@ -1432,7 +1462,10 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
                         {
                             "hooks": [
                                 {
-                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex user-prompt'
+                                    "command": (
+                                        'bash "$_R/scripts/hook_entry.sh" codex '
+                                        "user-prompt"
+                                    )
                                 }
                             ]
                         }
@@ -1441,7 +1474,10 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
                         {
                             "hooks": [
                                 {
-                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex post-tool'
+                                    "command": (
+                                        'bash "$_R/scripts/hook_entry.sh" codex '
+                                        "post-tool"
+                                    )
                                 }
                             ]
                         }
@@ -1450,7 +1486,9 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
                         {
                             "hooks": [
                                 {
-                                    "command": 'bash "$_R/scripts/hook_entry.sh" codex stop'
+                                    "command": (
+                                        'bash "$_R/scripts/hook_entry.sh" codex stop'
+                                    )
                                 }
                             ]
                         }
@@ -1473,7 +1511,8 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
     script = (
         f"const installer = require({json.dumps(str(NODE_INSTALLER))});"
         f"installer.bootstrapPluginRuntime({json.dumps(str(plugin_root))})"
-        ".then(() => console.log('done')).catch((err) => { console.error(err.message); process.exit(1); });"
+        ".then(() => console.log('done'))"
+        ".catch((err) => { console.error(err.message); process.exit(1); });"
     )
     env = os.environ.copy()
     env.update(
@@ -1540,7 +1579,10 @@ def test_node_installer_read_only_prunes_publish_hooks(tmp_path: Path) -> None:
                         {
                             "hooks": [
                                 {
-                                    "command": 'bash "$_R/scripts/hook_entry.sh" claude-code session-start'
+                                    "command": (
+                                        'bash "$_R/scripts/hook_entry.sh" '
+                                        "claude-code session-start"
+                                    )
                                 }
                             ]
                         }
@@ -1549,7 +1591,10 @@ def test_node_installer_read_only_prunes_publish_hooks(tmp_path: Path) -> None:
                         {
                             "hooks": [
                                 {
-                                    "command": 'bash "$_R/scripts/hook_entry.sh" claude-code stop'
+                                    "command": (
+                                        'bash "$_R/scripts/hook_entry.sh" '
+                                        "claude-code stop"
+                                    )
                                 }
                             ]
                         }
@@ -1558,10 +1603,16 @@ def test_node_installer_read_only_prunes_publish_hooks(tmp_path: Path) -> None:
                         {
                             "hooks": [
                                 {
-                                    "command": 'bash "$_R/scripts/hook_entry.sh" claude-code session-end'
+                                    "command": (
+                                        'bash "$_R/scripts/hook_entry.sh" '
+                                        "claude-code session-end"
+                                    )
                                 },
                                 {
-                                    "command": 'bash "$_R/scripts/backend-service.sh" session-end'
+                                    "command": (
+                                        'bash "$_R/scripts/backend-service.sh" '
+                                        "session-end"
+                                    )
                                 },
                             ]
                         }
@@ -1579,7 +1630,10 @@ def test_node_installer_read_only_prunes_publish_hooks(tmp_path: Path) -> None:
                         {
                             "hooks": [
                                 {
-                                    "command": '"/node" "/plugin/scripts/codex-hook.js" "hook" "session-start"'
+                                    "command": (
+                                        '"/node" "/plugin/scripts/codex-hook.js" '
+                                        '"hook" "session-start"'
+                                    )
                                 }
                             ]
                         }
@@ -1588,7 +1642,10 @@ def test_node_installer_read_only_prunes_publish_hooks(tmp_path: Path) -> None:
                         {
                             "hooks": [
                                 {
-                                    "command": '"/node" "/plugin/scripts/codex-hook.js" "hook" "stop"'
+                                    "command": (
+                                        '"/node" "/plugin/scripts/codex-hook.js" '
+                                        '"hook" "stop"'
+                                    )
                                 }
                             ]
                         }

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -19,6 +19,7 @@ LIB = REPO_ROOT / "plugin" / "scripts" / "_lib.sh"
 SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
 SETUP_LOCAL_DEV = REPO_ROOT / "scripts" / "setup-local-dev.sh"
 USE_LOCAL_REFLEXIO = REPO_ROOT / "scripts" / "use-local-reflexio.sh"
+DOCTOR_REFLEXIO = REPO_ROOT / "scripts" / "doctor-reflexio.py"
 SYNC_REFLEXIO_DEP = REPO_ROOT / "scripts" / "sync-reflexio-dep.py"
 CHECK_REFLEXIO_LOCK = REPO_ROOT / "scripts" / "check-reflexio-lock.py"
 VENDOR_REFLEXIO = REPO_ROOT / "scripts" / "vendor-reflexio.py"
@@ -881,17 +882,24 @@ def test_setup_local_dev_prefers_workspace_reflexio_checkout() -> None:
     assert "using Reflexio source at $REFLEXIO_ABS" in script
     assert "override_learning_stall" in script
     assert "selected Reflexio client does not support" in script
+    assert "verify source → make doctor-reflexio" in script
 
 
 def test_use_local_reflexio_installs_into_plugin_venv() -> None:
     script = USE_LOCAL_REFLEXIO.read_text()
+    doctor = DOCTOR_REFLEXIO.read_text()
+    makefile = (REPO_ROOT / "Makefile").read_text()
 
     assert 'REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"' in script
     assert 'uv sync --project "$PLUGIN_ROOT"' in script
     assert 'PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/bin/python"' in script
     assert 'uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" -e "$REFLEXIO_PATH"' in script
-    assert 'uv run --project "$PLUGIN_ROOT" --no-sync python' in script
-    assert "import reflexio; print(reflexio.__file__)" in script
+    assert 'python3 "$REPO_ROOT/scripts/doctor-reflexio.py"' in script
+    assert "Detected source: {source}" in doctor
+    assert "Fix: bash scripts/use-local-reflexio.sh" in doctor
+    assert "using PyPI/other Reflexio even though a local checkout exists" in doctor
+    assert "doctor-reflexio:" in makefile
+    assert "python3 scripts/doctor-reflexio.py" in makefile
 
 
 def test_reflexio_release_sync_has_strict_release_checks() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -20,6 +20,7 @@ SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
 SETUP_LOCAL_DEV = REPO_ROOT / "scripts" / "setup-local-dev.sh"
 USE_LOCAL_REFLEXIO = REPO_ROOT / "scripts" / "use-local-reflexio.sh"
 SYNC_REFLEXIO_DEP = REPO_ROOT / "scripts" / "sync-reflexio-dep.py"
+CHECK_REFLEXIO_LOCK = REPO_ROOT / "scripts" / "check-reflexio-lock.py"
 VENDOR_REFLEXIO = REPO_ROOT / "scripts" / "vendor-reflexio.py"
 RELEASE_WITH_REFLEXIO = REPO_ROOT / "scripts" / "release-with-reflexio.sh"
 SETUP_CLAUDE_SMART = REPO_ROOT / "scripts" / "setup-claude-smart.sh"
@@ -902,6 +903,8 @@ def test_reflexio_release_sync_has_strict_release_checks() -> None:
     assert "rev-parse\", \"origin/main" in sync_script
     assert "tag\", \"--points-at\", \"HEAD" in sync_script
     assert "v{version}" in sync_script
+    assert "PyPI reflexio-ai dependency" in sync_script
+    assert '"source": "pypi"' in sync_script
     assert 'REFLEXIO_PATH="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"' in release_script
     assert '--reflexio-path "$REFLEXIO_PATH"' in release_script
     assert "--check-pypi" in release_script
@@ -911,6 +914,7 @@ def test_reflexio_release_sync_has_strict_release_checks() -> None:
 def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     vendor_script = VENDOR_REFLEXIO.read_text()
     release_script = RELEASE_WITH_REFLEXIO.read_text()
+    lock_script = CHECK_REFLEXIO_LOCK.read_text()
     installer = NODE_INSTALLER.read_text()
     gitignore = (REPO_ROOT / ".gitignore").read_text()
 
@@ -918,12 +922,19 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     assert "git\", \"-C\", str(reflexio_path), \"archive\"" in vendor_script
     assert '"source": "vendor"' in vendor_script
     assert '"vendor_path": str(VENDOR_PATH)' in vendor_script
+    assert "package_include_paths" in vendor_script
+    assert "only-include" in vendor_script
     assert 'REFLEXIO_RELEASE_SOURCE="${REFLEXIO_RELEASE_SOURCE:-vendor}"' in release_script
-    assert "python scripts/vendor-reflexio.py" in release_script
+    assert 'PYTHON_BIN="${PYTHON:-python3}"' in release_script
+    assert '"$PYTHON_BIN" scripts/vendor-reflexio.py' in release_script
     assert "uv pip install --project plugin --python" in release_script
     assert "-e plugin/vendor/reflexio" in release_script
+    assert "OK: npm tarball includes vendored Reflexio files" in release_script
     assert "Keep generated plugin/vendor/reflexio in place" in release_script
     assert "make release-npm VERSION=<new-claude-smart-version>" in release_script
+    assert "VALID_SOURCES" in lock_script
+    assert "source=pypi must not include vendor_path" in lock_script
+    assert "vendored Reflexio version mismatch" in lock_script
     assert "installVendoredReflexio(pluginRoot, uv, env)" in installer
     assert 'join(pluginRoot, "vendor", "reflexio")' in installer
     assert '"pip", "install", "--project", pluginRoot' in installer

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -932,6 +932,8 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     release_script = RELEASE_WITH_REFLEXIO.read_text()
     lock_script = CHECK_REFLEXIO_LOCK.read_text()
     installer = NODE_INSTALLER.read_text()
+    smart_install = SMART_INSTALL.read_text()
+    lib = LIB.read_text()
     gitignore = (REPO_ROOT / ".gitignore").read_text()
 
     assert "plugin/vendor/reflexio" in vendor_script
@@ -954,7 +956,74 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     assert "installVendoredReflexio(pluginRoot, uv, env)" in installer
     assert 'join(pluginRoot, "vendor", "reflexio")' in installer
     assert '"pip", "install", "--project", pluginRoot' in installer
+    assert 'VENDORED_REFLEXIO="$PLUGIN_ROOT/vendor/reflexio"' in smart_install
+    assert (
+        'uv pip install --project "$PLUGIN_ROOT" --python "$PLUGIN_PYTHON" '
+        '--quiet -e "$VENDORED_REFLEXIO"'
+    ) in smart_install
+    assert "vendored Reflexio install failed" in smart_install
+    assert "install_vendored_reflexio" in smart_install
+    assert "vendor_reflexio_pyproject" in lib
     assert "/plugin/vendor/" in gitignore
+
+
+def test_smart_install_installs_vendored_reflexio(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    scripts = plugin_root / "scripts"
+    vendor = plugin_root / "vendor" / "reflexio"
+    fake_bin = tmp_path / "bin"
+    scripts.mkdir(parents=True)
+    vendor.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(SMART_INSTALL, scripts / "smart-install.sh")
+    shutil.copy2(LIB, scripts / "_lib.sh")
+    shutil.copy2(
+        REPO_ROOT / "plugin" / "scripts" / "ensure-plugin-root.sh",
+        scripts / "ensure-plugin-root.sh",
+    )
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    (plugin_root / "uv.lock").write_text("")
+    (vendor / "pyproject.toml").write_text("[project]\nname='reflexio-ai'\n")
+
+    uv = fake_bin / "uv"
+    uv.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$HOME/uv.log"\n'
+        'if [ "$1" = "sync" ]; then\n'
+        '  mkdir -p "$PWD/.venv/bin"\n'
+        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        '  chmod +x "$PWD/.venv/bin/python"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "python" ] && [ "$2" = "find" ]; then\n'
+        '  printf "%s\\n" "$PWD/.venv/bin/python"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "pip" ] && [ "$2" = "install" ]; then\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(scripts / "smart-install.sh")],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / ".claude-smart" / "install-failed").exists()
+    assert (tmp_path / ".claude-smart" / "install-complete").exists()
+    assert "installing bundled Reflexio source" in result.stderr
+    uv_log = (tmp_path / "uv.log").read_text()
+    assert "sync --locked --python 3.12 --quiet" in uv_log
+    assert f"pip install --project {plugin_root}" in uv_log
+    assert f"-e {vendor}" in uv_log
 
 
 def test_vendor_release_is_npm_only() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -20,6 +20,7 @@ SMART_INSTALL = REPO_ROOT / "plugin" / "scripts" / "smart-install.sh"
 SETUP_LOCAL_DEV = REPO_ROOT / "scripts" / "setup-local-dev.sh"
 USE_LOCAL_REFLEXIO = REPO_ROOT / "scripts" / "use-local-reflexio.sh"
 SYNC_REFLEXIO_DEP = REPO_ROOT / "scripts" / "sync-reflexio-dep.py"
+VENDOR_REFLEXIO = REPO_ROOT / "scripts" / "vendor-reflexio.py"
 RELEASE_WITH_REFLEXIO = REPO_ROOT / "scripts" / "release-with-reflexio.sh"
 SETUP_CLAUDE_SMART = REPO_ROOT / "scripts" / "setup-claude-smart.sh"
 HOOK_ENTRY = REPO_ROOT / "plugin" / "scripts" / "hook_entry.sh"
@@ -905,6 +906,40 @@ def test_reflexio_release_sync_has_strict_release_checks() -> None:
     assert '--reflexio-path "$REFLEXIO_PATH"' in release_script
     assert "--check-pypi" in release_script
     assert "--release-checks" in release_script
+
+
+def test_reflexio_vendor_release_uses_generated_bundle() -> None:
+    vendor_script = VENDOR_REFLEXIO.read_text()
+    release_script = RELEASE_WITH_REFLEXIO.read_text()
+    installer = NODE_INSTALLER.read_text()
+    gitignore = (REPO_ROOT / ".gitignore").read_text()
+
+    assert "plugin/vendor/reflexio" in vendor_script
+    assert "git\", \"-C\", str(reflexio_path), \"archive\"" in vendor_script
+    assert '"source": "vendor"' in vendor_script
+    assert '"vendor_path": str(VENDOR_PATH)' in vendor_script
+    assert 'REFLEXIO_RELEASE_SOURCE="${REFLEXIO_RELEASE_SOURCE:-vendor}"' in release_script
+    assert "python scripts/vendor-reflexio.py" in release_script
+    assert "uv pip install --project plugin --python" in release_script
+    assert "-e plugin/vendor/reflexio" in release_script
+    assert "Keep generated plugin/vendor/reflexio in place" in release_script
+    assert "make release-npm VERSION=<new-claude-smart-version>" in release_script
+    assert "installVendoredReflexio(pluginRoot, uv, env)" in installer
+    assert 'join(pluginRoot, "vendor", "reflexio")' in installer
+    assert '"pip", "install", "--project", pluginRoot' in installer
+    assert "/plugin/vendor/" in gitignore
+
+
+def test_vendor_release_is_npm_only() -> None:
+    makefile = (REPO_ROOT / "Makefile").read_text()
+    developer = (REPO_ROOT / "DEVELOPER.md").read_text()
+
+    assert "release-npm:" in makefile
+    assert "check-pypi-compatible-reflexio:" in makefile
+    assert "source=vendor" in makefile
+    assert "make release-npm VERSION=..." in makefile
+    assert "make release-npm VERSION=<new-claude-smart-version>" in developer
+    assert "intentionally refuses to publish PyPI" in developer
 
 
 def test_backend_service_configures_shared_embedding_daemon() -> None:

--- a/tests/test_internal_call.py
+++ b/tests/test_internal_call.py
@@ -8,6 +8,8 @@ each detection path has an explicit test.
 
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
 from claude_smart import internal_call, runtime
@@ -38,6 +40,19 @@ def test_returns_true_when_cwd_inside_reflexio(
     (fake_reflexio / "server").mkdir(parents=True)
     monkeypatch.setattr(internal_call, "_REFLEXIO_DIR", fake_reflexio)
     assert is_internal_invocation({"cwd": str(fake_reflexio / "server")}) is True
+
+
+def test_reflexio_dir_env_override_is_resolved(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CLAUDE_SMART_REFLEXIO_DIR", "reflexio")
+    try:
+        reloaded = importlib.reload(internal_call)
+        assert reloaded._REFLEXIO_DIR == (tmp_path / "reflexio").resolve()  # noqa: SLF001
+    finally:
+        monkeypatch.delenv("CLAUDE_SMART_REFLEXIO_DIR", raising=False)
+        importlib.reload(internal_call)
 
 
 def test_returns_false_for_external_cwd(


### PR DESCRIPTION
## Summary
- Removes the nested Reflexio git submodule from claude-smart so published installs resolve `reflexio-ai` from PyPI only.
- Adds a lock/sync workflow that derives the Reflexio dependency from a side-by-side checkout and records the source version plus commit in `reflexio.lock.json`.
- Keeps local cross-repo development supported through an editable install helper instead of committing local path metadata.

## Changes
- Dependency workflow
  - Delete `.gitmodules` and the `reflexio` submodule gitlink.
  - Add `scripts/sync-reflexio-dep.py`, `scripts/check-reflexio-lock.py`, `scripts/use-local-reflexio.sh`, and `scripts/release-with-reflexio.sh`.
  - Update `plugin/pyproject.toml` and `plugin/uv.lock` to use `reflexio-ai>=0.2.22`.
- Local development
  - Update `scripts/setup-local-dev.sh` to resolve `REFLEXIO_PATH` or `../reflexio` and install Reflexio editable into the plugin venv.
  - Stop mutating `plugin/pyproject.toml` with `[tool.uv.sources]` or skip-worktree flags.
  - Run hook/backend/CLI wrappers with `uv run --no-sync` so local editable installs are not undone during development.
- Documentation and release checks
  - Refresh `DEVELOPER.md`, `README.md`, and `ARCHITECTURE.md` to document side-by-side Reflexio development and release flow.
  - Add `check-reflexio-lock` to the Makefile release checks.
  - Make `release-with-reflexio.sh` accept `REFLEXIO_PATH` and require Reflexio `HEAD == origin/main`, a `v<version>` tag, and a matching PyPI version.
  - Extend install-script tests for the new workflow.

## Test Plan
- `uv run python scripts/check-reflexio-lock.py`
- `uv run python scripts/sync-reflexio-dep.py --reflexio-path ../reflexio`
- `REFLEXIO_PATH=../reflexio bash scripts/use-local-reflexio.sh`
- `REFLEXIO_PATH=../reflexio bash scripts/setup-local-dev.sh --host codex`
- `cd plugin && uv run --project . pytest --rootdir .. -o addopts= ../tests/test_install_scripts.py -q`
- `cd plugin && uv run --project . pytest --rootdir .. -o addopts= ../tests -q`
- `npm pack --dry-run`
- Manual Codex/tmux smoke: `/plugins` showed `claude-smart`; prompt hooks injected memory; hook log recorded `session-start`, `user-prompt`, and `stop` with `publish_status=ok`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a vendoring and lock-based release path for the reflexio-ai dependency to support npm-only releases.

* **Improvements**
  * Replaced embedded submodule workflow with package-based Reflexio integration and editable local-checkout support.
  * Release tooling now enforces reflexio lock consistency and blocks incompatible PyPI publishes.
  * CLI/backend startup defaults to non-sync launches to better support editable local Reflexio.

* **Documentation**
  * Updated developer guides and architecture/README for new local-dev and release workflows.

* **Tests**
  * Added coverage for local Reflexio install, vendor/release flows, and lock validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
