### PR TITLE
docs: surface OpenCode support in plugin metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Yi Lu"
   },
   "metadata": {
-    "description": "claude-smart — self-improving Claude Code and Codex plugin powered by Reflexio"
+    "description": "claude-smart — self-improving Claude Code, Codex, and OpenCode plugin powered by Reflexio"
   },
   "plugins": [
     {
       "name": "claude-smart",
       "version": "0.2.45",
       "source": "./plugin",
-      "description": "Turns corrections into Preferences, Project-specific skills, and Shared skills — uses Claude Code or Codex as the LLM backend (no external API key required)"
+      "description": "Turns corrections into Preferences, Project-specific skills, and Shared skills — uses Claude Code, Codex, or OpenCode as the LLM backend (no external API key required)"
     }
   ]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.45",
-  "description": "Self-improving Claude Code and Codex plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
+  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
   "author": {
     "name": "Yi Lu"
   },
@@ -11,6 +11,8 @@
     "claude-code-plugin",
     "codex",
     "codex-plugin",
+    "opencode",
+    "opencode-plugin",
     "memory",
     "agent-memory",
     "plugin",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,8 +1,8 @@
 # claude-smart
 
-Self-improving [Claude Code](https://claude.com/claude-code) and Codex plugin — turns corrections and successful workflows into durable Preferences, Project-specific skills, and Shared skills that future sessions follow, via [reflexio](https://github.com/ReflexioAI/reflexio).
+Self-improving [Claude Code](https://claude.com/claude-code), Codex, and OpenCode plugin — turns corrections and successful workflows into durable Preferences, Project-specific skills, and Shared skills that future sessions follow, via [reflexio](https://github.com/ReflexioAI/reflexio).
 
-This directory is the published Python package (`claude-smart` on PyPI) and the Claude Code/Codex plugin payload shipped through the marketplace. For the project overview, install instructions, benchmarks, and feature walkthrough, see the [top-level README](https://github.com/ReflexioAI/claude-smart#readme).
+This directory is the published Python package (`claude-smart` on PyPI) and the Claude Code/Codex/OpenCode plugin payload shipped through the marketplace and npm. For the project overview, install instructions, benchmarks, and feature walkthrough, see the [top-level README](https://github.com/ReflexioAI/claude-smart#readme).
 
 ## Install
 
@@ -36,6 +36,17 @@ npx claude-smart install --host codex
 Then fully quit and reopen Codex so hooks reload. Codex installs reuse the same
 local Preferences, Project-specific skills, and Shared skills as Claude Code.
 
+### OpenCode
+
+```bash
+npx claude-smart install --host opencode
+```
+
+Then restart OpenCode in your project so it loads the plugin from `opencode.json`
+or your existing `.opencode/opencode.json*` config. OpenCode installs reuse the
+same local Preferences, Project-specific skills, and Shared skills as Claude Code
+and Codex.
+
 ## Uninstall
 
 ### Claude Code
@@ -58,6 +69,15 @@ npx claude-smart uninstall --host codex
 
 Restart Codex after uninstalling. Local data under `~/.reflexio/` and
 `~/.claude-smart/` is left in place for both hosts — remove manually if desired.
+
+### OpenCode
+
+```bash
+npx claude-smart uninstall --host opencode
+```
+
+Restart OpenCode after uninstalling. Local data under `~/.reflexio/` and
+`~/.claude-smart/` is preserved and shared across supported hosts.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Updates Claude plugin metadata and marketplace copy to mention OpenCode alongside Claude Code and Codex.
- Adds OpenCode install/uninstall snippets to the plugin package README.
- Keeps public terminology aligned with `DEVELOPER.md`: Preferences, Project-specific skills, and Shared skills.

## Test Plan / Validation
- `git diff --check`
- `python3 -m json.tool package.json >/dev/null`
- `python3 -m json.tool plugin/.claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`

## Marketing rationale
OpenCode support is now present in the top-level README and npm metadata on `main`, but plugin-specific metadata still described claude-smart as Claude Code + Codex only. This small docs/metadata update improves discoverability for OpenCode users without changing behavior or making new benchmark/security claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin and marketplace descriptions to include OpenCode alongside Claude Code and Codex.
  * Expanded the README with OpenCode install and uninstall instructions, including the relevant command and configuration steps.
  * Added OpenCode-related keywords and clarified the package description for broader host support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->