### PR TITLE
docs: add Codex install notes to plugin README

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -6,6 +6,8 @@ This directory is the published Python package (`claude-smart` on PyPI) and the 
 
 ## Install
 
+### Claude Code
+
 ```bash
 claude plugin marketplace add ReflexioAI/claude-smart
 claude plugin install claude-smart@reflexioai
@@ -25,7 +27,18 @@ embedding/ML dependency stack does not provide a complete native wheel set.
 
 Then restart Claude Code.
 
+### Codex
+
+```bash
+npx claude-smart install --host codex
+```
+
+Then fully quit and reopen Codex so hooks reload. Codex installs reuse the same
+local Preferences, Project-specific skills, and Shared skills as Claude Code.
+
 ## Uninstall
+
+### Claude Code
 
 ```bash
 claude plugin uninstall claude-smart@reflexioai
@@ -37,7 +50,14 @@ Or, if Node.js or uv is already installed:
 npx claude-smart uninstall   # or: uvx claude-smart uninstall
 ```
 
-Local data under `~/.reflexio/` and `~/.claude-smart/` is left in place — remove manually if desired.
+### Codex
+
+```bash
+npx claude-smart uninstall --host codex
+```
+
+Restart Codex after uninstalling. Local data under `~/.reflexio/` and
+`~/.claude-smart/` is left in place for both hosts — remove manually if desired.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add explicit Codex install and uninstall instructions to the published plugin README.
- Split install/uninstall docs into Claude Code and Codex subsections for faster scanning.
- Note that Codex and Claude Code reuse the same local Preferences, Project-specific skills, and Shared skills.

## Test Plan / Validation
- `git diff --check`
- Manual read-through of `plugin/README.md`

## Marketing rationale
Codex support is a meaningful discovery and conversion hook for developers comparing local agent memory tools. The PyPI/plugin README is a public-facing package surface, so making Codex installation obvious reduces friction without changing product claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup and uninstall instructions with explicit host-specific guidance for Claude Code and Codex integration.
  * Added detailed steps for configuring the plugin across different hosts and properly reloading changes.
  * Expanded notes on local data locations to help users understand the full cleanup process during uninstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->