### PR TITLE
fix: prevent Windows SessionEnd hook hang (#76)

### DIFF
--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -3,11 +3,53 @@
 # Claude Code hooks run with a minimal non-interactive PATH that often omits
 # nvm/asdf/brew shims where `npm`, `uv`, etc. live. Pull the user's login-shell
 # PATH the same way claude-mem does so hook-spawned scripts find them without
-# the user having to mutate their global PATH. Best-effort — failures silent.
+# the user having to mutate their global PATH. Best-effort and bounded: shell
+# profile startup can be slow or stuck on Windows, so this must never outlive a
+# hook's timeout budget.
+claude_smart_login_path_timeout_seconds() {
+  local _VALUE
+  _VALUE="${CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS:-2}"
+  case "$_VALUE" in
+    ''|*[!0-9]*) printf '%s\n' "2" ;;
+    *) printf '%s\n' "$_VALUE" ;;
+  esac
+}
+
+claude_smart_capture_login_path() {
+  local _TIMEOUT _TMP _PID _WAITED _LINE
+  _TIMEOUT="$(claude_smart_login_path_timeout_seconds)"
+  [ "$_TIMEOUT" -gt 0 ] || return 1
+
+  _TMP="${TMPDIR:-/tmp}/claude-smart-login-path.$$"
+  rm -f "$_TMP" 2>/dev/null || true
+  "$SHELL" -lc 'printf %s "$PATH"' >"$_TMP" 2>/dev/null &
+  _PID=$!
+  _WAITED=0
+  while kill -0 "$_PID" 2>/dev/null; do
+    if [ "$_WAITED" -ge "$_TIMEOUT" ]; then
+      kill "$_PID" 2>/dev/null || true
+      wait "$_PID" 2>/dev/null || true
+      rm -f "$_TMP" 2>/dev/null || true
+      return 1
+    fi
+    sleep 1
+    _WAITED=$((_WAITED + 1))
+  done
+  if wait "$_PID" 2>/dev/null; then
+    while IFS= read -r _LINE || [ -n "$_LINE" ]; do
+      printf '%s' "$_LINE"
+    done <"$_TMP"
+    rm -f "$_TMP" 2>/dev/null || true
+    return 0
+  fi
+  rm -f "$_TMP" 2>/dev/null || true
+  return 1
+}
+
 claude_smart_source_login_path() {
   local _SHELL_PATH
   if [ -n "${SHELL:-}" ] && [ -x "$SHELL" ]; then
-    if _SHELL_PATH="$("$SHELL" -lc 'printf %s "$PATH"' 2>/dev/null)"; then
+    if _SHELL_PATH="$(claude_smart_capture_login_path)"; then
       [ -n "$_SHELL_PATH" ] && export PATH="$_SHELL_PATH:$PATH"
     fi
   fi
@@ -116,30 +158,24 @@ claude_smart_dashboard_unavailable_marker() {
 }
 
 claude_smart_node_recovery_hint() {
-  cat <<'EOF'
-Recovery:
-  1. Restart Claude Code to let claude-smart retry its private Node.js install.
-  2. If the retry is blocked by your network or OS policy, install Node.js 20.9+ manually:
-EOF
+  printf '%s\n' \
+    "Recovery:" \
+    "  1. Restart Claude Code to let claude-smart retry its private Node.js install." \
+    "  2. If the retry is blocked by your network or OS policy, install Node.js 20.9+ manually:"
   if claude_smart_is_windows; then
-    cat <<'EOF'
-     - winget install OpenJS.NodeJS.LTS
-     - or download the LTS installer from https://nodejs.org/
-EOF
+    printf '%s\n' \
+      "     - winget install OpenJS.NodeJS.LTS" \
+      "     - or download the LTS installer from https://nodejs.org/"
   elif [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    cat <<'EOF'
-     - brew install node
-     - or download the LTS installer from https://nodejs.org/
-EOF
+    printf '%s\n' \
+      "     - brew install node" \
+      "     - or download the LTS installer from https://nodejs.org/"
   else
-    cat <<'EOF'
-     - use your distro package manager for nodejs/npm
-     - or download the LTS archive from https://nodejs.org/
-EOF
+    printf '%s\n' \
+      "     - use your distro package manager for nodejs/npm" \
+      "     - or download the LTS archive from https://nodejs.org/"
   fi
-  cat <<'EOF'
-  3. Run /claude-smart:restart, then /claude-smart:dashboard.
-EOF
+  printf '%s\n' "  3. Run /claude-smart:restart, then /claude-smart:dashboard."
 }
 
 claude_smart_write_dashboard_unavailable() {
@@ -529,14 +565,20 @@ claude_smart_append_capped_log() {
 # `os.setsid()` is POSIX-only; nohup ignores SIGHUP which is enough to
 # survive the parent console closing. On Windows, stdout/stderr are also
 # closed here so hook-runner pipes cannot be kept alive by long-lived
-# background children after the hook script exits. The python3 fallback is
-# gated on a real-interpreter probe (-V) so the Windows App Execution Alias
-# stub doesn't get invoked. POSIX callers are responsible for redirecting
-# stdout/stderr; we do not impose a log destination there. Stdin is closed so
-# the child cannot inherit a tty. Use `$!` after this call to capture the pid.
+# background children after the hook script exits unless the caller explicitly
+# opts into preserving stdout/stderr for a file redirection. The python3
+# fallback is gated on a real-interpreter probe (-V) so the Windows App
+# Execution Alias stub doesn't get invoked. POSIX callers are responsible for
+# redirecting stdout/stderr; we do not impose a log destination there. Stdin is
+# closed so the child cannot inherit a tty. Use `$!` after this call to capture
+# the pid.
 claude_smart_spawn_detached() {
   if claude_smart_is_windows; then
-    nohup "$@" < /dev/null > /dev/null 2>&1 &
+    if [ "${CLAUDE_SMART_SPAWN_KEEP_OUTPUT:-}" = "1" ]; then
+      nohup "$@" < /dev/null &
+    else
+      nohup "$@" < /dev/null > /dev/null 2>&1 &
+    fi
     return 0
   fi
   if command -v setsid >/dev/null 2>&1; then

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -527,14 +527,16 @@ claude_smart_append_capped_log() {
 # POSIX: setsid → python3 os.setsid → nohup (in that order of strength).
 # Windows: nohup alone — Git Bash has no setsid, no process groups, and
 # `os.setsid()` is POSIX-only; nohup ignores SIGHUP which is enough to
-# survive the parent console closing. The python3 fallback is gated on a
-# real-interpreter probe (-V) so the Windows App Execution Alias stub
-# doesn't get invoked. Caller is responsible for redirecting stdout/stderr;
-# we do not impose a log destination here. Stdin is closed so the child
-# cannot inherit a tty. Use `$!` after this call to capture the pid.
+# survive the parent console closing. On Windows, stdout/stderr are also
+# closed here so hook-runner pipes cannot be kept alive by long-lived
+# background children after the hook script exits. The python3 fallback is
+# gated on a real-interpreter probe (-V) so the Windows App Execution Alias
+# stub doesn't get invoked. POSIX callers are responsible for redirecting
+# stdout/stderr; we do not impose a log destination there. Stdin is closed so
+# the child cannot inherit a tty. Use `$!` after this call to capture the pid.
 claude_smart_spawn_detached() {
   if claude_smart_is_windows; then
-    nohup "$@" < /dev/null &
+    nohup "$@" < /dev/null > /dev/null 2>&1 &
     return 0
   fi
   if command -v setsid >/dev/null 2>&1; then

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -264,7 +264,7 @@ case "$CMD" in
     if ! command -v uv >/dev/null 2>&1; then
       if [ "${CLAUDE_SMART_BOOTSTRAPPING:-}" != "1" ] && [ -x "$PLUGIN_ROOT/scripts/smart-install.sh" ]; then
         claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: uv not on PATH; starting installer in background"
-        claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
+        CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
           bash "$PLUGIN_ROOT/scripts/smart-install.sh" \
           >>"$STATE_DIR/install.log" 2>&1 || true
       fi

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -20,11 +20,13 @@ set -eu
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
-claude_smart_source_login_path
+CMD="${1:-start}"
+if [ "$CMD" != "session-end" ]; then
+  claude_smart_source_login_path
+fi
 claude_smart_prepend_astral_bins
 claude_smart_source_reflexio_env
 
-CMD="${1:-start}"
 PORT=8071
 EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"
 # Pass through to `reflexio services start/stop` so the spawned backend

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -194,7 +194,7 @@ case "$CMD" in
     if [ -z "$NPM_BIN" ] || ! "$NPM_BIN" --version >/dev/null 2>&1; then
       if [ "${CLAUDE_SMART_BOOTSTRAPPING:-}" != "1" ] && [ -x "$PLUGIN_ROOT/scripts/smart-install.sh" ]; then
         echo "[claude-smart] dashboard: npm is not on PATH; starting installer in background" >>"$LOG_FILE"
-        claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
+        CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
           bash "$PLUGIN_ROOT/scripts/smart-install.sh" \
           >>"$STATE_DIR/install.log" 2>&1 || true
       fi
@@ -216,7 +216,7 @@ case "$CMD" in
       BUILD_PID_FILE="$STATE_DIR/dashboard-build.pid"
       if ! claude_smart_pid_alive_file "$BUILD_PID_FILE"; then
         echo "[claude-smart] dashboard: .next missing — starting background build (~1-2 min)" >>"$LOG_FILE"
-        claude_smart_spawn_detached bash "$HERE/dashboard-build.sh" >>"$LOG_FILE" 2>&1
+        CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached bash "$HERE/dashboard-build.sh" >>"$LOG_FILE" 2>&1
       fi
       emit_ok; exit 0
     fi
@@ -231,7 +231,7 @@ case "$CMD" in
     # Caller-side `>>file 2>&1` redirection is honoured before the child
     # detaches, so per-OS log paths stay identical.
     export CLAUDE_SMART_DASHBOARD_WORKSPACE="$WORKSPACE_CWD"
-    claude_smart_spawn_detached "$NPM_BIN" run start >>"$LOG_FILE" 2>&1
+    CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached "$NPM_BIN" run start >>"$LOG_FILE" 2>&1
     dash_pid=$!
     # Record the spawned pid, not a pgid sampled with ps. On POSIX,
     # setsid/python os.setsid make this pid the new process group leader;

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -21,11 +21,13 @@ set -eu
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_lib.sh
 . "$HERE/_lib.sh"
-claude_smart_source_login_path
+CMD="${1:-start}"
+if [ "$CMD" != "session-end" ]; then
+  claude_smart_source_login_path
+fi
 claude_smart_prepend_node_bins
 claude_smart_source_reflexio_env
 
-CMD="${1:-start}"
 PORT=3001
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -96,7 +96,7 @@ if ! command -v uv >/dev/null 2>&1; then
   fi
   if [ -x "$PLUGIN_ROOT/scripts/smart-install.sh" ]; then
     mkdir -p "$STATE_DIR"
-    claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
+    CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
       bash "$PLUGIN_ROOT/scripts/smart-install.sh" \
       >>"$STATE_DIR/install.log" 2>&1 || true
   fi
@@ -123,7 +123,7 @@ ensure_hook_package_importable() {
     printf '%s\n' "[claude-smart] hook: claude_smart.hook is not importable; retrying install in background"
     date 2>/dev/null || true
   } >>"$STATE_DIR/install.log" 2>&1
-  claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
+  CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
     bash "$PLUGIN_ROOT/scripts/smart-install.sh" \
     >>"$STATE_DIR/install.log" 2>&1 || true
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -338,6 +338,20 @@ def test_backend_service_pins_reflexio_home_to_user_home() -> None:
     assert 'export REFLEXIO_LOG_DIR="${REFLEXIO_LOG_DIR:-$HOME}"' in service
 
 
+def test_windows_detached_spawn_closes_hook_output_pipes() -> None:
+    lib = LIB.read_text()
+
+    assert 'nohup "$@" < /dev/null > /dev/null 2>&1 &' in lib
+
+
+def test_session_end_service_hooks_skip_login_shell_path_lookup() -> None:
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+    dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
+
+    assert 'CMD="${1:-start}"\nif [ "$CMD" != "session-end" ]; then\n  claude_smart_source_login_path\nfi' in backend
+    assert 'CMD="${1:-start}"\nif [ "$CMD" != "session-end" ]; then\n  claude_smart_source_login_path\nfi' in dashboard
+
+
 def test_service_start_scripts_recover_missing_dependencies_without_cli_command() -> (
     None
 ):

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -342,14 +342,77 @@ def test_windows_detached_spawn_closes_hook_output_pipes() -> None:
     lib = LIB.read_text()
 
     assert 'nohup "$@" < /dev/null > /dev/null 2>&1 &' in lib
+    assert '[ "${CLAUDE_SMART_SPAWN_KEEP_OUTPUT:-}" = "1" ]' in lib
+    assert 'nohup "$@" < /dev/null &' in lib
+
+
+def test_login_shell_path_lookup_is_bounded(tmp_path: Path) -> None:
+    slow_shell = tmp_path / "slow-shell"
+    slow_shell.write_text("#!/bin/sh\nsleep 5\nprintf '%s' '/too-late/bin'\n")
+    slow_shell.chmod(slow_shell.stat().st_mode | stat.S_IXUSR)
+
+    env = _isolated_env(tmp_path)
+    env["SHELL"] = str(slow_shell)
+    env["CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS"] = "1"
+    env["PATH"] = _minimal_path(tmp_path, "cat", "rm", "sleep")
+
+    started = time.monotonic()
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            f'. "{LIB}"; claude_smart_source_login_path; printf "%s" "$PATH"',
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=3,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert time.monotonic() - started < 3
+    assert "/too-late/bin" not in result.stdout
+
+
+def test_detached_spawns_with_log_redirection_preserve_output_on_windows() -> None:
+    hook_entry = HOOK_ENTRY.read_text()
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+    dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
+
+    assert (
+        "CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env "
+        "CLAUDE_SMART_BOOTSTRAPPING=1"
+    ) in hook_entry
+    assert (
+        "CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env "
+        "CLAUDE_SMART_BOOTSTRAPPING=1"
+    ) in backend
+    assert (
+        "CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env "
+        "CLAUDE_SMART_BOOTSTRAPPING=1"
+    ) in dashboard
+    assert (
+        "CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached "
+        '"$NPM_BIN" run start >>"$LOG_FILE" 2>&1'
+        in dashboard
+    )
 
 
 def test_session_end_service_hooks_skip_login_shell_path_lookup() -> None:
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
     dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
 
-    assert 'CMD="${1:-start}"\nif [ "$CMD" != "session-end" ]; then\n  claude_smart_source_login_path\nfi' in backend
-    assert 'CMD="${1:-start}"\nif [ "$CMD" != "session-end" ]; then\n  claude_smart_source_login_path\nfi' in dashboard
+    session_end_guard = (
+        'CMD="${1:-start}"\n'
+        'if [ "$CMD" != "session-end" ]; then\n'
+        "  claude_smart_source_login_path\n"
+        "fi"
+    )
+    assert session_end_guard in backend
+    assert session_end_guard in dashboard
 
 
 def test_service_start_scripts_recover_missing_dependencies_without_cli_command() -> (


### PR DESCRIPTION
## Summary
- Fixes Windows detached hook spawning so background services cannot keep Claude Code hook stdout/stderr pipes open.
- Bounds login-shell PATH lookup globally so slow or stuck shell startup cannot hang `hook_entry.sh` or service hooks.
- Skips expensive login-shell PATH lookup for backend/dashboard `session-end` no-op hooks.
- Preserves explicit log redirection for detached installer/dashboard recovery spawns while still closing hook-runner pipes by default.
- Adds regression coverage for Windows pipe detachment, bounded login-shell lookup, SessionEnd login-shell avoidance, and log-preserving detached spawns.

## Test Plan
- `git diff --check`
- `bash -n plugin/scripts/_lib.sh plugin/scripts/hook_entry.sh plugin/scripts/backend-service.sh plugin/scripts/dashboard-service.sh plugin/scripts/smart-install.sh`
- `uv run --project plugin pytest tests/test_install_scripts.py -q`
- `uv run --project plugin pytest tests/test_install_scripts.py::test_windows_detached_spawn_closes_hook_output_pipes tests/test_install_scripts.py::test_login_shell_path_lookup_is_bounded tests/test_install_scripts.py::test_detached_spawns_with_log_redirection_preserve_output_on_windows tests/test_install_scripts.py::test_session_end_service_hooks_skip_login_shell_path_lookup tests/test_install_scripts.py::test_service_start_scripts_recover_missing_dependencies_without_cli_command -q`

Fixes #76


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved login-shell `PATH` capture with a bounded timeout to prevent long waits.
  * Enhanced Windows behavior for detached background processes by suppressing unwanted stdout/stderr output unless output is explicitly kept.
  * Updated service startup logic to avoid unnecessary environment setup for `session-end`.
  * Adjusted Windows recovery/installer and dashboard spawns to preserve output when configured.

* **Tests**
  * Added regression tests covering Windows detached output redirection and session-end environment setup skipping.
  * Added a timeout-focused test to ensure `PATH` capture does not hang on slow shells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
