### PR TITLE
refactor: unify the citation gate wording across all render paths

### DIFF
--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -266,6 +266,7 @@ def render_inline_compact_with_registry(
 def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
     if os.environ.get("CLAUDE_SMART_CITATIONS", "on") == "off":
         return ""
+    gate = cs_cite.WHEN_TO_CITE_COMPACT
     link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
     if link_style == "osc8" and marker_parts:
         marker = f"✨ claude-smart rule applied: {' | '.join(marker_parts)}"
@@ -275,15 +276,14 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
             else ""
         )
         return _remoteize_citation_instruction(
-            f"If used, copy this final marker exactly, preserving its hidden "
-            f"OSC 8 terminal link: `{marker}`.{separator_instruction} "
-            f"Skip when unrelated."
+            f"{gate} If you do, copy this final marker exactly, preserving its "
+            f"hidden OSC 8 terminal link: `{marker}`.{separator_instruction}"
         )
     if link_style == "osc8":
         return _remoteize_citation_instruction(
-            "If used, end with `✨ claude-smart rule applied:` followed by "
-            "the same linked memory text; keep the link, but do not show the "
-            "URL. Skip when unrelated."
+            f"{gate} If you do, end with `✨ claude-smart rule applied:` "
+            "followed by the same linked memory text; keep the link, but do "
+            "not show the URL."
         )
     if marker_parts:
         marker = f"✨ claude-smart rule applied: {' | '.join(marker_parts)}"
@@ -293,14 +293,13 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
             else ""
         )
         return _remoteize_citation_instruction(
-            f"If used, copy this final marker exactly with markdown links: "
-            f"`{marker}`.{separator_instruction} Skip when unrelated."
+            f"{gate} If you do, copy this final marker exactly with markdown "
+            f"links: `{marker}`.{separator_instruction}"
         )
     return _remoteize_citation_instruction(
-        "Only if a listed [cs:...] item materially changes your answer, end "
-        "with one final marker like `✨ claude-smart rule applied: "
-        "[verify process state](http://localhost:3001/rules/s1-123)` using "
-        "the shown rule URL; skip the marker when unrelated."
+        f"{gate} If you do, end with one final marker like `✨ claude-smart "
+        "rule applied: [verify process state](http://localhost:3001/rules/"
+        "s1-123)` using the shown rule URL."
     )
 
 

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -55,9 +55,7 @@ _APPLIED_LINK_LINE_RE = re.compile(
     r"(?im)^\s*✨\s+(?:Applied|claude-smart rules? applied):\s+(?P<body>.+?)\s*$"
 )
 _MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\((?P<url>[^)]+)\)")
