### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/plugin/src/README.md
+++ b/plugin/src/README.md
@@ -1,5 +1,5 @@
 # claude_smart (plugin/src)
-Description: Python package powering the claude-smart plugin — hook handlers that buffer Claude Code / Codex session activity, publish it to a local Reflexio backend, and inject the learned skills/preferences back into future sessions.
+Description: Python package powering the claude-smart plugin — hook handlers and CLI flows that buffer Claude Code / Codex / OpenCode session activity, publish it to a local Reflexio backend, and inject learned skills/preferences back into future sessions.
 
 > User-facing install/usage docs live in [`../README.md`](../README.md). This is the code map for the `claude_smart` package.
 
@@ -8,7 +8,7 @@ Description: Python package powering the claude-smart plugin — hook handlers t
 | File | Purpose |
 |------|---------|
 | `hook.py` | Hook dispatcher. Parses the stdin JSON payload and routes each event (Setup, SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd) to its handler in `events/`. |
-| `cli.py` | `claude-smart` CLI: `install`, `uninstall`, `show`, `learn`, `restart`, `dashboard`, `clear-all`. |
+| `cli.py` | `claude-smart` CLI: `install`, `uninstall`, `show`, `learn`, `restart`, `dashboard`, `clear-all`; installs host-specific Claude Code, Codex, or OpenCode integration files. |
 | `state.py` | Per-session JSONL buffer at `~/.claude-smart/sessions/{session_id}.jsonl`; high-water mark for idempotent publish retries. |
 | `publish.py` | Drains the session buffer, calls the Reflexio adapter, and stamps the watermark. Used by Stop, SessionEnd, and `learn`. |
 | `reflexio_adapter.py` | Thin wrapper over `reflexio.ReflexioClient` — isolates import failures, 5s HTTP timeout, injects/queries learnings, degrades gracefully when the backend is down. |
@@ -29,9 +29,9 @@ Description: Python package powering the claude-smart plugin — hook handlers t
 | File | Purpose |
 |------|---------|
 | `env_config.py` | Parses `~/.claude-smart/.env` (`REFLEXIO_URL`, `REFLEXIO_API_KEY`, `CLAUDE_SMART_READ_ONLY`, local embedding/CLI flags). |
-| `runtime.py` | Host detection (Claude Code vs Codex); shared agent version. |
+| `runtime.py` | Host detection (Claude Code, Codex, OpenCode); shared agent version. |
 | `ids.py` | Session / project ID generation and resolution. |
-| `context_inject.py`, `context_format.py`, `query_compose.py`, `cs_cite.py` | Build search queries, format learned skills as markdown, inject into context, format citations. |
+| `context_inject.py`, `context_format.py`, `query_compose.py`, `cs_cite.py` | Build search queries, format learned skills as markdown, inject into host context, format citations. |
 | `stall_banner.py` | User-facing message when the Reflexio provider hits an auth/billing stall. |
 | `optimizer_assistant.py` | Claude-code CLI agent that extracts Reflexio optimization hints. |
 | `hook_log.py`, `internal_call.py` | Structured JSON logging to `~/.claude-smart/hook.log`; detect internal/test invocations to skip learning. |
@@ -39,19 +39,20 @@ Description: Python package powering the claude-smart plugin — hook handlers t
 ## Architecture
 
 ```
-SessionStart -> bootstrap Reflexio backend (8071) + Next.js dashboard (3001)
-PostToolUse  -> state.py buffers each tool call to ~/.claude-smart/sessions/{id}.jsonl
-Stop/SessionEnd -> publish.py -> reflexio_adapter -> Reflexio extracts playbooks + preferences
-UserPromptSubmit / PreToolUse -> context_inject pulls relevant learnings back into context
+Claude Code/Codex hooks -> hook.py -> events/* -> state.py buffer
+OpenCode plugin -> ../opencode/* -> claude_smart CLI/publish paths
+Stop/SessionEnd/learn -> publish.py -> reflexio_adapter -> Reflexio extracts playbooks + preferences
+UserPromptSubmit / PreToolUse / OpenCode request path -> context_inject pulls relevant learnings back into context
 ```
 
-- **Dual-host** — the same package runs under Claude Code (native slash commands) and Codex (shell-script fallbacks in `../scripts/`); host shape is normalized in `runtime.py`.
+- **Multi-host** — the same package runs under Claude Code (native slash commands), Codex (shell-script fallbacks in `../scripts/`), and OpenCode (npm plugin bridge in `../opencode/`); host shape is normalized in `runtime.py`.
 - **Offline-resilient** — if Reflexio is unreachable, interactions stay buffered and drain on the next successful publish.
-- **Hooks registered** in `../hooks/hooks.json` (Claude Code) and `../hooks/codex-hooks.json` (Codex), dispatched through `../scripts/hook_entry.sh`.
+- **Hooks/bridges registered** in `../hooks/hooks.json` (Claude Code), `../hooks/codex-hooks.json` (Codex), and OpenCode config (`opencode.json` / `~/.config/opencode/opencode.json`) pointing at `../opencode/dist/server.mjs`; Claude/Codex events dispatch through `../scripts/hook_entry.sh`.
 
 ## Requirements / Problems to Avoid
 
 - **All learned state is external to the repo** — sessions buffer under `~/.claude-smart/`, Reflexio state under `~/.reflexio/`. Don't write generated runtime artifacts inside the plugin root.
 - **Backend lives at `http://localhost:8071`**, dashboard at `http://localhost:3001`; both are long-lived across sessions (no hard shutdown on SessionEnd by default).
-- **`CLAUDE_SMART_READ_ONLY`** skips publishing entirely — respect it in any new publish path.
+- **`CLAUDE_SMART_READ_ONLY`** skips publishing entirely — respect it in any new publish path, including host bridges.
+- **OpenCode extraction runs isolated** — `CLAUDE_SMART_OPENCODE_MODEL` can override the model used by internal `opencode run --pure` extraction; do not assume a project config is loaded for that subprocess.
 - **Keep handlers fast** — tool-use hooks run on a 10–15s timeout; heavy work belongs in the backend, not the hook.


### PR DESCRIPTION
## Summary
- Syncs the `claude_smart` package code map with the latest multi-host architecture.
- Documents OpenCode support alongside Claude Code and Codex paths, including the npm plugin bridge and isolated OpenCode extraction model override.

## Repositories/submodules reviewed
- Parent repository: `ReflexioAI/reflexio-enterprise`
- Submodule updated in this PR: `ReflexioAI/claude-smart` (`open_source/claude-smart`)
- Also reviewed: `ReflexioAI/reflexio` submodule (separate PR when applicable)

## README files updated
- `plugin/src/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/claude-smart plugin/src/README.md`

## Notes/Risks
- Updates follow `/root/reflexio-enterprise/how_to_write_readme.md` and are scoped to a model-facing code-map README.
- User-facing root README content was left intact; it had already been updated upstream for OpenCode usage.
- Parent submodule pointers should not be committed for this docs-only submodule PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture and module overview to better reflect current CLI flows, hook handling, buffering, and host integration behavior.
  * Expanded the component list with additional runtime, session, context formatting, logging, and stall-notification details.
  * Revised the flow diagram and guidance to clarify routing, context injection, and key operational constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->