### PR TITLE
fix: stop unbounded ~/.reflexio growth from stray per-session plugin copies (#65)

### DIFF
--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -220,6 +220,97 @@ importlib.import_module(sys.argv[1])
 PY
 }
 
+claude_smart_canonical_dir() {
+  local dir
+  dir="$1"
+  [ -d "$dir" ] || return 1
+  (cd "$dir" 2>/dev/null && pwd -P)
+}
+
+# True when $1 canonicalizes to a plugin directory that physically lives
+# *inside* ~/.reflexio. claude-smart's real install never places the live
+# plugin tree there: the only entry under ~/.reflexio is the `plugin-root`
+# symlink, whose `pwd -P` resolves to a cache dir *outside* ~/.reflexio
+# (~/.claude, ~/.codex, or the npm global). So any plugin root that resolves
+# to a descendant of ~/.reflexio is a stray host-made copy — e.g. the Windows
+# cwd-derived `CUsers...` directories from issue #65 — that we must not
+# bootstrap a heavy .venv/node_modules into.
+#
+# Detection is structural (descendant-of-~/.reflexio + plugin markers) rather
+# than name-based on purpose: the host mangles the cwd differently per drive
+# and user dir (C:\Users -> CUsers..., D:\repos -> Drepos..., varying case),
+# so matching a fixed prefix like `Cu*` misses most real copies.
+claude_smart_is_reflexio_session_copy() {
+  local plugin_root reflexio_root
+  plugin_root="$(claude_smart_canonical_dir "$1" 2>/dev/null || true)"
+  [ -n "$plugin_root" ] || return 1
+  # Must look like a plugin root — not ~/.reflexio/data, /configs, or .env.
+  [ -f "$plugin_root/pyproject.toml" ] || return 1
+  [ -d "$plugin_root/scripts" ] || return 1
+  reflexio_root="$(claude_smart_canonical_dir "$HOME/.reflexio" 2>/dev/null || true)"
+  [ -n "$reflexio_root" ] || return 1
+  # Descendant of ~/.reflexio. The trailing slash on the subject plus the
+  # "/" before * pins the boundary so a sibling like ~/.reflexio-bak/plugin
+  # does not match.
+  case "$plugin_root/" in
+    "$reflexio_root"/*) return 0 ;;
+  esac
+  return 1
+}
+
+claude_smart_stable_plugin_root_for_session_copy() {
+  local current candidate current_real candidate_real glob
+  current="$1"
+  if ! claude_smart_is_reflexio_session_copy "$current"; then
+    return 1
+  fi
+  current_real="$(claude_smart_canonical_dir "$current" 2>/dev/null || true)"
+
+  for candidate in \
+    "$HOME/.reflexio/plugin-root" \
+    "$HOME/.claude/plugins/marketplaces/reflexioai/plugin" \
+    "$HOME/.codex/plugins/cache/reflexioai/claude-smart/current"
+  do
+    [ -f "$candidate/pyproject.toml" ] || continue
+    candidate_real="$(claude_smart_canonical_dir "$candidate" 2>/dev/null || true)"
+    [ -n "$candidate_real" ] || continue
+    [ "$candidate_real" != "$current_real" ] || continue
+    if claude_smart_is_reflexio_session_copy "$candidate_real"; then
+      continue
+    fi
+    printf '%s\n' "$candidate_real"
+    return 0
+  done
+
+  for glob in "$HOME/.claude/plugins/cache/reflexioai/claude-smart"/* "$HOME/.codex/plugins/cache/reflexioai/claude-smart"/*; do
+    [ -f "$glob/pyproject.toml" ] || continue
+    candidate_real="$(claude_smart_canonical_dir "$glob" 2>/dev/null || true)"
+    [ -n "$candidate_real" ] || continue
+    [ "$candidate_real" != "$current_real" ] || continue
+    if claude_smart_is_reflexio_session_copy "$candidate_real"; then
+      continue
+    fi
+    printf '%s\n' "$candidate_real"
+    return 0
+  done
+  return 1
+}
+
+claude_smart_reexec_stable_plugin_root_if_needed() {
+  local plugin_root script stable
+  plugin_root="$1"
+  script="$2"
+  stable="$(claude_smart_stable_plugin_root_for_session_copy "$plugin_root" 2>/dev/null || true)"
+  [ -n "$stable" ] || return 0
+  # `-f` not `-x`: we re-run via `exec bash <script>`, which does not need the
+  # executable bit. Cached copies on Windows/NTFS often lack +x, so requiring
+  # -x would no-op the guard on the very platform issue #65 affects.
+  [ -f "$stable/scripts/$script" ] || return 0
+  echo "[claude-smart] redirecting stray plugin copy under ~/.reflexio ($plugin_root) to stable root $stable" >&2
+  shift 2
+  exec bash "$stable/scripts/$script" "$@"
+}
+
 claude_smart_download() {
   local url dest src _CS_PY
   url="$1"

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -45,6 +45,7 @@ fi
 # CLI dir (commonly ~/.local/bin or /opt/homebrew/bin). Pin the CLI
 # explicitly if we can resolve it from our own (post-login-path) PATH.
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "backend-service.sh" "$@"
 
 if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
   if [ "${CLAUDE_SMART_HOST:-claude-code}" = "codex" ]; then

--- a/plugin/scripts/cli.sh
+++ b/plugin/scripts/cli.sh
@@ -18,6 +18,7 @@ claude_smart_prepend_node_bins
 claude_smart_source_reflexio_env
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "cli.sh" "$@"
 
 # If the Setup hook recorded an install failure, surface that reason
 # instead of falling through to a generic "uv not found" — mirrors the

--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -89,14 +89,82 @@ function appendLog(name, line) {
   trimLog(file);
 }
 
+function realDir(dir) {
+  try {
+    if (!fs.statSync(dir).isDirectory()) return null;
+    return fs.realpathSync(dir);
+  } catch {
+    return null;
+  }
+}
+
+function isInsideDir(parent, child) {
+  const rel = path.relative(parent, child);
+  return rel && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+function isPluginLikeRoot(root) {
+  return fs.existsSync(path.join(root, "pyproject.toml")) && fs.existsSync(path.join(root, "scripts"));
+}
+
+function isReflexioStrayPluginCopy(root) {
+  if (!isPluginLikeRoot(root)) return false;
+  const rootReal = realDir(root);
+  const reflexioReal = realDir(REFLEXIO_DIR);
+  if (!rootReal || !reflexioReal) return false;
+  return isInsideDir(reflexioReal, rootReal);
+}
+
+function stablePluginRootForStrayCopy(root) {
+  if (!isReflexioStrayPluginCopy(root)) return null;
+  const rootReal = realDir(root);
+  const candidates = [
+    path.join(REFLEXIO_DIR, "plugin-root"),
+    path.join(HOME, ".claude", "plugins", "marketplaces", "reflexioai", "plugin"),
+    path.join(HOME, ".codex", "plugins", "cache", "reflexioai", "claude-smart", "current"),
+  ];
+  for (const cacheRoot of [
+    path.join(HOME, ".claude", "plugins", "cache", "reflexioai", "claude-smart"),
+    path.join(HOME, ".codex", "plugins", "cache", "reflexioai", "claude-smart"),
+  ]) {
+    try {
+      const versions = fs
+        .readdirSync(cacheRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => path.join(cacheRoot, entry.name))
+        .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+      candidates.push(...versions);
+    } catch {
+      // Missing cache roots are fine; try the next candidate family.
+    }
+  }
+  for (const candidate of candidates) {
+    if (!isPluginLikeRoot(candidate)) continue;
+    const candidateReal = realDir(candidate);
+    if (!candidateReal || candidateReal === rootReal) continue;
+    if (isReflexioStrayPluginCopy(candidateReal)) continue;
+    return candidateReal;
+  }
+  return null;
+}
+
+function stablePluginRoot(root) {
+  const stable = stablePluginRootForStrayCopy(root);
+  if (stable) {
+    appendLog("backend.log", `[claude-smart] redirecting stray plugin copy under ~/.reflexio (${root}) to stable root ${stable}`);
+    return stable;
+  }
+  return root;
+}
+
 function pluginRoot() {
   for (const value of [process.env.CLAUDE_PLUGIN_ROOT, process.env.PLUGIN_ROOT]) {
     if (value && fs.existsSync(path.join(value, "pyproject.toml"))) {
-      return path.resolve(value);
+      return stablePluginRoot(path.resolve(value));
     }
   }
   const fromScript = path.resolve(__dirname, "..");
-  if (fs.existsSync(path.join(fromScript, "pyproject.toml"))) return fromScript;
+  if (fs.existsSync(path.join(fromScript, "pyproject.toml"))) return stablePluginRoot(fromScript);
   const cacheRoot = path.join(HOME, ".codex", "plugins", "cache", "reflexioai", "claude-smart");
   try {
     const versions = fs
@@ -105,12 +173,12 @@ function pluginRoot() {
       .map((entry) => path.join(cacheRoot, entry.name))
       .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
     for (const candidate of versions) {
-      if (fs.existsSync(path.join(candidate, "pyproject.toml"))) return candidate;
+      if (fs.existsSync(path.join(candidate, "pyproject.toml"))) return stablePluginRoot(candidate);
     }
   } catch {
     // Fall through to the stable plugin-root link.
   }
-  return path.join(REFLEXIO_DIR, "plugin-root");
+  return stablePluginRoot(path.join(REFLEXIO_DIR, "plugin-root"));
 }
 
 function prependRuntimePath() {

--- a/plugin/scripts/dashboard-build.sh
+++ b/plugin/scripts/dashboard-build.sh
@@ -27,6 +27,7 @@ claude_smart_source_login_path
 claude_smart_prepend_node_bins
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "dashboard-build.sh" "$@"
 DASHBOARD_DIR="$PLUGIN_ROOT/dashboard"
 
 STATE_DIR="$HOME/.claude-smart"

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -29,6 +29,7 @@ CMD="${1:-start}"
 PORT=3001
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "dashboard-service.sh" "$@"
 DASHBOARD_DIR="$PLUGIN_ROOT/dashboard"
 WORKSPACE_CWD="${PWD:-}"
 

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -46,6 +46,7 @@ claude_smart_prepend_astral_bins
 claude_smart_source_reflexio_env
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "hook_entry.sh" "$@"
 
 FAILURE_MARKER="$HOME/.claude-smart/install-failed"
 STATE_DIR="$HOME/.claude-smart"

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -17,6 +17,7 @@ claude_smart_prepend_node_bins
 claude_smart_source_reflexio_env
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
+claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "smart-install.sh" "$@"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 
 MARKER_DIR="$HOME/.claude-smart"

--- a/plugin/src/claude_smart/ids.py
+++ b/plugin/src/claude_smart/ids.py
@@ -19,13 +19,21 @@ from __future__ import annotations
 import logging
 import os
 import subprocess  # noqa: S404 — git invocation with a fixed flag set.
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from claude_smart import env_config
 
 _LOGGER = logging.getLogger(__name__)
 
 _USER_ID_OVERRIDE_ENV = "REFLEXIO_USER_ID"
+
+
+def _basename(path: str | os.PathLike[str]) -> str:
+    """Return a cwd basename, including native Windows paths under Git Bash."""
+    text = os.fspath(path)
+    if "\\" in text or (len(text) >= 2 and text[0].isalpha() and text[1] == ":"):
+        return PureWindowsPath(text).name or "unknown-project"
+    return Path(path).name or "unknown-project"
 
 
 def resolve_project_id(cwd: str | os.PathLike[str] | None = None) -> str:
@@ -47,7 +55,7 @@ def resolve_project_id(cwd: str | os.PathLike[str] | None = None) -> str:
     base = Path(cwd) if cwd is not None else Path.cwd()
     try:
         result = subprocess.run(  # noqa: S603, S607 — fixed argv, cwd is a Path.
-            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "rev-parse", "--show-toplevel"],  # noqa: S607
             cwd=base,
             capture_output=True,
             text=True,
@@ -57,10 +65,10 @@ def resolve_project_id(cwd: str | os.PathLike[str] | None = None) -> str:
         if result.returncode == 0:
             toplevel = result.stdout.strip()
             if toplevel:
-                return Path(toplevel).name
-    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                return _basename(toplevel)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
         _LOGGER.debug("git toplevel resolution failed: %s", exc)
-    return base.name or "unknown-project"
+    return _basename(cwd) if cwd is not None else _basename(base)
 
 
 def resolve_user_id(cwd: str | os.PathLike[str] | None = None) -> str:

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -45,6 +45,26 @@ def test_resolve_handles_missing_git_binary(tmp_path, monkeypatch) -> None:
     assert ids.resolve_project_id(tmp_path) == tmp_path.name
 
 
+def test_resolve_handles_windows_cwd_when_git_fails(monkeypatch) -> None:
+    def _boom(*_a, **_kw):
+        raise FileNotFoundError("git missing")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert ids.resolve_project_id(r"C:\Users\Alice\repo") == "repo"
+
+
+def test_resolve_handles_windows_git_toplevel(monkeypatch) -> None:
+    def _git(*_a, **_kw):
+        return subprocess.CompletedProcess(
+            args=["git", "rev-parse", "--show-toplevel"],
+            returncode=0,
+            stdout="C:\\Users\\Alice\\repo\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _git)
+    assert ids.resolve_project_id(r"C:\Users\Alice\repo\packages\core") == "repo"
+
+
 def test_resolve_project_id_ignores_user_id_override(tmp_path, monkeypatch) -> None:
     _isolate_git_env(monkeypatch)
     monkeypatch.setenv("REFLEXIO_API_KEY", "rflx-test-key")

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -2464,6 +2464,49 @@ def test_codex_hook_ensure_root_tracks_active_plugin_root(tmp_path: Path) -> Non
     assert json.loads(result.stdout) == {"continue": True}
 
 
+def test_codex_hook_redirects_reflexio_stray_copy_to_stable_root(
+    tmp_path: Path,
+) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for codex hook wrapper tests")
+
+    stray_root = tmp_path / ".reflexio" / "CUsersAliceRepo" / "plugin"
+    stable_root = (
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.2.42"
+    )
+    for root in (stray_root, stable_root):
+        (root / "scripts").mkdir(parents=True)
+        (root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+
+    reflexio = tmp_path / ".reflexio"
+    (reflexio / "plugin-root").symlink_to(stable_root, target_is_directory=True)
+
+    env = _isolated_env(tmp_path)
+    env["CLAUDE_PLUGIN_ROOT"] = str(stray_root)
+    result = subprocess.run(
+        [node, str(CODEX_HOOK), "ensure-root"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (reflexio / "plugin-root").resolve() == stable_root
+    assert json.loads(result.stdout) == {"continue": True}
+    assert not (reflexio / "plugin-root").resolve() == stray_root
+    assert "redirecting stray plugin copy" in (
+        tmp_path / ".claude-smart" / "backend.log"
+    ).read_text()
+
+
 def test_codex_hook_caps_backend_log_appends(tmp_path: Path) -> None:
     node = shutil.which("node")
     if not node:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1351,6 +1351,87 @@ def test_smart_install_installs_vendored_reflexio(tmp_path: Path) -> None:
     assert f"-e {vendor}" in uv_log
 
 
+@pytest.mark.parametrize(
+    "copy_dirname",
+    [
+        # Windows cwd C:\Users\Alice\repo with ':' and '\' stripped by the host
+        # (issue #65). Capital 'U' — a `Cu*` glob would miss this.
+        "CUsersAliceRepo",
+        # A different drive/dir: D:\repos\proj -> Dreposproj. No `Cu`/`CUsers`
+        # prefix at all; only structural (under ~/.reflexio) detection catches it.
+        "Dreposproj",
+        # Lowercased host mangling, to be casing-agnostic.
+        "cusersbobwork",
+    ],
+)
+def test_smart_install_redirects_reflexio_stray_copies_to_stable_root(
+    tmp_path: Path,
+    copy_dirname: str,
+) -> None:
+    """Regression: a host can expose CLAUDE_PLUGIN_ROOT as a cwd-derived copy
+    physically under ~/.reflexio (e.g. ``CUsers...`` on Windows, issue #65).
+    Installing .venv/node_modules there duplicates the full runtime per
+    project; smart-install must instead use the stable plugin root recorded in
+    ~/.reflexio/plugin-root. Detection is structural (any plugin dir under
+    ~/.reflexio), so it must hold regardless of the mangled name's prefix/case.
+    """
+    session_root = tmp_path / ".reflexio" / copy_dirname / "plugin"
+    stable_root = tmp_path / ".claude" / "plugins" / "cache" / "reflexioai" / "claude-smart" / "0.2.42"
+    fake_bin = tmp_path / "bin"
+    for root in (session_root, stable_root):
+        scripts = root / "scripts"
+        scripts.mkdir(parents=True)
+        shutil.copy2(SMART_INSTALL, scripts / "smart-install.sh")
+        shutil.copy2(LIB, scripts / "_lib.sh")
+        shutil.copy2(
+            REPO_ROOT / "plugin" / "scripts" / "ensure-plugin-root.sh",
+            scripts / "ensure-plugin-root.sh",
+        )
+        (root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+        (root / "uv.lock").write_text("")
+
+    (tmp_path / ".reflexio").mkdir(exist_ok=True)
+    (tmp_path / ".reflexio" / "plugin-root").symlink_to(
+        stable_root,
+        target_is_directory=True,
+    )
+    fake_bin.mkdir()
+    uv = fake_bin / "uv"
+    uv.write_text(
+        "#!/bin/sh\n"
+        'printf "%s|%s\\n" "$PWD" "$*" >> "$HOME/uv.log"\n'
+        'if [ "$1" = "sync" ]; then\n'
+        '  mkdir -p "$PWD/.venv/bin"\n'
+        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        '  chmod +x "$PWD/.venv/bin/python"\n'
+        "fi\n"
+        "exit 0\n"
+    )
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            str(session_root / "scripts" / "smart-install.sh"),
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (session_root / ".venv").exists()
+    assert (stable_root / ".venv" / "bin" / "python").exists()
+    uv_log = (tmp_path / "uv.log").read_text()
+    assert f"{stable_root}|sync --locked --python 3.12 --quiet" in uv_log
+    assert str(session_root) not in uv_log
+
+
 def test_smart_install_repairs_reflexio_template_env_drift(tmp_path: Path) -> None:
     plugin_root = tmp_path / "plugin"
     scripts = plugin_root / "scripts"


### PR DESCRIPTION
## Summary
Closes #65.

On Windows, the host (Claude Code / Codex) sometimes hands the plugin a `CLAUDE_PLUGIN_ROOT` that is a stray, cwd-derived copy of the plugin tree living **inside** `~/.reflexio` (e.g. `~/.reflexio/CUsers...`). When an entry script bootstraps a heavy `.venv` / `node_modules` into that location, every session accumulates a full PyTorch + ChromaDB + ONNX + Next/TypeScript runtime — ~1.5 GB each — which is never cleaned up and filled the reporter's 1.9 TB drive in roughly two weeks.

This PR stops the growth at the source: detect a stray plugin root under `~/.reflexio` and redirect execution to the stable, shared plugin root before any heavy install happens.

## Changes

**Stray-copy detection & redirect (shell)** — `plugin/scripts/_lib.sh`
- `claude_smart_is_reflexio_session_copy`: structural detection — a plugin-like dir (has `pyproject.toml` + `scripts/`) whose canonical path is a descendant of canonical `~/.reflexio`. Structural (descendant + markers) rather than name-based, because the host mangles the cwd differently per drive/user/case (`C:\Users` → `CUsers...`, `D:\repos` → `Drepos...`), so a fixed `Cu*` glob would miss most real copies.
- `claude_smart_stable_plugin_root_for_session_copy`: resolves the real shared root from known candidates (`~/.reflexio/plugin-root`, the Claude marketplace plugin, the Codex `current` link) and the Claude/Codex version caches, skipping any candidate that is itself a stray copy.
- `claude_smart_reexec_stable_plugin_root_if_needed`: `exec bash`s the same script from the stable root. Uses `-f` (not `-x`) since re-exec via `bash <script>` doesn't need the executable bit — cached copies on Windows/NTFS often lack it.

**Entry-script guards** — `backend-service.sh`, `cli.sh`, `dashboard-build.sh`, `dashboard-service.sh`, `hook_entry.sh`, `smart-install.sh`
- Each entry point calls the re-exec guard so a stray root is redirected before bootstrapping a runtime.

**Codex hook parity** — `plugin/scripts/codex-hook.js`
- Mirrors the shell logic (`isReflexioStrayPluginCopy` / `stablePluginRootForStrayCopy` / `stablePluginRoot`) and routes every `pluginRoot()` return path through the redirect.

**Windows project-id fix** — `plugin/src/claude_smart/ids.py`
- `_basename` handles native Windows paths under Git Bash (backslashes / `C:` drive prefix) via `PureWindowsPath`, and `resolve_project_id` falls back to the cwd basename on `OSError` so a bad path doesn't crash id resolution.

**Tests** — `tests/test_install_scripts.py`, `tests/test_ids.py`
- Cover stray-copy detection, redirect-to-stable-root behavior, and Windows path basename derivation.

## Test Plan
- `pytest tests/test_install_scripts.py tests/test_ids.py`
- `bash -n` on every modified shell script
- Parameterized cases use realistic stray names across drive letters and mixed case (not just `Cu*`), confirming the structural guard fires where a glob would miss.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Plugin system now intelligently detects temporary plugin copies and automatically redirects execution to stable cached versions, preventing redundant dependency bootstrapping.
  * Improved Windows path handling for consistent project identification across platforms.

* **Tests**
  * Added regression tests validating stray plugin detection and stable plugin root resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->