### PR TITLE
fix: restore CLAUDE.md in .agents/skills/sync-agent-instructions

### DIFF
--- a/.agents/skills/sync-agent-instructions/SKILL.md
+++ b/.agents/skills/sync-agent-instructions/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: sync-agent-instructions
-description: Sync AI coding tool instruction files (AGENTS.md, GEMINI.md, AGENTS.md) so they stay aligned. Detects which file changed and copies it to the others. Use when syncing md files, syncing instructions, updating GEMINI.md, or updating AGENTS.md.
+description: Sync AI coding tool instruction files (CLAUDE.md, GEMINI.md, AGENTS.md) so they stay aligned. Detects which file changed and copies it to the others. Use when syncing md files, syncing instructions, updating GEMINI.md, or updating AGENTS.md.
 ---
 
 # Sync Agent Instructions
 
-Keep AGENTS.md, GEMINI.md, and AGENTS.md in sync so all AI coding tools share the same project instructions.
+Keep CLAUDE.md, GEMINI.md, and AGENTS.md in sync so all AI coding tools share the same project instructions.
 
 ## Workflow
 
-1. **Detect changes** — Run `git diff HEAD -- AGENTS.md GEMINI.md AGENTS.md` to see which file(s) have uncommitted changes.
+1. **Detect changes** — Run `git diff HEAD -- CLAUDE.md GEMINI.md AGENTS.md` to see which file(s) have uncommitted changes.
 
 2. **Determine source file:**
    - **One file changed** — That file is the source. Copy its content to the other two.


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `.agents/skills/sync-agent-instructions/SKILL.md` lists `AGENTS.md` twice (once where `CLAUDE.md` should be) in the frontmatter description, the h1, and the `git diff` command in Step 1 — `CLAUDE.md` is absent from all three places. The `git diff HEAD -- AGENTS.md GEMINI.md AGENTS.md` command in Step 1 will never detect changes to `CLAUDE.md`. The `.claude/skills/sync-agent-instructions/SKILL.md` copy is correct and unaffected.

**Evidence**: Line 3 frontmatter reads `AGENTS.md, GEMINI.md, AGENTS.md`; line 8 h1 reads `AGENTS.md, GEMINI.md, and AGENTS.md`; line 12 git diff lists `AGENTS.md GEMINI.md AGENTS.md` — `CLAUDE.md` absent in all three. The `.claude/skills/` copy correctly lists `CLAUDE.md` in each location.

**Fix**: Replace the duplicate `AGENTS.md` with `CLAUDE.md` in the frontmatter description, h1, and Step 1 git diff command — matching the `.claude/skills/` copy exactly.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:16e56a7ff115192dbefb5c81c341f8e1346f8defbbca87ccf13774a1291ed208"}]}
nlpm-metadata-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected agent instructions documentation to ensure proper synchronization of configuration files and updated the workflow to accurately track all instruction sources, improving consistency across agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->