### PR TITLE
fix: clean up .reflexio stray plugin copies (#73)

### DIFF
--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -148,10 +148,37 @@ function stablePluginRootForStrayCopy(root) {
   return null;
 }
 
+function cleanupStrayPluginCopy(root) {
+  if (!isReflexioStrayPluginCopy(root)) return;
+  const rootReal = realDir(root);
+  if (!rootReal) return;
+  try {
+    fs.rmSync(rootReal, { recursive: true, force: true });
+    appendLog("backend.log", `[claude-smart] removed stray plugin copy under ~/.reflexio (${rootReal})`);
+  } catch (err) {
+    appendLog("backend.log", `[claude-smart] failed to remove stray plugin copy ${rootReal}: ${err && err.message ? err.message : err}`);
+    return;
+  }
+
+  // Remove now-empty host-created wrapper folders (for example
+  // ~/.reflexio/CUsersAliceRepo/) without touching real Reflexio state dirs.
+  let parent = path.dirname(rootReal);
+  const reflexioReal = realDir(REFLEXIO_DIR);
+  while (reflexioReal && isInsideDir(reflexioReal, parent)) {
+    try {
+      fs.rmdirSync(parent);
+    } catch {
+      break;
+    }
+    parent = path.dirname(parent);
+  }
+}
+
 function stablePluginRoot(root) {
   const stable = stablePluginRootForStrayCopy(root);
   if (stable) {
     appendLog("backend.log", `[claude-smart] redirecting stray plugin copy under ~/.reflexio (${root}) to stable root ${stable}`);
+    cleanupStrayPluginCopy(root);
     return stable;
   }
   return root;

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -2579,7 +2579,8 @@ def test_codex_hook_redirects_reflexio_stray_copy_to_stable_root(
     assert (reflexio / "plugin-root").resolve() == stable_root
     assert json.loads(result.stdout) == {"continue": True}
     assert not (reflexio / "plugin-root").resolve() == stray_root
-    assert "redirecting stray plugin copy" in (
+    assert not stray_root.exists()
+    assert "removed stray plugin copy" in (
         tmp_path / ".claude-smart" / "backend.log"
     ).read_text()
 


### PR DESCRIPTION
## Summary
- Removes redirected stray plugin copies under `~/.reflexio` once a stable plugin cache root is found.
- Prunes empty wrapper directories created by host path mangling so `.reflexio` stops accumulating per-project plugin trees.
- Adds a regression assertion for the Codex hook stray-copy redirect path.

## Test Plan
- `cd plugin && uv run pytest ../tests/test_install_scripts.py::test_codex_hook_redirects_reflexio_stray_copy_to_stable_root -q`
- `cd plugin && uv run pytest ../tests/test_install_scripts.py::test_codex_hook_redirects_reflexio_stray_copy_to_stable_root ../tests/test_install_scripts.py::test_codex_hook_ensure_root_tracks_active_plugin_root -q`
- `git diff --check`

Note: full `uv run pytest ../tests/test_install_scripts.py -q` was attempted and hit existing environment-sensitive failures unrelated to this change (PATH-limited fake private Node tests and stale managed env test); the targeted regression and adjacent guard passed.

Fixes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin system now properly removes stray plugin copies after redirecting them to their stable locations, eliminating unnecessary duplicate directories that may have accumulated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->