### PR TITLE
fix: keep plugin root pointed at checkout

### DIFF
--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -513,11 +513,6 @@ enabled["claude-smart@reflexioai"] = False
 settings_path.write_text(json.dumps(data, indent=2) + "\n")
 PY
   log "wrote $SETTINGS_FILE (claude-smart@reflexioai-local enabled, @reflexioai shadowed off)"
-
-  # Warn (don't abort) on failure — marketplace registration and settings
-  # have already been committed by this point, so aborting would leave the
-  # user in a half-configured state.
-  force_plugin_root_to_checkout
 fi
 
 if [ "$SETUP_CODEX" = "1" ]; then
@@ -536,10 +531,13 @@ if [ "$SETUP_CODEX" = "1" ]; then
   install_editable_reflexio_into_codex_cache
 fi
 
-if [ "$SETUP_CLAUDE_CODE" = "1" ] && [ "$SETUP_CODEX" = "1" ]; then
-  log "restoring plugin-root to editable checkout after Codex install..."
-  force_plugin_root_to_checkout
-fi
+# Point ~/.reflexio/plugin-root at this repo's plugin/ regardless of host.
+# Codex install rewrites the link to its cache; Claude Code's SessionStart
+# self-heal would otherwise leave a stale cache target in place. Forcing this
+# unconditionally at the end keeps slash commands and CLI shims resolving to
+# the live working tree.
+log "pointing ~/.reflexio/plugin-root at editable checkout..."
+force_plugin_root_to_checkout
 
 refresh_local_dashboard
 


### PR DESCRIPTION
## Summary
- Keep the claude-smart local setup script pointing ~/.reflexio/plugin-root back at the editable checkout after Codex setup rewrites it to the cache.
- This keeps Claude Code slash commands and CLI shims resolving to the live working tree after combined Claude/Codex setup runs.

## Changes
- Move the plugin-root reset to the end of setup-local-dev.sh so it always runs after optional Codex installation.
- Replace the conditional Claude+Codex-only reset with an unconditional final reset and explanatory comments.

## Test Plan
- Not run; shell script behavior change only, reviewed diff for setup ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved local development setup script to ensure consistent plugin path configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->