### PR TITLE
feat: seed claude-smart local-mode env defaults on install

### DIFF
--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -16,6 +16,7 @@
 const { execSync, spawn, spawnSync } = require("child_process");
 const crypto = require("crypto");
 const {
+  chmodSync,
   cpSync,
   existsSync,
   lstatSync,
@@ -41,6 +42,8 @@ const REFLEXIO_ENV_PATH = join(homedir(), ".reflexio", ".env");
 const MANAGED_REFLEXIO_URL = "https://www.reflexio.ai/";
 const MANAGED_SETUP_ENV = "CLAUDE_SMART_MANAGED_SETUP";
 const CLAUDE_SMART_READ_ONLY_ENV = "CLAUDE_SMART_READ_ONLY";
+const CLAUDE_SMART_USE_LOCAL_CLI_ENV = "CLAUDE_SMART_USE_LOCAL_CLI";
+const CLAUDE_SMART_USE_LOCAL_EMBEDDING_ENV = "CLAUDE_SMART_USE_LOCAL_EMBEDDING";
 const REFLEXIO_USER_ID_ENV = "REFLEXIO_USER_ID";
 const REFLEXIO_DIR = join(homedir(), ".reflexio");
 const CLAUDE_SMART_STATE_DIR = join(homedir(), ".claude-smart");
@@ -89,6 +92,24 @@ const COPYTREE_IGNORE_NAMES = new Set([
   ".ruff_cache",
   "node_modules",
   ".next",
+]);
+const LOCAL_DEFAULT_ENV_ENTRIES = [
+  [
+    "# Route reflexio generation through the local Claude Code CLI",
+    CLAUDE_SMART_USE_LOCAL_CLI_ENV,
+    "1",
+  ],
+  [
+    "# Use the in-process ONNX embedder (chromadb) - no API key for semantic search",
+    CLAUDE_SMART_USE_LOCAL_EMBEDDING_ENV,
+    "1",
+  ],
+  [null, CLAUDE_SMART_READ_ONLY_ENV, "0"],
+];
+const LOCAL_MODE_PRUNE_KEYS = new Set([
+  "REFLEXIO_URL",
+  "REFLEXIO_API_KEY",
+  REFLEXIO_USER_ID_ENV,
 ]);
 
 function shouldCopyPath(src) {
@@ -216,6 +237,57 @@ function parseEnvLine(line) {
   return { key, value };
 }
 
+function escapeEnvValue(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function ensureLocalReflexioEnv() {
+  mkdirSync(dirname(REFLEXIO_ENV_PATH), { recursive: true });
+  const existing = existsSync(REFLEXIO_ENV_PATH)
+    ? readFileSync(REFLEXIO_ENV_PATH, "utf8")
+    : "";
+  const present = new Set();
+  const keptLines = [];
+  let pruned = false;
+  for (const line of existing.split(/\r?\n/)) {
+    const parsed = parseEnvLine(line);
+    if (parsed) {
+      if (LOCAL_MODE_PRUNE_KEYS.has(parsed.key)) {
+        pruned = true;
+        continue;
+      }
+      present.add(parsed.key);
+    }
+    keptLines.push(line);
+  }
+
+  const additions = [];
+  const added = [];
+  for (const [comment, key, value] of LOCAL_DEFAULT_ENV_ENTRIES) {
+    if (present.has(key)) continue;
+    if (comment) additions.push(comment);
+    if (key === CLAUDE_SMART_READ_ONLY_ENV) {
+      additions.push(`${key}="${escapeEnvValue(value)}"`);
+    } else {
+      additions.push(`${key}=${escapeEnvValue(value)}`);
+    }
+    added.push(key);
+  }
+
+  if (additions.length > 0 || pruned) {
+    let content = keptLines.join("\n").replace(/\n*$/, "");
+    if (additions.length > 0) {
+      const prefix = content ? "\n" : "";
+      content = content + prefix + additions.join("\n");
+    }
+    writeFileSync(REFLEXIO_ENV_PATH, content ? `${content}\n` : "");
+  } else if (!existsSync(REFLEXIO_ENV_PATH)) {
+    writeFileSync(REFLEXIO_ENV_PATH, "");
+  }
+  chmodSync(REFLEXIO_ENV_PATH, 0o600);
+  return added;
+}
+
 function maskSecret(value) {
   if (!value) return "";
   if (value.length <= 8) return "*".repeat(value.length);
@@ -254,7 +326,12 @@ function loadReflexioSetupEnv() {
   } else {
     delete process.env.REFLEXIO_URL;
     delete process.env.REFLEXIO_API_KEY;
+    delete process.env[REFLEXIO_USER_ID_ENV];
     delete process.env[MANAGED_SETUP_ENV];
+    const added = ensureLocalReflexioEnv();
+    if (added.length > 0) {
+      process.stdout.write(`Seeded ${REFLEXIO_ENV_PATH} with ${added.join(", ")}.\n`);
+    }
   }
   const readOnly = ["1", "true", "yes", "on"].includes(
     String(readOnlyValue).trim().toLowerCase(),

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
     # downloaded on first use, not at install time.
     "chromadb>=0.5",
     "einops>=0.8.0",
+    # Native SQLite vector KNN for local storage. Reflexio can fall back to
+    # Python ranking without this, but installed claude-smart should include
+    # the accelerator by default.
+    "sqlite-vec>=0.1.6",
 ]
 
 [project.scripts]

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -106,6 +106,12 @@ install_complete() {
   command -v uv >/dev/null 2>&1 || return 1
   [ -d "$PLUGIN_ROOT/.venv" ] || return 1
   claude_smart_python_imports "$PLUGIN_ROOT" claude_smart.hook || return 1
+  if [ -z "${REFLEXIO_API_KEY:-}" ]; then
+    [ -f "$HOME/.reflexio/.env" ] || return 1
+    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_CLI=' "$HOME/.reflexio/.env" || return 1
+    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$HOME/.reflexio/.env" || return 1
+    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_READ_ONLY=' "$HOME/.reflexio/.env" || return 1
+  fi
   if [ -d "$PLUGIN_ROOT/dashboard" ]; then
     [ -d "$PLUGIN_ROOT/dashboard/.next" ] || [ -f "$MARKER_DIR/dashboard-build.pid" ] || [ -f "$(claude_smart_dashboard_unavailable_marker)" ] || return 1
   fi
@@ -490,6 +496,63 @@ claude_smart_env_upsert() {
     printf '%s="%s"\n' "$key" "$quoted" >> "$REFLEXIO_ENV"
   fi
 }
+
+claude_smart_env_append_raw_if_missing() {
+  local key value
+  key="$1"
+  value="$2"
+  if ! grep -qE "^(export[[:space:]]+)?${key}=" "$REFLEXIO_ENV"; then
+    printf '%s=%s\n' "$key" "$value" >> "$REFLEXIO_ENV"
+  fi
+}
+
+claude_smart_prune_managed_env_keys_for_local() {
+  local tmp line raw_key key
+  [ -f "$REFLEXIO_ENV" ] || return 0
+  tmp="$(mktemp "${REFLEXIO_ENV}.tmp.XXXXXX")"
+  while IFS= read -r line || [ -n "$line" ]; do
+    raw_key="$line"
+    raw_key="${raw_key#"${raw_key%%[![:space:]]*}"}"
+    case "$raw_key" in
+      export\ *) raw_key="${raw_key#export }" ;;
+    esac
+    key="${raw_key%%=*}"
+    key="${key%"${key##*[![:space:]]}"}"
+    case "$key" in
+      REFLEXIO_URL|REFLEXIO_API_KEY|REFLEXIO_USER_ID)
+        continue
+        ;;
+    esac
+    printf '%s\n' "$line" >> "$tmp"
+  done < "$REFLEXIO_ENV"
+  mv "$tmp" "$REFLEXIO_ENV"
+}
+
+claude_smart_ensure_local_env_defaults() {
+  [ -z "${REFLEXIO_API_KEY:-}" ] || return 0
+  mkdir -p "$(dirname "$REFLEXIO_ENV")"
+  touch "$REFLEXIO_ENV"
+  chmod 600 "$REFLEXIO_ENV"
+  claude_smart_prune_managed_env_keys_for_local
+  unset REFLEXIO_URL REFLEXIO_API_KEY REFLEXIO_USER_ID CLAUDE_SMART_MANAGED_SETUP
+  if ! grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_CLI=' "$REFLEXIO_ENV"; then
+    printf '# Route reflexio generation through the local Claude Code CLI\n' >> "$REFLEXIO_ENV"
+    claude_smart_env_append_raw_if_missing CLAUDE_SMART_USE_LOCAL_CLI "1"
+    echo "[claude-smart] appended CLAUDE_SMART_USE_LOCAL_CLI=1 to $REFLEXIO_ENV" >&2
+  fi
+  if ! grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$REFLEXIO_ENV"; then
+    printf '# Use the in-process ONNX embedder (chromadb) - no API key for semantic search\n' >> "$REFLEXIO_ENV"
+    claude_smart_env_append_raw_if_missing CLAUDE_SMART_USE_LOCAL_EMBEDDING "1"
+    echo "[claude-smart] appended CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 to $REFLEXIO_ENV" >&2
+  fi
+  if ! grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_READ_ONLY=' "$REFLEXIO_ENV"; then
+    claude_smart_env_upsert CLAUDE_SMART_READ_ONLY "0"
+    echo "[claude-smart] appended CLAUDE_SMART_READ_ONLY=0 to $REFLEXIO_ENV" >&2
+  fi
+  chmod 600 "$REFLEXIO_ENV"
+}
+
+claude_smart_ensure_local_env_defaults
 
 # Migrate stale REFLEXIO_URL from reflexio's library default (8081) to the
 # plugin backend port (8071). Matches the quoted and unquoted forms but

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -894,7 +894,7 @@ def _register_codex_marketplace(root: Path) -> tuple[bool, str]:
 
 
 def _configure_reflexio_setup() -> bool:
-    """Load setup state from ``~/.reflexio/.env`` without writing local defaults.
+    """Load setup state and ensure local defaults when unmanaged.
 
     Returns:
         bool: Whether read-only mode is enabled.
@@ -939,7 +939,11 @@ def _configure_reflexio_setup() -> bool:
     else:
         os.environ.pop(env_config.REFLEXIO_URL_ENV, None)
         os.environ.pop(env_config.REFLEXIO_API_KEY_ENV, None)
+        os.environ.pop("REFLEXIO_USER_ID", None)
         os.environ.pop("CLAUDE_SMART_MANAGED_SETUP", None)
+        added = env_config.ensure_local_env_defaults(_REFLEXIO_ENV_PATH)
+        if added:
+            sys.stdout.write(f"Seeded {_REFLEXIO_ENV_PATH} with {', '.join(added)}.\n")
     return read_only
 
 
@@ -1342,7 +1346,9 @@ def _run_service(script: Path, subcmd: str) -> int:
         return 1
     bash = _resolve_bash()
     if not bash:
-        sys.stderr.write("error: bash is required to run claude-smart service scripts\n")
+        sys.stderr.write(
+            "error: bash is required to run claude-smart service scripts\n"
+        )
         return 1
     try:
         subprocess.run([bash, str(script), subcmd], check=True)

--- a/plugin/src/claude_smart/env_config.py
+++ b/plugin/src/claude_smart/env_config.py
@@ -10,6 +10,27 @@ MANAGED_REFLEXIO_URL = "https://www.reflexio.ai/"
 REFLEXIO_URL_ENV = "REFLEXIO_URL"
 REFLEXIO_API_KEY_ENV = "REFLEXIO_API_KEY"
 CLAUDE_SMART_READ_ONLY_ENV = "CLAUDE_SMART_READ_ONLY"
+CLAUDE_SMART_USE_LOCAL_CLI_ENV = "CLAUDE_SMART_USE_LOCAL_CLI"
+CLAUDE_SMART_USE_LOCAL_EMBEDDING_ENV = "CLAUDE_SMART_USE_LOCAL_EMBEDDING"
+
+_LOCAL_DEFAULT_ENTRIES = (
+    (
+        "# Route reflexio generation through the local Claude Code CLI",
+        CLAUDE_SMART_USE_LOCAL_CLI_ENV,
+        "1",
+    ),
+    (
+        "# Use the in-process ONNX embedder (chromadb) - no API key for semantic search",
+        CLAUDE_SMART_USE_LOCAL_EMBEDDING_ENV,
+        "1",
+    ),
+    (None, CLAUDE_SMART_READ_ONLY_ENV, "0"),
+)
+_LOCAL_MODE_PRUNE_KEYS = {
+    REFLEXIO_URL_ENV,
+    REFLEXIO_API_KEY_ENV,
+    "REFLEXIO_USER_ID",
+}
 
 
 def parse_env_line(line: str) -> tuple[str, str] | None:
@@ -87,6 +108,59 @@ def set_env_vars(path: Path, values: dict[str, str]) -> list[str]:
     path.write_text(content + ("\n" if content else ""), encoding="utf-8")
     path.chmod(0o600)
     return added
+
+
+def ensure_local_env_defaults(path: Path | None = None) -> list[str]:
+    """Create or augment ``~/.reflexio/.env`` for claude-smart local mode.
+
+    Existing active assignments win. This repairs first installs and deleted
+    env files without clobbering explicit user overrides such as
+    ``CLAUDE_SMART_READ_ONLY=1``.
+    """
+    path = path or REFLEXIO_ENV_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing = path.read_text()
+    except OSError:
+        existing = ""
+
+    present: set[str] = set()
+    kept_lines: list[str] = []
+    pruned = False
+    for line in existing.splitlines():
+        parsed = parse_env_line(line)
+        if parsed is not None:
+            key, _value = parsed
+            if key in _LOCAL_MODE_PRUNE_KEYS:
+                pruned = True
+                continue
+            present.add(key)
+        kept_lines.append(line)
+
+    additions: list[str] = []
+    added_keys: list[str] = []
+    for comment, key, value in _LOCAL_DEFAULT_ENTRIES:
+        if key in present:
+            continue
+        if comment:
+            additions.append(comment)
+        if key == CLAUDE_SMART_READ_ONLY_ENV:
+            additions.append(f'{key}="{_escape_env_value(value)}"')
+        else:
+            additions.append(f"{key}={_escape_env_value(value)}")
+        added_keys.append(key)
+
+    if additions or pruned:
+        content = "\n".join(kept_lines)
+        if additions:
+            prefix = "" if not content or content.endswith("\n") else "\n"
+            content = content + prefix + "\n".join(additions)
+        content = content + ("\n" if content else "")
+        path.write_text(content, encoding="utf-8")
+    elif not path.exists():
+        path.touch()
+    path.chmod(0o600)
+    return added_keys
 
 
 def env_truthy(name: str) -> bool:

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -425,6 +425,7 @@ dependencies = [
     { name = "chromadb" },
     { name = "einops" },
     { name = "reflexio-ai" },
+    { name = "sqlite-vec" },
 ]
 
 [package.dev-dependencies]
@@ -437,6 +438,7 @@ requires-dist = [
     { name = "chromadb", specifier = ">=0.5" },
     { name = "einops", specifier = ">=0.8.0" },
     { name = "reflexio-ai", specifier = ">=0.2.23" },
+    { name = "sqlite-vec", specifier = ">=0.1.6" },
 ]
 
 [package.metadata.requires-dev]
@@ -3105,6 +3107,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]

--- a/scripts/setup-claude-smart.sh
+++ b/scripts/setup-claude-smart.sh
@@ -106,6 +106,34 @@ append_env_value() {
   chmod 600 "$REFLEXIO_ENV"
 }
 
+append_env_raw() {
+  local key value
+  key="$1"
+  value="$2"
+  mkdir -p "$(dirname "$REFLEXIO_ENV")"
+  touch "$REFLEXIO_ENV"
+  chmod 600 "$REFLEXIO_ENV"
+  printf '%s=%s\n' "$key" "$value" >> "$REFLEXIO_ENV"
+  chmod 600 "$REFLEXIO_ENV"
+}
+
+ensure_local_env_defaults() {
+  mkdir -p "$(dirname "$REFLEXIO_ENV")"
+  touch "$REFLEXIO_ENV"
+  chmod 600 "$REFLEXIO_ENV"
+  if ! get_env_value CLAUDE_SMART_USE_LOCAL_CLI >/dev/null 2>&1; then
+    printf '# Route reflexio generation through the local Claude Code CLI\n' >> "$REFLEXIO_ENV"
+    append_env_raw CLAUDE_SMART_USE_LOCAL_CLI "1"
+  fi
+  if ! get_env_value CLAUDE_SMART_USE_LOCAL_EMBEDDING >/dev/null 2>&1; then
+    printf '# Use the in-process ONNX embedder (chromadb) - no API key for semantic search\n' >> "$REFLEXIO_ENV"
+    append_env_raw CLAUDE_SMART_USE_LOCAL_EMBEDDING "1"
+  fi
+  if ! get_env_value CLAUDE_SMART_READ_ONLY >/dev/null 2>&1; then
+    append_env_value CLAUDE_SMART_READ_ONLY "0"
+  fi
+}
+
 mask_secret() {
   local value len suffix
   value="$1"
@@ -283,11 +311,11 @@ main() {
 
   if [ "$mode" = "local" ]; then
     if [ -f "$REFLEXIO_ENV" ]; then
-      remove_env_keys
+      remove_env_keys REFLEXIO_API_KEY REFLEXIO_URL REFLEXIO_USER_ID
       log "removed managed Reflexio settings from $REFLEXIO_ENV"
-    else
-      log "local mode selected; no $REFLEXIO_ENV exists, so no env file was created"
     fi
+    ensure_local_env_defaults
+    log "configured local Reflexio defaults in $REFLEXIO_ENV"
     install_for_host "$host"
     return 0
   fi

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -160,16 +160,18 @@ def test_cmd_install_fails_when_dependency_bootstrap_fails(
     assert rc == 1
 
 
-def test_install_setup_default_does_not_create_local_env(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_install_setup_default_creates_local_env(monkeypatch, tmp_path: Path) -> None:
     env_path = tmp_path / ".reflexio" / ".env"
     monkeypatch.setattr(cli, "_REFLEXIO_ENV_PATH", env_path)
 
     read_only = cli._configure_reflexio_setup()
 
     assert read_only is False
-    assert not env_path.exists()
+    text = env_path.read_text()
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in text
+    assert 'CLAUDE_SMART_READ_ONLY="0"' in text
+    assert env_path.stat().st_mode & 0o777 == 0o600
 
 
 def test_install_setup_reads_managed_reflexio_from_env(
@@ -230,6 +232,10 @@ def test_install_setup_ignores_stale_url_without_api_key(
 
     assert read_only is False
     assert "REFLEXIO_URL" not in os.environ
+    text = env_path.read_text()
+    assert "REFLEXIO_URL" not in text
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in text
 
 
 def test_install_parser_keeps_plain_install() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -287,13 +287,15 @@ def test_backend_service_skips_local_start_for_remote_reflexio_url() -> None:
     assert "remote configured at $REFLEXIO_URL" in backend
 
 
-def test_smart_install_does_not_create_local_env_defaults() -> None:
+def test_smart_install_repairs_local_env_defaults() -> None:
     script = (REPO_ROOT / "plugin" / "scripts" / "smart-install.sh").read_text()
     lib = (REPO_ROOT / "plugin" / "scripts" / "_lib.sh").read_text()
 
-    assert 'touch "$REFLEXIO_ENV"' not in script
-    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" not in script
-    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" not in script
+    assert 'touch "$REFLEXIO_ENV"' in script
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in script
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in script
+    assert "CLAUDE_SMART_READ_ONLY=0" in script
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=" in script.split("install_complete()", 1)[1]
     assert "claude_smart_source_reflexio_env" in script
     assert "CLAUDE_SMART_READ_ONLY" in lib
     assert "REFLEXIO_USER_ID" in lib
@@ -368,11 +370,14 @@ def _run_setup_script(tmp_path: Path, stdin: str) -> subprocess.CompletedProcess
     )
 
 
-def test_setup_script_local_mode_does_not_create_env(tmp_path: Path) -> None:
+def test_setup_script_local_mode_creates_env(tmp_path: Path) -> None:
     result = _run_setup_script(tmp_path, "claude-code\nlocal\n")
 
     assert result.returncode == 0, result.stderr
-    assert not (tmp_path / ".reflexio" / ".env").exists()
+    text = (tmp_path / ".reflexio" / ".env").read_text()
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in text
+    assert 'CLAUDE_SMART_READ_ONLY="0"' in text
 
 
 def test_setup_script_local_mode_cleans_managed_keys(tmp_path: Path) -> None:
@@ -392,10 +397,13 @@ def test_setup_script_local_mode_cleans_managed_keys(tmp_path: Path) -> None:
     assert "REFLEXIO_URL" not in text
     assert "REFLEXIO_API_KEY" not in text
     assert "REFLEXIO_USER_ID" not in text
-    assert "CLAUDE_SMART_READ_ONLY" not in text
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in text
+    assert "CLAUDE_SMART_READ_ONLY=1" in text
+    assert 'CLAUDE_SMART_READ_ONLY="0"' not in text
 
 
-def test_setup_script_local_mode_deletes_empty_env(tmp_path: Path) -> None:
+def test_setup_script_local_mode_replaces_managed_only_env(tmp_path: Path) -> None:
     env_path = tmp_path / ".reflexio" / ".env"
     env_path.parent.mkdir()
     env_path.write_text('REFLEXIO_API_KEY="rflx-test"\n')
@@ -403,7 +411,11 @@ def test_setup_script_local_mode_deletes_empty_env(tmp_path: Path) -> None:
     result = _run_setup_script(tmp_path, "claude-code\nlocal\n")
 
     assert result.returncode == 0, result.stderr
-    assert not env_path.exists()
+    text = env_path.read_text()
+    assert "REFLEXIO_API_KEY" not in text
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in text
+    assert 'CLAUDE_SMART_READ_ONLY="0"' in text
 
 
 def test_setup_script_managed_project_scoped(tmp_path: Path) -> None:
@@ -564,7 +576,15 @@ def test_node_installer_ignores_stale_url_without_api_key(tmp_path: Path) -> Non
     )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout == ""
+    assert result.stdout.endswith(
+        "CLAUDE_SMART_USE_LOCAL_CLI, "
+        "CLAUDE_SMART_USE_LOCAL_EMBEDDING, CLAUDE_SMART_READ_ONLY.\n"
+    )
+    env_text = env_path.read_text()
+    assert "REFLEXIO_URL" not in env_text
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in env_text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in env_text
+    assert 'CLAUDE_SMART_READ_ONLY="0"' in env_text
 
 
 def test_node_installer_supports_managed_reflexio_setup() -> None:
@@ -1142,6 +1162,74 @@ def test_smart_install_installs_vendored_reflexio(tmp_path: Path) -> None:
     assert "sync --locked --python 3.12 --quiet" in uv_log
     assert f"pip install --project {plugin_root}" in uv_log
     assert f"-e {vendor}" in uv_log
+
+
+def test_smart_install_repairs_reflexio_template_env_drift(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    scripts = plugin_root / "scripts"
+    fake_bin = tmp_path / "bin"
+    scripts.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(SMART_INSTALL, scripts / "smart-install.sh")
+    shutil.copy2(LIB, scripts / "_lib.sh")
+    shutil.copy2(
+        REPO_ROOT / "plugin" / "scripts" / "ensure-plugin-root.sh",
+        scripts / "ensure-plugin-root.sh",
+    )
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    (plugin_root / "uv.lock").write_text("")
+
+    uv = fake_bin / "uv"
+    uv.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$HOME/uv.log"\n'
+        'if [ "$1" = "sync" ]; then\n'
+        '  mkdir -p "$PWD/.venv/bin"\n'
+        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        '  chmod +x "$PWD/.venv/bin/python"\n'
+        "fi\n"
+        "exit 0\n"
+    )
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    command = ["/bin/bash", "--noprofile", "--norc", str(scripts / "smart-install.sh")]
+
+    first = subprocess.run(
+        command,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert first.returncode == 0, first.stderr
+    assert (tmp_path / ".claude-smart" / "install-complete").exists()
+
+    reflexio_env = tmp_path / ".reflexio" / ".env"
+    reflexio_env.write_text(
+        "# Reflexio template-style env without claude-smart local defaults\n"
+        "OPENAI_API_KEY=\n"
+        "ANTHROPIC_API_KEY=\n"
+    )
+
+    second = subprocess.run(
+        command,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert second.returncode == 0, second.stderr
+    env_text = reflexio_env.read_text()
+    assert "OPENAI_API_KEY=" in env_text
+    assert "CLAUDE_SMART_USE_LOCAL_CLI=1" in env_text
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in env_text
+    assert 'CLAUDE_SMART_READ_ONLY="0"' in env_text
+    assert (tmp_path / "uv.log").read_text().count(
+        "sync --locked --python 3.12 --quiet"
+    ) == 2
 
 
 def test_vendor_release_is_npm_only() -> None:


### PR DESCRIPTION
## Summary
- Make claude-smart "local mode" self-configuring: when no managed `REFLEXIO_API_KEY` is present, seed `~/.reflexio/.env` with `CLAUDE_SMART_USE_LOCAL_CLI=1`, `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1`, and `CLAUDE_SMART_READ_ONLY=0` so first-install (or a wiped env file) produces a working setup without hand-editing.
- Preserve user overrides — existing active assignments win, so `CLAUDE_SMART_READ_ONLY=1` set deliberately by a user survives.
- Keep managed/local state consistent across surfaces: prune `REFLEXIO_URL`, `REFLEXIO_API_KEY`, and `REFLEXIO_USER_ID` from both the env file and the current process env in the no-API-key branch (previously `REFLEXIO_USER_ID` leaked through in the Python and JS paths).
- Ship `sqlite-vec` as a runtime dep so the native SQLite vector KNN accelerator is available by default; reflexio still falls back to Python ranking if missing.

## Changes
**Local-mode env seeding (four parallel implementations, kept in sync):**
- `plugin/src/claude_smart/env_config.py` — new `ensure_local_env_defaults()` with prune-then-seed logic.
- `plugin/src/claude_smart/cli.py` — `_configure_reflexio_setup()` now calls `ensure_local_env_defaults` and pops `REFLEXIO_USER_ID` / `REFLEXIO_URL` / `REFLEXIO_API_KEY` / `CLAUDE_SMART_MANAGED_SETUP` from `os.environ` in the no-API-key branch.
- `bin/claude-smart.js` — JS equivalent (`ensureLocalReflexioEnv`) for the npm wrapper, plus `delete process.env.REFLEXIO_USER_ID` in the no-API-key branch.
- `plugin/scripts/smart-install.sh` — `claude_smart_ensure_local_env_defaults` + `claude_smart_prune_managed_env_keys_for_local`, invoked on every install when no `REFLEXIO_API_KEY` is exported.
- `scripts/setup-claude-smart.sh` — interactive `ensure_local_env_defaults`; local-mode branch now calls `remove_env_keys REFLEXIO_API_KEY REFLEXIO_URL REFLEXIO_USER_ID` explicitly so a user's `CLAUDE_SMART_READ_ONLY=1` is preserved.

**`install_complete` gate:** `smart-install.sh` now treats a missing local-default in `~/.reflexio/.env` as "install incomplete," so a hook invocation will re-seed defaults if the file was tampered with.

**Dependency:** `sqlite-vec>=0.1.6` added to `plugin/pyproject.toml` and `plugin/uv.lock`.

**Tests updated:**
- `test_install_setup_default_creates_local_env` (was `_does_not_create_local_env`) — asserts the three defaults are written with `0o600` perms.
- `test_install_setup_ignores_stale_url_without_api_key` — asserts `REFLEXIO_URL` is gone from both env and file, and the defaults are written.
- `test_smart_install_repairs_local_env_defaults` (was `_does_not_create_local_env_defaults`) — covers the shell-side install gate.
- `test_setup_script_local_mode_creates_env`, `test_setup_script_local_mode_cleans_managed_keys`, `test_setup_script_local_mode_replaces_managed_only_env` — cover the interactive setup script. The `cleans_managed_keys` case specifically asserts that a pre-existing `CLAUDE_SMART_READ_ONLY=1` is preserved (not overwritten with `"0"`).
- `test_node_installer_ignores_stale_url_without_api_key` — asserts the JS wrapper emits the expected "Seeded ..." message and writes the defaults.

## Test Plan
- [x] `uv run --project plugin pytest tests/test_cli_install.py tests/test_install_scripts.py` — 90 passed.
- [x] `uv run --project plugin pyright src/claude_smart/env_config.py src/claude_smart/cli.py` — 0 errors.
- [x] `uv run --project plugin ruff check plugin/src/claude_smart/env_config.py` — clean.
- [x] `bash -n` on modified shell scripts and `node --check` on `bin/claude-smart.js` — clean.
- [ ] Manual: fresh install in a sandbox with no `~/.reflexio/.env` — confirm file is created with the three defaults and `0o600` perms.
- [ ] Manual: pre-existing `CLAUDE_SMART_READ_ONLY=1` in `~/.reflexio/.env` — run `setup-claude-smart.sh local` and confirm value is preserved.
- [ ] Manual: pre-existing managed `REFLEXIO_API_KEY` in `~/.reflexio/.env` — run `smart-install.sh` with no env-var override and confirm the file is untouched (no defaults seeded).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local installation now works without requiring API credentials
  * Automatic local configuration setup with CLI and embedding support
  * Added native vector storage for improved local search and retrieval

* **Dependencies**
  * Added SQLite vector support for local data storage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->