### PR TITLE
feat: run claude-smart under its own org id and env file

### DIFF
--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -87,8 +87,12 @@ claude_smart_env_unquote() {
 }
 
 claude_smart_source_reflexio_env() {
+  # claude-smart's env lives at ~/.claude-smart/.env (kept separate from the OSS
+  # reflexio default ~/.reflexio/.env). Stays in sync with
+  # env_config.REFLEXIO_ENV_PATH and the REFLEXIO_ENV_FILE export in
+  # backend-service.sh.
   local env_file line key value
-  env_file="$HOME/.reflexio/.env"
+  env_file="$HOME/.claude-smart/.env"
   [ -f "$env_file" ] || return 0
   while IFS= read -r line || [ -n "$line" ]; do
     line="${line#"${line%%[![:space:]]*}"}"

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -42,6 +42,13 @@ export EMBEDDING_PORT
 # config_self-host-org.json. Must stay in sync with cli.py's config path.
 export REFLEXIO_DEFAULT_ORG_ID="claude-smart"
 
+# Load claude-smart's env from ~/.claude-smart/.env instead of the reflexio
+# default ~/.reflexio/.env, so an OSS reflexio backend's .env on this machine
+# can't leak in. The data dir is independent (LOCAL_STORAGE_PATH), so both still
+# share ~/.reflexio/data. Must stay in sync with env_config.REFLEXIO_ENV_PATH and
+# the source path in _lib.sh (claude_smart_source_reflexio_env).
+export REFLEXIO_ENV_FILE="$HOME/.claude-smart/.env"
+
 # Default: route extraction through the active host CLI + ONNX embedder
 # so claude-smart works without any LLM API key. Users can opt out by
 # pre-exporting these to 0.

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -34,6 +34,14 @@ EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"
 export BACKEND_PORT="$PORT"
 export EMBEDDING_PORT
 
+# Run claude-smart's backend under its own org id. The reflexio no-auth resolver
+# reads REFLEXIO_DEFAULT_ORG_ID, which scopes the request org -> config file
+# name (config_<org>.json) and SQLite data. Hard-set (not :-defaulted) so a
+# value in the shared ~/.reflexio/.env can't drag claude-smart back onto
+# "self-host-org" and collide with the enterprise self-host backend over
+# config_self-host-org.json. Must stay in sync with cli.py's config path.
+export REFLEXIO_DEFAULT_ORG_ID="claude-smart"
+
 # Default: route extraction through the active host CLI + ONNX embedder
 # so claude-smart works without any LLM API key. Users can opt out by
 # pre-exporting these to 0.

--- a/plugin/scripts/ensure-plugin-root.sh
+++ b/plugin/scripts/ensure-plugin-root.sh
@@ -36,8 +36,8 @@ fi
 # symlink tracks the currently loaded plugin.
 FOLLOW="${CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION:-}"
 if [ -z "$FOLLOW" ] && [ -f "$HOME/.claude-smart/.env" ]; then
-    FOLLOW="$(grep -E '^CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION=' "$HOME/.claude-smart/.env" \
-        | tail -n1 | cut -d= -f2-)"
+    FOLLOW="$(grep -E '^(export[[:space:]]+)?CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION=' "$HOME/.claude-smart/.env" \
+        | tail -n1 | sed -E 's/^(export[[:space:]]+)?CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION=//')"
     # Strip a single pair of surrounding double or single quotes, if present.
     FOLLOW="${FOLLOW#\"}"; FOLLOW="${FOLLOW%\"}"
     FOLLOW="${FOLLOW#\'}"; FOLLOW="${FOLLOW%\'}"

--- a/plugin/scripts/ensure-plugin-root.sh
+++ b/plugin/scripts/ensure-plugin-root.sh
@@ -32,11 +32,11 @@ if [ "$FORCE" = "--force" ]; then
 fi
 
 # Opt-in: when CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION=1 (set in the
-# environment or in ~/.reflexio/.env), always relink to $TARGET so the
+# environment or in ~/.claude-smart/.env), always relink to $TARGET so the
 # symlink tracks the currently loaded plugin.
 FOLLOW="${CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION:-}"
-if [ -z "$FOLLOW" ] && [ -f "$HOME/.reflexio/.env" ]; then
-    FOLLOW="$(grep -E '^CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION=' "$HOME/.reflexio/.env" \
+if [ -z "$FOLLOW" ] && [ -f "$HOME/.claude-smart/.env" ]; then
+    FOLLOW="$(grep -E '^CLAUDE_SMART_PLUGIN_ROOT_FOLLOW_SESSION=' "$HOME/.claude-smart/.env" \
         | tail -n1 | cut -d= -f2-)"
     # Strip a single pair of surrounding double or single quotes, if present.
     FOLLOW="${FOLLOW#\"}"; FOLLOW="${FOLLOW%\"}"

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -108,10 +108,10 @@ install_complete() {
   [ -d "$PLUGIN_ROOT/.venv" ] || return 1
   claude_smart_python_imports "$PLUGIN_ROOT" claude_smart.hook || return 1
   if [ -z "${REFLEXIO_API_KEY:-}" ]; then
-    [ -f "$HOME/.reflexio/.env" ] || return 1
-    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_CLI=' "$HOME/.reflexio/.env" || return 1
-    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$HOME/.reflexio/.env" || return 1
-    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_READ_ONLY=' "$HOME/.reflexio/.env" || return 1
+    [ -f "$HOME/.claude-smart/.env" ] || return 1
+    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_CLI=' "$HOME/.claude-smart/.env" || return 1
+    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_USE_LOCAL_EMBEDDING=' "$HOME/.claude-smart/.env" || return 1
+    grep -qE '^(export[[:space:]]+)?CLAUDE_SMART_READ_ONLY=' "$HOME/.claude-smart/.env" || return 1
   fi
   if [ -d "$PLUGIN_ROOT/dashboard" ]; then
     [ -d "$PLUGIN_ROOT/dashboard/.next" ] || [ -f "$MARKER_DIR/dashboard-build.pid" ] || [ -f "$(claude_smart_dashboard_unavailable_marker)" ] || return 1
@@ -480,10 +480,12 @@ if ! claude_smart_python_imports "$PLUGIN_ROOT" claude_smart.hook; then
   write_failure "claude-smart package is not importable after vendored Reflexio install in $PLUGIN_ROOT/.venv"
 fi
 
-# Reflexio's CLI reads ~/.reflexio/.env (see reflexio/cli/env_loader.py);
-# append our two opt-in flags there so `reflexio services start` picks
-# them up regardless of which directory the user runs it from.
-REFLEXIO_ENV="$HOME/.reflexio/.env"
+# claude-smart's backend loads ~/.claude-smart/.env (backend-service.sh exports
+# REFLEXIO_ENV_FILE so reflexio's CLI reads it instead of ~/.reflexio/.env);
+# append our opt-in flags there so `reflexio services start` picks them up. Keep
+# this path in sync with env_config.REFLEXIO_ENV_PATH and backend-service.sh.
+REFLEXIO_ENV="$HOME/.claude-smart/.env"
+mkdir -p "$(dirname "$REFLEXIO_ENV")"
 claude_smart_env_quote() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
 }

--- a/plugin/src/README.md
+++ b/plugin/src/README.md
@@ -28,7 +28,7 @@ Description: Python package powering the claude-smart plugin — hook handlers t
 
 | File | Purpose |
 |------|---------|
-| `env_config.py` | Parses `~/.reflexio/.env` (`REFLEXIO_URL`, `REFLEXIO_API_KEY`, `CLAUDE_SMART_READ_ONLY`, local embedding/CLI flags). |
+| `env_config.py` | Parses `~/.claude-smart/.env` (`REFLEXIO_URL`, `REFLEXIO_API_KEY`, `CLAUDE_SMART_READ_ONLY`, local embedding/CLI flags). |
 | `runtime.py` | Host detection (Claude Code vs Codex); shared agent version. |
 | `ids.py` | Session / project ID generation and resolution. |
 | `context_inject.py`, `context_format.py`, `query_compose.py`, `cs_cite.py` | Build search queries, format learned skills as markdown, inject into context, format citations. |

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -83,7 +83,12 @@ _LOCAL_DATA_NOTICE = (
 _INSTALL_FAILURE_MARKER = _STATE_DIR / "install-failed"
 _SERVICE_STATUS_PROBE_FAILED = "probe_failed"
 _DEFAULT_STORAGE_ROOT = _REFLEXIO_DIR / "data"
-_REFLEXIO_CONFIG_PATH = _REFLEXIO_DIR / "configs" / "config_self-host-org.json"
+# Org id claude-smart's backend runs under (set via REFLEXIO_DEFAULT_ORG_ID in
+# backend-service.sh). reflexio names the config file config_<org>.json, so this
+# must stay in sync with that export; using our own org keeps us off the
+# enterprise self-host backend's config_self-host-org.json.
+_REFLEXIO_ORG_ID = "claude-smart"
+_REFLEXIO_CONFIG_PATH = _REFLEXIO_DIR / "configs" / f"config_{_REFLEXIO_ORG_ID}.json"
 _LOCAL_STORAGE_ENV = "LOCAL_STORAGE_PATH"
 _CODEX_REQUIRED_FILES = (
     Path(".agents/plugins/marketplace.json"),

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -3,7 +3,7 @@
 Exposes the following subcommands:
 
 - ``install``: register the GitHub marketplace and install the plugin into
-  Claude Code, then seed ``~/.reflexio/.env`` with the local-provider flags.
+  Claude Code, then seed ``~/.claude-smart/.env`` with the local-provider flags.
 - ``update``: update the plugin to the latest version via the native Claude
   Code plugin CLI.
 - ``uninstall``: remove the plugin from Claude Code via the native plugin
@@ -1078,7 +1078,7 @@ def cmd_install(args: argparse.Namespace) -> int:
 
     Runs ``claude plugin marketplace add`` (pointed at the bundled marketplace
     at ``_REPO_ROOT``) followed by ``claude plugin install``, then appends the
-    local-provider flags to ``~/.reflexio/.env`` so reflexio can route
+    local-provider flags to ``~/.claude-smart/.env`` so reflexio can route
     generation through the local Claude Code CLI.
 
     Args:

--- a/plugin/src/claude_smart/env_config.py
+++ b/plugin/src/claude_smart/env_config.py
@@ -1,11 +1,19 @@
-"""Shared ``~/.reflexio/.env`` helpers for claude-smart."""
+"""Shared ``~/.claude-smart/.env`` helpers for claude-smart.
+
+claude-smart keeps its env under ``~/.claude-smart`` (not ``~/.reflexio``) so an
+OSS reflexio backend sharing this machine never leaks its ``.env`` into
+claude-smart. The data directory stays shared at ``~/.reflexio/data``. This path
+must stay in sync with the ``REFLEXIO_ENV_FILE`` export in
+``scripts/backend-service.sh`` and the source path in
+``scripts/_lib.sh`` (``claude_smart_source_reflexio_env``).
+"""
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
 
-REFLEXIO_ENV_PATH = Path.home() / ".reflexio" / ".env"
+REFLEXIO_ENV_PATH = Path.home() / ".claude-smart" / ".env"
 MANAGED_REFLEXIO_URL = "https://www.reflexio.ai/"
 REFLEXIO_URL_ENV = "REFLEXIO_URL"
 REFLEXIO_API_KEY_ENV = "REFLEXIO_API_KEY"
@@ -60,7 +68,7 @@ def parse_env_line(line: str) -> tuple[str, str] | None:
 
 
 def load_reflexio_env(path: Path | None = None) -> None:
-    """Load ``~/.reflexio/.env`` into ``os.environ`` without overriding values."""
+    """Load ``~/.claude-smart/.env`` into ``os.environ`` without overriding values."""
     path = path or REFLEXIO_ENV_PATH
     try:
         text = path.read_text()
@@ -111,7 +119,7 @@ def set_env_vars(path: Path, values: dict[str, str]) -> list[str]:
 
 
 def ensure_local_env_defaults(path: Path | None = None) -> list[str]:
-    """Create or augment ``~/.reflexio/.env`` for claude-smart local mode.
+    """Create or augment ``~/.claude-smart/.env`` for claude-smart local mode.
 
     Existing active assignments win. This repairs first installs and deleted
     env files without clobbering explicit user overrides such as

--- a/plugin/src/claude_smart/ids.py
+++ b/plugin/src/claude_smart/ids.py
@@ -77,7 +77,7 @@ def resolve_user_id(cwd: str | os.PathLike[str] | None = None) -> str:
     Honors the ``REFLEXIO_USER_ID`` env var as an explicit override (e.g. so a
     user can point multiple projects at a single Reflexio identity), and
     otherwise falls back to :func:`resolve_project_id`. The env var is
-    loaded from ``~/.reflexio/.env`` before reading the process environment so
+    loaded from ``~/.claude-smart/.env`` before reading the process environment so
     CLI commands and hooks use the same identity resolution.
 
     Args:

--- a/reflexio.lock.json
+++ b/reflexio.lock.json
@@ -1,9 +1,10 @@
 {
   "package": "reflexio-ai",
   "repo": "https://github.com/ReflexioAI/reflexio.git",
-  "version": "0.2.25",
-  "commit": "1aedbc6c080442c140dd35005ccf5a736de938c7",
+  "version": "0.2.26",
+  "commit": "5e854375dfbf51f0db5652e71c4d2f264297a07b",
   "dependency": "reflexio-ai>=0.2.25",
-  "source": "pypi",
-  "updated_at": "2026-06-10T18:07:10Z"
+  "source": "vendor",
+  "vendor_path": "plugin/vendor/reflexio",
+  "updated_at": "2026-06-27T18:02:46Z"
 }

--- a/tests/test_cli_clear_all.py
+++ b/tests/test_cli_clear_all.py
@@ -21,7 +21,7 @@ def clear_all_harness(monkeypatch, tmp_path):
     """Isolate clear-all paths and service calls from the real user machine."""
     reflexio_dir = tmp_path / "reflexio"
     env_path = reflexio_dir / ".env"
-    config_path = reflexio_dir / "configs" / "config_self-host-org.json"
+    config_path = reflexio_dir / "configs" / "config_claude-smart.json"
     plugin_root = tmp_path / "plugin"
     backend_script = plugin_root / "scripts" / "backend-service.sh"
     backend_script.parent.mkdir(parents=True)

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -468,7 +468,7 @@ def test_smart_install_repairs_local_env_defaults() -> None:
 def test_reflexio_env_file_overrides_stale_managed_process_env(
     tmp_path: Path,
 ) -> None:
-    env_path = tmp_path / ".reflexio" / ".env"
+    env_path = tmp_path / ".claude-smart" / ".env"
     env_path.parent.mkdir()
     env_path.write_text(
         'REFLEXIO_URL="https://www.reflexio.ai/"\nREFLEXIO_API_KEY="rflx-file-secret"\n'
@@ -499,7 +499,7 @@ def test_reflexio_env_file_overrides_stale_managed_process_env(
 
 
 def test_reflexio_env_loader_exports_read_only_flag(tmp_path: Path) -> None:
-    env_path = tmp_path / ".reflexio" / ".env"
+    env_path = tmp_path / ".claude-smart" / ".env"
     env_path.parent.mkdir()
     env_path.write_text('CLAUDE_SMART_READ_ONLY="1"\n')
 
@@ -1606,7 +1606,7 @@ def test_smart_install_repairs_reflexio_template_env_drift(tmp_path: Path) -> No
     assert first.returncode == 0, first.stderr
     assert (tmp_path / ".claude-smart" / "install-complete").exists()
 
-    reflexio_env = tmp_path / ".reflexio" / ".env"
+    reflexio_env = tmp_path / ".claude-smart" / ".env"
     reflexio_env.write_text(
         "# Reflexio template-style env without claude-smart local defaults\n"
         "OPENAI_API_KEY=\n"


### PR DESCRIPTION
## Summary

Runs claude-smart's local backend under its own org **and** its own env file so it never collides with an OSS reflexio or enterprise backend sharing the same machine. The data directory stays shared at `~/.reflexio/data`.

- **Own org** — `backend-service.sh` exports `REFLEXIO_DEFAULT_ORG_ID=claude-smart`, so reflexio uses `config_claude-smart.json` instead of fighting the enterprise self-host backend over `config_self-host-org.json`. `cli.py` reads/writes the matching config path.
- **Own env file** — exports `REFLEXIO_ENV_FILE=$HOME/.claude-smart/.env`, so the backend loads `~/.claude-smart/.env` instead of the shared `~/.reflexio/.env`. This prevents an OSS/enterprise `~/.reflexio/.env` (e.g. `REFLEXIO_STORAGE=supabase`) from leaking in and crashing startup. `env_config`, `_lib.sh`, `smart-install.sh`, and `ensure-plugin-root.sh` all point at the new path.
- **Re-vendor** — `reflexio.lock.json` → `5e85437` (reflexio PR with the `REFLEXIO_ENV_FILE` override + a SQLite `migrate()` ordering fix).

## Changes

- `plugin/scripts/backend-service.sh` — export `REFLEXIO_DEFAULT_ORG_ID` and `REFLEXIO_ENV_FILE`.
- `plugin/src/claude_smart/cli.py` — `_REFLEXIO_ORG_ID="claude-smart"` → `config_claude-smart.json`.
- `plugin/src/claude_smart/env_config.py` — `REFLEXIO_ENV_PATH` → `~/.claude-smart/.env`.
- `plugin/scripts/{_lib.sh,smart-install.sh,ensure-plugin-root.sh}` — read/seed `~/.claude-smart/.env` (installer creates the dir).
- `tests/test_install_scripts.py`, `tests/test_cli_clear_all.py` — fixtures updated for the new paths.
- `reflexio.lock.json` — re-vendored reflexio snapshot.

## Test Plan

- Full plugin test suite passes (incl. updated install-script + clear-all tests).
- Manual: reinstall + restart → backend logs `SQLite Storage for org claude-smart`, loads env from `~/.claude-smart/.env`, learned data carries over (shared `reflexio.db`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Smart now uses its own configuration and environment files, keeping setup isolated from the shared Reflexio defaults.
  * Backend startup and install flows now consistently target the Claude Smart environment.

* **Bug Fixes**
  * Fixed environment loading so local settings are read from the correct Claude Smart location.
  * Improved handling of the “follow session” setting when it is defined in the environment file.

* **Documentation**
  * Updated setup and CLI documentation to reflect the new Claude Smart file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->