### PR TITLE
chore: expand plugin keywords and refine marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "claude-smart",
       "version": "0.2.42",
       "source": "./plugin",
-      "description": "Learns user corrections and project playbooks via reflexio — uses Claude Code itself as the LLM backend (no external API key required)"
+      "description": "Learns user corrections into project-specific and shared skills via reflexio — uses Claude Code itself as the LLM backend (no external API key required)"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ benchmarks/memory_comparison/results
 
 # Local design docs / brainstorm specs (kept out of public repo)
 docs/superpowers/
+marketing/

--- a/package.json
+++ b/package.json
@@ -5,10 +5,16 @@
   "keywords": [
     "claude",
     "claude-code",
+    "claude-code-plugin",
+    "codex",
+    "codex-plugin",
+    "memory",
+    "agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
-    "playbook",
+    "self-improving-agents",
+    "skills",
     "learning"
   ],
   "homepage": "https://github.com/ReflexioAI/claude-smart#readme",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -8,10 +8,16 @@
   "keywords": [
     "claude",
     "claude-code",
+    "claude-code-plugin",
+    "codex",
+    "codex-plugin",
+    "memory",
+    "agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
-    "playbook",
+    "self-improving-agents",
+    "skills",
     "learning"
   ]
 }


### PR DESCRIPTION
## Summary
- Broaden plugin keywords (npm + Claude marketplace) so discovery surfaces claude-smart for Codex, memory, and self-improving-agent searches.
- Refine the marketplace description to reflect that corrections feed project-specific and shared skills rather than "playbooks".
- Add `marketing/` to `.gitignore` so local marketing assets stay out of the public repo.

## Changes
- `.claude-plugin/marketplace.json` — updated description string.
- `package.json` + `plugin/.claude-plugin/plugin.json` — added `claude-code-plugin`, `codex`, `codex-plugin`, `memory`, `agent-memory`, `self-improving-agents`, `skills`; dropped `playbook`.
- `.gitignore` — ignore `marketing/`.

## Test Plan
- [ ] `jq . .claude-plugin/marketplace.json plugin/.claude-plugin/plugin.json package.json` parses cleanly.
- [ ] Verify on npm/Claude marketplace listing that new keywords resolve after release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin marketplace description to clarify that the plugin learns user corrections into both project-specific and shared skills.
  * Updated package and plugin metadata keywords for improved discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/claude-smart/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->