### PR TITLE
fix: write OpenCode bridge config under dot directory

### DIFF
--- a/plugin/scripts/opencode-claude-compat.js
+++ b/plugin/scripts/opencode-claude-compat.js
@@ -104,7 +104,9 @@ function prepareWorkDir() {
       },
     },
   };
-  fs.writeFileSync(path.join(dir, "opencode.json"), `${JSON.stringify(config, null, 2)}\n`);
+  const opencodeDir = path.join(dir, ".opencode");
+  fs.mkdirSync(opencodeDir, { recursive: true });
+  fs.writeFileSync(path.join(opencodeDir, "opencode.json"), `${JSON.stringify(config, null, 2)}\n`);
   return dir;
 }
 

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -679,65 +679,6 @@ def test_opencode_cli_bridge_pipes_large_prompt_via_stdin(tmp_path: Path) -> Non
     assert call["stdinLength"] == len(prompt)
 
 
-def test_opencode_cli_bridge_surfaces_opencode_stderr_and_cleans_workdir(
-    tmp_path: Path,
-) -> None:
-    if shutil_which_node() is None:
-        return
-    bridge = REPO_ROOT / "plugin" / "scripts" / "opencode-claude-compat.js"
-    fake_opencode = tmp_path / "opencode"
-    call_log = tmp_path / "calls.json"
-    fake_opencode.write_text(
-        textwrap.dedent(
-            f"""\
-            #!/usr/bin/env node
-            const fs = require("fs");
-            const args = process.argv.slice(2);
-            const dirIndex = args.indexOf("--dir");
-            const workDir = dirIndex >= 0 ? args[dirIndex + 1] : "";
-            fs.writeFileSync(
-              {json.dumps(str(call_log))},
-              JSON.stringify({{
-                args,
-                workDir
-              }})
-            );
-            process.stderr.write("model catalog does not include fake/model\\n");
-            process.exit(42);
-            """
-        )
-    )
-    fake_opencode.chmod(0o755)
-    env = {
-        **os.environ,
-        "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
-    }
-
-    result = subprocess.run(
-        [
-            shutil_which_node() or "node",
-            str(bridge),
-            "-p",
-            "--output-format",
-            "stream-json",
-        ],
-        input="user prompt",
-        text=True,
-        capture_output=True,
-        env=env,
-        check=False,
-    )
-
-    assert result.returncode == 1
-    assert result.stdout == ""
-    assert (
-        "opencode CLI exited 42: model catalog does not include fake/model"
-        in result.stderr
-    )
-    call = json.loads(call_log.read_text())
-    assert Path(call["workDir"]).exists() is False
-
-
 def test_node_installer_accepts_opencode_only_extraction_provider(tmp_path: Path) -> None:
     if shutil_which_node() is None:
         return

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -548,15 +548,24 @@ def test_opencode_cli_bridge_translates_claude_contract(tmp_path: Path) -> None:
     fake_opencode.write_text(
         f"""#!/usr/bin/env node
 const fs = require("fs");
+const path = require("path");
+const args = process.argv.slice(2);
+const dirIndex = args.indexOf("--dir");
+const workDir = dirIndex >= 0 ? args[dirIndex + 1] : "";
+const dotConfig = path.join(workDir, ".opencode", "opencode.json");
+const rootConfig = path.join(workDir, "opencode.json");
 fs.writeFileSync(
   {json.dumps(str(call_log))},
   JSON.stringify({{
-    args: process.argv.slice(2),
+    args,
     cwd: process.cwd(),
+    dotConfigExists: fs.existsSync(dotConfig),
+    rootConfigExists: fs.existsSync(rootConfig),
     stdin: fs.readFileSync(0, "utf8"),
     env: {{
       CLAUDE_SMART_HOST: process.env.CLAUDE_SMART_HOST,
-      CLAUDE_SMART_INTERNAL: process.env.CLAUDE_SMART_INTERNAL
+      CLAUDE_SMART_INTERNAL: process.env.CLAUDE_SMART_INTERNAL,
+      CLAUDE_CODE_ENTRYPOINT: process.env.CLAUDE_CODE_ENTRYPOINT
     }}
   }})
 );
@@ -603,10 +612,13 @@ process.stdout.write(JSON.stringify({{
     assert call["env"] == {
         "CLAUDE_SMART_HOST": "opencode",
         "CLAUDE_SMART_INTERNAL": "1",
+        "CLAUDE_CODE_ENTRYPOINT": "optimizer",
     }
     assert call["args"][:4] == ["run", "--pure", "--format", "json"]
     assert "--agent" in call["args"]
     assert "--dir" in call["args"]
+    assert call["dotConfigExists"] is True
+    assert call["rootConfigExists"] is False
     assert "--model" not in call["args"]
     assert "system text\n\n## Task\nuser prompt" not in call["args"]
     assert call["stdin"] == "system text\n\n## Task\nuser prompt"

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -564,8 +564,7 @@ fs.writeFileSync(
     stdin: fs.readFileSync(0, "utf8"),
     env: {{
       CLAUDE_SMART_HOST: process.env.CLAUDE_SMART_HOST,
-      CLAUDE_SMART_INTERNAL: process.env.CLAUDE_SMART_INTERNAL,
-      CLAUDE_CODE_ENTRYPOINT: process.env.CLAUDE_CODE_ENTRYPOINT
+      CLAUDE_SMART_INTERNAL: process.env.CLAUDE_SMART_INTERNAL
     }}
   }})
 );
@@ -612,7 +611,6 @@ process.stdout.write(JSON.stringify({{
     assert call["env"] == {
         "CLAUDE_SMART_HOST": "opencode",
         "CLAUDE_SMART_INTERNAL": "1",
-        "CLAUDE_CODE_ENTRYPOINT": "optimizer",
     }
     assert call["args"][:4] == ["run", "--pure", "--format", "json"]
     assert "--agent" in call["args"]

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -679,6 +679,65 @@ def test_opencode_cli_bridge_pipes_large_prompt_via_stdin(tmp_path: Path) -> Non
     assert call["stdinLength"] == len(prompt)
 
 
+def test_opencode_cli_bridge_surfaces_opencode_stderr_and_cleans_workdir(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        return
+    bridge = REPO_ROOT / "plugin" / "scripts" / "opencode-claude-compat.js"
+    fake_opencode = tmp_path / "opencode"
+    call_log = tmp_path / "calls.json"
+    fake_opencode.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env node
+            const fs = require("fs");
+            const args = process.argv.slice(2);
+            const dirIndex = args.indexOf("--dir");
+            const workDir = dirIndex >= 0 ? args[dirIndex + 1] : "";
+            fs.writeFileSync(
+              {json.dumps(str(call_log))},
+              JSON.stringify({{
+                args,
+                workDir
+              }})
+            );
+            process.stderr.write("model catalog does not include fake/model\\n");
+            process.exit(42);
+            """
+        )
+    )
+    fake_opencode.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
+    }
+
+    result = subprocess.run(
+        [
+            shutil_which_node() or "node",
+            str(bridge),
+            "-p",
+            "--output-format",
+            "stream-json",
+        ],
+        input="user prompt",
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert (
+        "opencode CLI exited 42: model catalog does not include fake/model"
+        in result.stderr
+    )
+    call = json.loads(call_log.read_text())
+    assert Path(call["workDir"]).exists() is False
+
+
 def test_node_installer_accepts_opencode_only_extraction_provider(tmp_path: Path) -> None:
     if shutil_which_node() is None:
         return


### PR DESCRIPTION
## Summary
- Fix the OpenCode Claude-compat bridge to write its temporary agent config where OpenCode 1.17+ discovers project agents.
- Add focused regression coverage proving the bridge creates `.opencode/opencode.json` and no longer relies on the ignored root `opencode.json` path.
- Keep broader hardening out of this PR: no locale-sensitive greeting string guard, no per-host extraction routing redesign, and no failure-path cleanup expansion.

## Concrete path example
- Bridge workdir example: `/var/folders/.../T/claude-smart-opencode-A1b2C3/`
- Previous wrong path: `/var/folders/.../T/claude-smart-opencode-A1b2C3/opencode.json`
- Fixed path OpenCode reads: `/var/folders/.../T/claude-smart-opencode-A1b2C3/.opencode/opencode.json`
- Unrelated global OpenCode config: `~/.config/opencode/opencode.json`

## Changes
- `plugin/scripts/opencode-claude-compat.js`
  - Creates the temporary `.opencode` directory.
  - Writes the generated `opencode.json` under that directory before invoking `opencode run --agent claude-smart-extractor`.
- `tests/test_opencode_support.py`
  - Extends the existing bridge contract test to inspect the temporary `--dir` while fake OpenCode is running.
  - Asserts `.opencode/opencode.json` exists and root-level `opencode.json` does not.

## Test Plan
- `uv --project plugin run pytest tests/test_opencode_support.py::test_opencode_cli_bridge_translates_claude_contract -q`
- `node --check plugin/scripts/opencode-claude-compat.js`
- `npm run build:opencode`
- `uvx ruff check tests/test_opencode_support.py`
- `PYTHONPATH=plugin/src uvx pyright tests/test_opencode_support.py`
- `uv --project plugin run pytest tests -q` (`546 passed`)
- `PYTHON=plugin/.venv/bin/python REFLEXIO_PATH=/tmp/reflexio-lock-5e854-claude-smart-pr bash scripts/release-with-reflexio.sh` (`546 passed`, vendored Reflexio tarball check passed)
- `PATH="$PWD/plugin/.venv/bin:$PATH" make package`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode compatibility by ensuring the app loads the intended agent configuration reliably in temporary work directories.
  * Added a safeguard that flags cases where the fallback/default greeting appears instead of the expected agent response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->