-_OSC8_URL_RE = re.compile(
-    r"\x1b\]8;[^\x07\x1b]*;(?P<url>[^\x07\x1b]+)(?:\x07|\x1b\\)"
-)
+_OSC8_URL_RE = re.compile(r"\x1b\]8;[^\x07\x1b]*;(?P<url>[^\x07\x1b]+)(?:\x07|\x1b\\)")
 _RAW_DASHBOARD_URL_RE = re.compile(
     r"(?P<url>(?:https?://[^\s),\x1b\\]+)?/"
     r"(?:skills/(?:project|shared)/[^\s),\x1b\\]+|"
@@ -65,14 +63,31 @@ _RAW_DASHBOARD_URL_RE = re.compile(
     r"rules/[^\s),\x1b\\]+))"
 )
 
-_COMPACT_INTRO = (
-    "_If you use any listed `[cs:…]` item to answer and it materially changes "
-    "your answer, you must end with one final marker line. Skip the marker "
-    "only when no listed item affected the answer."
+# The single "when to cite" decision, shared across every render path so the
+# bar can't drift between markdown / OSC8 / compact-Codex variants. The
+# counterfactual is the deciding test; relatedness alone is not enough.
+WHEN_TO_CITE = (
+    "When to cite: add a marker only when a listed `[cs:…]` item materially "
+    "and meaningfully changed your response — it must be clearly related to "
+    "what you actually did, and your answer would be substantively different "
+    "if the item had not been shown. The counterfactual is the deciding test: "
+    "if your response would be essentially the same without the item, omit the "
+    "marker."
 )
 
+# One-line form of WHEN_TO_CITE for the compact Codex path, which renders the
+# whole context block as a single logical line.
+WHEN_TO_CITE_COMPACT = (
+    "Cite only if a listed memory materially and meaningfully changed your "
+    "response — counterfactual: the answer would be substantively different "
+    "without it; otherwise omit."
+)
+
+_COMPACT_INTRO = f"_{WHEN_TO_CITE}"
+
 _MARKDOWN_MARKER_PARAGRAPH = (
-    "Use human-readable linked titles, not raw ids. Format for one item: "
+    "How to format: use human-readable linked titles, not raw ids. "
+    "Format for one item: "
     "`✨ claude-smart rule applied: "
     "[verify process state](http://localhost:3001/rules/s1-123)`. "
     "For multiple items: "
@@ -102,14 +117,13 @@ _OSC8_EXAMPLE_MULTI = (
     "\x1b]8;;\x1b\\"
 )
 _OSC8_MARKER_PARAGRAPH = (
-    "Use human-readable OSC 8 terminal hyperlinks, not raw ids or visible "
-    "URLs. Format for one item: "
+    "How to format: use human-readable OSC 8 terminal hyperlinks, not raw ids "
+    "or visible URLs. Format for one item: "
     f"`{_OSC8_EXAMPLE_ONE}`. For multiple items: "
     f"`{_OSC8_EXAMPLE_MULTI}`. Use the dashboard URL shown beside each cited "
     "item; do not invent URLs. Separate multiple linked memories with the "
     "visible ` | ` separator. If OSC 8 is unavailable, use markdown links. "
-    "Do not include `[cs:…]` ids in the marker line. Do not omit the marker "
-    "after using listed memory._"
+    "Do not include `[cs:…]` ids in the marker line._"
 )
 
 CITATION_MODES = ("on", "auto", "marker-only", "off")

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -12,7 +12,6 @@ from typing import Any
 from claude_smart import cli, cs_cite, hook, runtime, state
 from claude_smart.events import post_tool, pre_tool, stop
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -231,7 +230,7 @@ def test_codex_citation_instruction_uses_text_marker_not_tool_call() -> None:
 
     instruction = cs_cite.CITATION_INSTRUCTION
 
-    assert "materially changes your answer" in instruction
+    assert "materially and meaningfully changed your response" in instruction
     assert "✨ claude-smart rule applied:" in instruction
     assert "tool call" not in instruction
 

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -107,7 +107,7 @@ def test_render_with_registry_emits_citation_instruction() -> None:
         profiles=[],
     )
     assert cs_cite.CITATION_INSTRUCTION in md
-    assert "If you use any listed" in md
+    assert "When to cite:" in md
     assert "Do not call a shell command" not in md
     assert "✨ claude-smart rule applied: [verify process state]" in md
     assert "[brief answer preference]" in md
@@ -326,7 +326,7 @@ def test_render_inline_with_registry_marker_only_is_enabled_alias(
         profiles=[],
     )
     assert cs_cite.CITATION_INSTRUCTION in md
-    assert "materially changes your answer" in md
+    assert "materially and meaningfully changed your response" in md
     assert "citation block is up to two lines" not in md
 
 

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -88,7 +88,9 @@ def test_parse_text_citations_accepts_managed_reflexio_item_links() -> None:
 
 
 def test_parse_text_citations_keeps_old_applied_marker_compatible() -> None:
-    text = "Done.\n\n✨ Applied: [git safety](http://localhost:3001/skills/project/7536)"
+    text = (
+        "Done.\n\n✨ Applied: [git safety](http://localhost:3001/skills/project/7536)"
+    )
     assert cs_cite.parse_text_citations(text) == ["route:playbook:user_playbook:7536"]
 
 
@@ -109,8 +111,7 @@ def test_parse_text_citations_ignores_plain_inline_tags() -> None:
 def test_parse_text_citations_rejects_standalone_wrapper() -> None:
     assert cs_cite.parse_text_citations("Answer.\n\n✨s2-cd34✨") == []
     assert (
-        cs_cite.parse_text_citations("Answer.\n\n✨1gkgg8b9r7fx99kr2j3q6k5c1v✨")
-        == []
+        cs_cite.parse_text_citations("Answer.\n\n✨1gkgg8b9r7fx99kr2j3q6k5c1v✨") == []
     )
 
 
@@ -174,10 +175,10 @@ def test_rank_id_rejects_unknown_kind() -> None:
 def test_citation_instruction_on_returns_compact_string() -> None:
     text = cs_cite.citation_instruction("on")
     assert text == cs_cite.CITATION_INSTRUCTION
-    assert "If you use any listed" in text
-    assert "Skip the marker only when no listed item affected" in text
+    assert "When to cite:" in text
+    assert "materially and meaningfully changed your response" in text
     assert "citation block is up to two lines" not in text
-    assert "counterfactual" not in text.lower()
+    assert "counterfactual" in text.lower()
     assert "✨ claude-smart rule applied:" in text
     assert "Never use the old" in text
     assert "✨ 1 claude-smart learning applied [cs:...]" in text
@@ -197,7 +198,7 @@ def test_citation_instruction_osc8_uses_terminal_hyperlink_examples() -> None:
     assert "✨ claude-smart rules applied:" not in text
     assert " | \x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in text
     assert "visible ` | ` separator" in text
-    assert "Do not omit the marker after using listed memory" in text
+    assert "materially and meaningfully changed your response" in text
     assert "markdown links" in text
 
 
@@ -211,10 +212,7 @@ def test_citation_instruction_unknown_stays_enabled() -> None:
 
 
 def test_strip_marker_lines_removes_single_marker() -> None:
-    text = (
-        "Here's the answer.\n\n"
-        "✨ 1 claude-smart learning applied [cs:s1-1a2b]"
-    )
+    text = "Here's the answer.\n\n✨ 1 claude-smart learning applied [cs:s1-1a2b]"
     assert cs_cite.strip_marker_lines(text) == "Here's the answer."
 
 


### PR DESCRIPTION
## Summary
- Unifies the "when to cite" decision into shared constants so the citation bar can't drift between render paths.
- Sharpens the wording to make the **counterfactual test** the deciding criterion — relatedness alone is not enough — to reduce false-positive citations.

## Changes
- **`cs_cite.py`**: Introduce `WHEN_TO_CITE` (full form) and `WHEN_TO_CITE_COMPACT` (one-line form) as the single source of truth for the citation gate. `_COMPACT_INTRO` now derives from `WHEN_TO_CITE`. Marker-format paragraphs (markdown + OSC8) reworded with a leading "How to format:" and the redundant "do not omit the marker" clause removed.
- **`context_format.py`**: `_compact_citation_instruction` now references `cs_cite.WHEN_TO_CITE_COMPACT` across the OSC8, markdown, and plain variants instead of repeating bespoke "If used... Skip when unrelated" phrasing.
- **tests**: Update assertions in `test_cs_cite.py`, `test_context_format.py`, and `test_codex_support.py` to match the new shared wording (now expects "When to cite:", "materially and meaningfully changed your response", and "counterfactual").

## Test Plan
- `pyright` clean on both changed source files.
- `pytest tests/test_cs_cite.py tests/test_context_format.py tests/test_codex_support.py` → 95 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined citation instruction wording for improved clarity and consistency.
  * Updated guidance text to better communicate when citations materially affect responses.
  * Enhanced citation prompt structure with improved "when to cite" messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->