### PR TITLE
fix: add missing name frontmatter to plugin commands

### DIFF
--- a/plugin/commands/clear-all.md
+++ b/plugin/commands/clear-all.md
@@ -1,4 +1,5 @@
 ---
+name: clear-all
 description: Delete ALL local claude-smart learned data and restart the backend (destructive)
 allowed-tools: Bash(bash:*)
 ---

--- a/plugin/commands/dashboard.md
+++ b/plugin/commands/dashboard.md
@@ -1,4 +1,5 @@
 ---
+name: dashboard
 description: Open the claude-smart dashboard (http://localhost:3001) in the browser, starting the backend and dashboard if they aren't running
 allowed-tools: Bash(bash:*)
 ---

--- a/plugin/commands/learn.md
+++ b/plugin/commands/learn.md
@@ -1,4 +1,5 @@
 ---
+name: learn
 description: Force claude-smart to extract learnings from this session now
 argument-hint: [optional note to capture]
 allowed-tools: Bash(bash:*)

--- a/plugin/commands/restart.md
+++ b/plugin/commands/restart.md
@@ -1,4 +1,5 @@
 ---
+name: restart
 description: Restart the reflexio backend and dashboard to pick up new changes
 allowed-tools: Bash(bash:*)
 ---

--- a/plugin/commands/show.md
+++ b/plugin/commands/show.md
@@ -1,4 +1,5 @@
 ---
+name: show
 description: Show current project-specific skills and session preferences
 allowed-tools: Bash(bash:*)
 ---


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: All five plugin commands (`restart`, `learn`, `clear-all`, `show`, `dashboard`) are missing the required `name` field in their YAML frontmatter; each has only `description` and `allowed-tools`. Claude Code plugin commands require a `name` field for slash-command registration — without it the commands may not be registered under predictable names.

**Evidence**: `grep -n "^name:" plugin/commands/*.md` returns zero matches; every frontmatter block opens with `description:` as the first field.

**Fix**: Add `name: <command>` (matching the filename) as the first field in each file's frontmatter — five one-line additions, no other changes.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:fd21a1a77276d64f157876d416241c295340e50f5cb9cc1e6b3c770a3b36af81"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:dddc0821cbccde44b170f5a875b72abfd4406b6aa0df0c837b478358f4dfbdcc"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:3b3c1e80fd536ed7e010d41c0d8ccd76c5d25d41d49c0b30a9d8c8383f7ba41c"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:92a33598b25d4a9bce91f0a291c26ed95da1ea80176699087fa802554f856581"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:b90dcb78f7b26acb1d2530245ad28e4b91d64cdd1d2dc71bfc5b0babf02d2f04"}]}
nlpm-metadata-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata documentation across command references (clear-all, dashboard, learn, restart, show).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->