### PR TITLE
docs: improve PyPI discovery metadata

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # claude-smart
 
-Self-improving [Claude Code](https://claude.com/claude-code) and Codex plugin — turns your corrections into durable skills that future sessions follow, via [reflexio](https://github.com/ReflexioAI/reflexio).
+Self-improving [Claude Code](https://claude.com/claude-code) and Codex plugin — turns corrections and successful workflows into durable Preferences, Project-specific skills, and Shared skills that future sessions follow, via [reflexio](https://github.com/ReflexioAI/reflexio).
 
 This directory is the published Python package (`claude-smart` on PyPI) and the Claude Code/Codex plugin payload shipped through the marketplace. For the project overview, install instructions, benchmarks, and feature walkthrough, see the [top-level README](https://github.com/ReflexioAI/claude-smart#readme).
 

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -2,6 +2,21 @@
 name = "claude-smart"
 version = "0.2.45"
 description = "Self-improving Claude Code and Codex plugin that turns corrections into Preferences, Project-specific skills, and Shared skills"
+keywords = [
+    "claude",
+    "claude-code",
+    "claude-code-plugin",
+    "codex",
+    "codex-plugin",
+    "memory",
+    "agent-memory",
+    "plugin",
+    "reflexio",
+    "self-improvement",
+    "self-improving-agents",
+    "skills",
+    "learning",
+]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Add PyPI keywords mirroring the established npm/plugin discovery terms for Claude Code, Codex, memory, skills, and self-improving agents.
- Tighten the plugin package README opening sentence to mention Preferences, Project-specific skills, and Shared skills.

## Test Plan / Validation
- `git diff --check`
- `python3` TOML parse/assertion for `plugin/pyproject.toml`
- `uv build --project plugin --sdist --out-dir /tmp/claude-smart-build-1782118965`

## Marketing rationale
This is a low-risk discoverability improvement for the published Python package surface. It keeps public terminology aligned with `DEVELOPER.md` and the top-level README while improving search relevance for developers looking for Claude Code memory, Codex plugin, agent-memory, and self-improving agent tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin description to clarify that it converts corrections and successful workflows into durable skills and preferences.
  * Added relevant keywords to plugin metadata for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->