### PR TITLE
fix(plugin): remove top-level description from codex-hooks.json

### DIFF
--- a/plugin/hooks/codex-hooks.json
+++ b/plugin/hooks/codex-hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "claude-smart hooks for Codex — learn from sessions via reflexio",
   "hooks": {
     "SessionStart": [
       {

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -184,6 +184,15 @@ def test_codex_hooks_use_expected_events_and_marketplace_fallback() -> None:
         assert ".codex/plugins/cache/reflexioai/claude-smart" in command
 
 
+def test_codex_hooks_top_level_matches_codex_schema() -> None:
+    # Codex's plugin hook schema is strict and rejects any top-level field
+    # other than "hooks" (e.g. "description" causes
+    # "unknown field description, expected hooks"). Tests that only read
+    # `["hooks"]` would silently miss a regression of this kind, so guard the
+    # top-level shape explicitly.
+    assert set(_read_json("plugin/hooks/codex-hooks.json")) == {"hooks"}
+
+
 def test_hook_main_accepts_legacy_and_host_argv(monkeypatch) -> None:
     calls: list[tuple[str, str]] = []
 


### PR DESCRIPTION
## Problem

After upgrading Codex, the plugin fails to load with:

```
failed to parse plugin hooks config .../claude-smart/.../hooks/codex-hooks.json: unknown field description, expected hooks at line 2 column 15
```

Codex's plugin hook schema is strict: it only accepts a top-level `hooks` field. The current `plugin/hooks/codex-hooks.json` includes an extra `description` field at the top level, which Codex rejects — breaking the plugin on every Codex session.

The `description` field is valid for the Claude Code plugin schema (and is still present in `plugin/hooks/hooks.json`, where it is harmless). The Codex variant just needs to be schema-clean.

## Fix

Drop the top-level `description` line from `plugin/hooks/codex-hooks.json`. No other changes — the hook command set and structure are unchanged.

```diff
 {
-  "description": "claude-smart hooks for Codex — learn from sessions via reflexio",
   "hooks": {
     ...
   }
 }
```

## Verification

- `python3 -m json.tool plugin/hooks/codex-hooks.json` → valid JSON
- `uv run --with pytest pytest tests/test_codex_support.py tests/test_install_scripts.py` → **129 passed** (the relevant tests only access the file via the `["hooks"]` key, so they're unaffected by the removed top-level field)

Repro path for maintainers: install v0.2.45 in current Codex → start a session → observe the parse error in plugin config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Codex hooks configuration to match the expected JSON schema (removed an unsupported top-level metadata field).
* **Tests**
  * Added a schema validation test to ensure the hooks file has the correct top-level structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->