### PR TITLE
docs: add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
   <a href="#quick-start">
     <img src="https://img.shields.io/badge/hosts-Claude%20Code%20%2B%20Codex-purple.svg" alt="Hosts">
   </a>
+  <a href="https://discord.gg/7fnCxahase">
+    <img src="https://img.shields.io/badge/Discord-Join%20community-5865F2?logo=discord&logoColor=white" alt="Discord">
+  </a>
 </p>
 
 <p align="center">
@@ -232,6 +235,7 @@ See the [LICENSE](LICENSE) file for details.
 
 ## Support
 
+- **Discord**: join the community at [discord.gg/7fnCxahase](https://discord.gg/7fnCxahase).
 - **Issues**: open one on GitHub describing the symptom and include the reflexio backend log (`~/.claude-smart/backend.log`) and the relevant lines of `~/.claude-smart/sessions/{session_id}.jsonl`.
 
 ---


### PR DESCRIPTION
## Summary
- Make the community Discord visible from the claude-smart README header.
- Keep the invite available in the existing Support section for readers looking for help.

## Changes
- Added a Discord Shields.io badge to the top README badge block.
- Added the Discord invite to Support.

## Test Plan
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Discord community badge and link for easier discovery.
  * Updated Support section with direct Discord community join link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->