### PR TITLE
docs: clarify Codex support in plugin metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Yi Lu"
   },
   "metadata": {
-    "description": "claude-smart — self-improving Claude Code plugin via reflexio"
+    "description": "claude-smart — self-improving Claude Code and Codex plugin via reflexio"
   },
   "plugins": [
     {
       "name": "claude-smart",
       "version": "0.2.42",
       "source": "./plugin",
-      "description": "Learns user corrections into project-specific and shared skills via reflexio — uses Claude Code itself as the LLM backend (no external API key required)"
+      "description": "Turns user corrections into project-specific and shared skills via reflexio — uses Claude Code or Codex as the LLM backend (no external API key required)"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.42",
-  "description": "Self-improving Claude Code plugin — learns from corrections via reflexio",
+  "description": "Self-improving Claude Code and Codex plugin — turns corrections into durable skills via reflexio",
   "keywords": [
     "claude",
     "claude-code",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.42",
-  "description": "Self-improving Claude Code plugin — learns from corrections across sessions via reflexio",
+  "description": "Self-improving Claude Code and Codex plugin — turns corrections into durable skills via reflexio",
   "author": {
     "name": "Yi Lu"
   },

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,8 +1,8 @@
 # claude-smart
 
-Self-improving [Claude Code](https://claude.com/claude-code) plugin — turns your corrections into durable rules that Claude Code follows in future sessions, via [reflexio](https://github.com/ReflexioAI/reflexio).
+Self-improving [Claude Code](https://claude.com/claude-code) and Codex plugin — turns your corrections into durable skills that future sessions follow, via [reflexio](https://github.com/ReflexioAI/reflexio).
 
-This directory is the published Python package (`claude-smart` on PyPI) and the Claude Code plugin payload shipped through the marketplace. For the project overview, install instructions, benchmarks, and feature walkthrough, see the [top-level README](https://github.com/ReflexioAI/claude-smart#readme).
+This directory is the published Python package (`claude-smart` on PyPI) and the Claude Code/Codex plugin payload shipped through the marketplace. For the project overview, install instructions, benchmarks, and feature walkthrough, see the [top-level README](https://github.com/ReflexioAI/claude-smart#readme).
 
 ## Install
 

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "claude-smart"
 version = "0.2.42"
-description = "Self-improving Claude Code plugin — learns from corrections via reflexio"
+description = "Self-improving Claude Code and Codex plugin — turns corrections into durable skills via reflexio"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Updates npm/PyPI/plugin/marketplace descriptions to mention both Claude Code and Codex support.
- Aligns published package copy around turning corrections into durable skills.
- Updates the plugin README summary to describe the Claude Code/Codex payload more accurately.

## Test Plan / Validation
- `git diff --check`
- `python3 -m json.tool package.json`
- `python3 -m json.tool plugin/.claude-plugin/plugin.json`
- `python3 -m json.tool .claude-plugin/marketplace.json`
- `python3 - <<'PY'\nimport tomllib\nwith open('plugin/pyproject.toml','rb') as f:\n    tomllib.load(f)\nPY`\n\n## Marketing rationale\nCodex is now part of the public pitch and install flow, but several distribution surfaces still positioned claude-smart as Claude Code-only. This small metadata update improves discoverability for Codex and multi-host agent-memory searches without changing product claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin descriptions and metadata to reflect support for both Claude Code and Codex
  * Clarified feature descriptions across marketplace and package documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->