### PR TITLE
docs: clarify plugin metadata terminology

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Yi Lu"
   },
   "metadata": {
-    "description": "claude-smart — self-improving Claude Code and Codex plugin via reflexio"
+    "description": "claude-smart — self-improving Claude Code and Codex plugin powered by Reflexio"
   },
   "plugins": [
     {
       "name": "claude-smart",
       "version": "0.2.44",
       "source": "./plugin",
-      "description": "Turns user corrections into project-specific and shared skills via reflexio — uses Claude Code or Codex as the LLM backend (no external API key required)"
+      "description": "Turns corrections into Preferences, Project-specific skills, and Shared skills — uses Claude Code or Codex as the LLM backend (no external API key required)"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.44",
-  "description": "Self-improving Claude Code and Codex plugin — turns corrections into durable skills via reflexio",
+  "description": "Self-improving Claude Code and Codex plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
   "keywords": [
     "claude",
     "claude-code",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.44",
-  "description": "Self-improving Claude Code and Codex plugin — turns corrections into durable skills via reflexio",
+  "description": "Self-improving Claude Code and Codex plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
   "author": {
     "name": "Yi Lu"
   },

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "claude-smart"
 version = "0.2.44"
-description = "Self-improving Claude Code and Codex plugin — turns corrections into durable skills via reflexio"
+description = "Self-improving Claude Code and Codex plugin that turns corrections into Preferences, Project-specific skills, and Shared skills"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Align npm, PyPI/plugin, and marketplace descriptions with the public claude-smart terminology: Preferences, Project-specific skills, and Shared skills.
- Keep the marketplace provenance as "powered by Reflexio" without exposing internal storage/API terms.
- Improve package/plugin discoverability for developers searching for Claude Code, Codex, memory, and self-improving agent tooling.

## Test Plan / Validation
- `git diff --check`
- `python3` JSON/TOML parse for `package.json`, `plugin/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `plugin/pyproject.toml`
- `npm pack --dry-run --json`

## Marketing rationale
This is a low-risk metadata-only change that reinforces the core public pitch: claude-smart turns corrections and working patterns into durable learning artifacts that future Claude Code and Codex sessions can reuse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product descriptions across marketplace, package, and plugin configuration files to reflect current branding and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->