### PR TITLE
fix: load profile details by exact id

### DIFF
--- a/plugin/dashboard/app/preferences/[id]/page.tsx
+++ b/plugin/dashboard/app/preferences/[id]/page.tsx
@@ -53,12 +53,9 @@ export default function PreferenceDetailPage({
   useEffect(() => {
     let cancelled = false;
     reflexio
-      .getAllProfiles({ limit: 500 })
-      .then((res) => {
+      .getProfileById(id, { includeTombstones: true })
+      .then((found) => {
         if (cancelled) return;
-        const found = (res.user_profiles ?? []).find(
-          (p) => p.profile_id === id,
-        );
         if (!found) {
           setNotFound(true);
           return;
@@ -397,12 +394,12 @@ function Prose({ text }: { text: string }) {
 function StatusBadge({
   status,
 }: {
-  status: "CURRENT" | "ARCHIVED" | "PENDING";
+  status: "CURRENT" | "ARCHIVED" | "PENDING" | "MERGED" | "SUPERSEDED";
 }) {
   const variant =
     status === "CURRENT"
       ? "secondary"
-      : status === "ARCHIVED"
+      : status === "ARCHIVED" || status === "MERGED" || status === "SUPERSEDED"
         ? "outline"
         : "default";
   return (
@@ -412,7 +409,10 @@ function StatusBadge({
           "h-1.5 w-1.5 rounded-full",
           status === "CURRENT" && "bg-emerald-500",
           status === "PENDING" && "bg-amber-500",
-          status === "ARCHIVED" && "bg-muted-foreground",
+          (status === "ARCHIVED" ||
+            status === "MERGED" ||
+            status === "SUPERSEDED") &&
+            "bg-muted-foreground",
         )}
       />
       {status}

--- a/plugin/dashboard/app/skills/project/[id]/page.tsx
+++ b/plugin/dashboard/app/skills/project/[id]/page.tsx
@@ -28,6 +28,7 @@ import { reflexio } from "@/lib/reflexio-client";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { statusLabel } from "@/lib/status";
+import type { StatusLabel } from "@/lib/status";
 import type { UserPlaybook } from "@/lib/types";
 
 type FormState = { content: string; trigger: string; rationale: string };
@@ -464,12 +465,12 @@ function AutoTextarea({
 function StatusBadge({
   status,
 }: {
-  status: "CURRENT" | "ARCHIVED" | "PENDING";
+  status: StatusLabel;
 }) {
   const variant =
     status === "CURRENT"
       ? "secondary"
-      : status === "ARCHIVED"
+      : status === "ARCHIVED" || status === "MERGED" || status === "SUPERSEDED"
         ? "outline"
         : "default";
   return (
@@ -479,7 +480,10 @@ function StatusBadge({
           "h-1.5 w-1.5 rounded-full",
           status === "CURRENT" && "bg-emerald-500",
           status === "PENDING" && "bg-amber-500",
-          status === "ARCHIVED" && "bg-muted-foreground",
+          (status === "ARCHIVED" ||
+            status === "MERGED" ||
+            status === "SUPERSEDED") &&
+            "bg-muted-foreground",
         )}
       />
       {status}

--- a/plugin/dashboard/app/skills/shared/[id]/page.tsx
+++ b/plugin/dashboard/app/skills/shared/[id]/page.tsx
@@ -35,6 +35,7 @@ import { reflexio } from "@/lib/reflexio-client";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { agentPlaybookStatusLabel, statusLabel } from "@/lib/status";
+import type { StatusLabel } from "@/lib/status";
 import type { AgentPlaybook, AgentPlaybookStatus } from "@/lib/types";
 
 type FormState = {
@@ -571,12 +572,15 @@ function AutoTextarea({
 function StatusBadge({
   status,
 }: {
-  status: "CURRENT" | "ARCHIVED" | "PENDING" | "APPROVED" | "REJECTED";
+  status: StatusLabel | "APPROVED" | "REJECTED";
 }) {
   const variant =
     status === "CURRENT" || status === "APPROVED"
       ? "secondary"
-      : status === "ARCHIVED" || status === "REJECTED"
+      : status === "ARCHIVED" ||
+          status === "MERGED" ||
+          status === "SUPERSEDED" ||
+          status === "REJECTED"
         ? "outline"
         : "default";
   return (
@@ -588,7 +592,10 @@ function StatusBadge({
           status === "APPROVED" && "bg-emerald-500",
           status === "PENDING" && "bg-amber-500",
           status === "REJECTED" && "bg-destructive",
-          status === "ARCHIVED" && "bg-muted-foreground",
+          (status === "ARCHIVED" ||
+            status === "MERGED" ||
+            status === "SUPERSEDED") &&
+            "bg-muted-foreground",
         )}
       />
       {status}

--- a/plugin/dashboard/lib/reflexio-client.ts
+++ b/plugin/dashboard/lib/reflexio-client.ts
@@ -93,6 +93,22 @@ export const reflexio = {
     return get(`get_all_profiles?${qs.toString()}`);
   },
 
+  async getProfileById(
+    profileId: string,
+    opts: { includeTombstones?: boolean } = {},
+  ): Promise<UserProfile | null> {
+    const qs = new URLSearchParams();
+    qs.set("profile_id", profileId);
+    if (opts.includeTombstones) qs.set("include_tombstones", "true");
+    const res = await get<{ user_profiles: UserProfile[] }>(
+      `get_all_profiles?${qs.toString()}`,
+    );
+    return (
+      res.user_profiles?.find((profile) => profile.profile_id === profileId) ??
+      null
+    );
+  },
+
   /** GET /api/get_all_interactions — global, unfiltered. */
   async getAllInteractions(
     opts: { limit?: number } = {},

--- a/plugin/dashboard/lib/status.ts
+++ b/plugin/dashboard/lib/status.ts
@@ -1,9 +1,14 @@
-// Wire status comes from Python's Status StrEnum: lowercase strings
-// ("archived", "pending"). CURRENT rows are omitted from JSON entirely
+// Wire status comes from Python's Status enum: lowercase strings
+// ("archived", "pending", "merged", "superseded"). CURRENT rows are omitted from JSON entirely
 // (response_model_exclude_none) and arrive as `null`/undefined.
 // Normalize to the uppercase label the dashboard renders.
 
-export type StatusLabel = "CURRENT" | "ARCHIVED" | "PENDING";
+export type StatusLabel =
+  | "CURRENT"
+  | "ARCHIVED"
+  | "PENDING"
+  | "MERGED"
+  | "SUPERSEDED";
 export type AgentPlaybookStatusLabel = "PENDING" | "APPROVED" | "REJECTED";
 
 export function statusLabel(p: { status?: string | null }): StatusLabel {
@@ -11,6 +16,8 @@ export function statusLabel(p: { status?: string | null }): StatusLabel {
   const s = String(p.status).toLowerCase();
   if (s === "archived") return "ARCHIVED";
   if (s === "pending") return "PENDING";
+  if (s === "merged") return "MERGED";
+  if (s === "superseded") return "SUPERSEDED";
   return "CURRENT";
 }
 

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -9,11 +9,11 @@ export type UserActionType =
 // (response_model_exclude_none strips it from the JSON entirely), so the type
 // only enumerates the non-null values. The values are lowercase because they
 // come from Python's Status StrEnum.
-export type LifecycleStatus = "pending" | "archived";
+export type LifecycleStatus = "pending" | "archived" | "merged" | "superseded";
 
 export type AgentPlaybookStatus = "pending" | "approved" | "rejected";
 
-export type ProfileStatus = "pending" | "archived";
+export type ProfileStatus = "pending" | "archived" | "merged" | "superseded";
 
 export interface ToolUsed {
   tool_name: string;


### PR DESCRIPTION
## Summary
- Load preference detail pages by exact profile id instead of fetching a capped list and filtering locally.
- Preserve access to merged/superseded profile rows for detail views while guarding against older backends that ignore the exact lookup query.
- Teach dashboard status types and badges about merged and superseded lifecycle states.

## Changes
- Dashboard client: add `getProfileById` using `profile_id` and `include_tombstones`, and verify the returned id before using it.
- Preferences: switch detail loading to the exact-id helper.
- Skills/preferences UI: extend lifecycle status types and badge rendering for merged/superseded states.

## Test Plan
- `npx tsc --noEmit`
- `npx eslint app/preferences/[id]/page.tsx app/skills/project/[id]/page.tsx app/skills/shared/[id]/page.tsx lib/reflexio-client.ts lib/status.ts lib/types.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional status values across the dashboard, including merged and superseded items.
  * Improved detail pages to load a single record directly and show a not-found state when nothing matches.

* **Bug Fixes**
  * Status badges now display the correct styling and indicator colors for more status types.
  * Status labels are now recognized consistently across related views and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->