### PR TITLE
feat: add claude-smart reranker toggle

### DIFF
--- a/plugin/dashboard/app/configure/server/page.tsx
+++ b/plugin/dashboard/app/configure/server/page.tsx
@@ -6,11 +6,29 @@ import { PageHeader } from "@/components/common/page-header";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { ReflexioConfig } from "@/lib/types";
+import { Switch } from "@/components/ui/switch";
+import type { ReflexioConfig, ReflexioRetrievalFloorConfig } from "@/lib/types";
 
 type ExtractorField =
   | "profile_extractor_configs"
   | "user_playbook_extractor_configs";
+
+const DEFAULT_RETRIEVAL_FLOOR: Required<
+  Pick<
+    ReflexioRetrievalFloorConfig,
+    | "enabled"
+    | "pool_size"
+    | "profile_floor"
+    | "user_playbook_floor"
+    | "agent_playbook_floor"
+  >
+> = {
+  enabled: false,
+  pool_size: 30,
+  profile_floor: -3,
+  user_playbook_floor: -3,
+  agent_playbook_floor: -3,
+};
 
 export default function ConfigureServerPage() {
   const [srvConfig, setSrvConfig] = useState<ReflexioConfig | null>(null);
@@ -70,6 +88,22 @@ export default function ConfigureServerPage() {
       next[0] = { ...next[0], extraction_definition_prompt: v };
       return { ...prev, [field]: next };
     });
+    setSrvSaved(false);
+  };
+
+  const updateReranker = (enabled: boolean) => {
+    setSrvConfig((prev) =>
+      prev
+        ? {
+            ...prev,
+            retrieval_floor: {
+              ...DEFAULT_RETRIEVAL_FLOOR,
+              ...(prev.retrieval_floor ?? {}),
+              enabled,
+            },
+          }
+        : prev,
+    );
     setSrvSaved(false);
   };
 
@@ -188,6 +222,22 @@ export default function ConfigureServerPage() {
                 }}
                 className="font-mono text-xs bg-background/80"
                 placeholder="5"
+              />
+            </div>
+
+            <div className="flex items-start justify-between gap-4 rounded-md border border-border bg-background/60 p-3">
+              <div className="min-w-0">
+                <Label htmlFor="search-reranker">Search reranker</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Use the local cross-encoder relevance floor for injected
+                  memory search. The first enabled search loads the model into
+                  the backend process.
+                </p>
+              </div>
+              <Switch
+                id="search-reranker"
+                checked={!!srvConfig.retrieval_floor?.enabled}
+                onCheckedChange={updateReranker}
               />
             </div>
 

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -140,10 +140,20 @@ export interface ReflexioExtractorConfig {
   [k: string]: unknown;
 }
 
+export interface ReflexioRetrievalFloorConfig {
+  enabled?: boolean;
+  pool_size?: number;
+  profile_floor?: number;
+  user_playbook_floor?: number;
+  agent_playbook_floor?: number;
+  [k: string]: unknown;
+}
+
 export interface ReflexioConfig {
   agent_context_prompt?: string | null;
   window_size?: number;
   stride_size?: number;
+  retrieval_floor?: ReflexioRetrievalFloorConfig | null;
   profile_extractor_configs?: ReflexioExtractorConfig[] | null;
   user_playbook_extractor_configs?: ReflexioExtractorConfig[] | null;
   [k: string]: unknown;


### PR DESCRIPTION
## Summary
- Add a Reflexio server setting in the claude-smart dashboard for enabling the search reranker.
- Preserve the existing backend config shape by writing the retrieval floor defaults when the switch is first toggled.

## Changes
- Add a `Search reranker` switch to Configure → Reflexio server.
- Add dashboard TypeScript types for `retrieval_floor`.

## Test Plan
- `npm run lint`
- `npm run build`
- Browser smoke: opened `/configure/server` locally and verified the switch renders and toggles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Search reranker” toggle in server configuration.
  * Configuration now supports reranker-related settings with sensible defaults while preserving existing custom values.

* **Bug Fixes**
  * Improved saving behavior for reranker settings so changes are reflected correctly in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->