### PR TITLE
fix: make OpenCode first install reliable

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
           make check-standalone-lock
 
   pytest:
-    name: pytest host regressions
+    name: pytest suite
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -53,13 +53,8 @@ jobs:
       - name: Install test dependencies
         run: uv sync --project plugin --group dev --python 3.12 --locked
 
-      - name: Run host regression tests
-        run: >
-          uv --project plugin run pytest
-          tests/test_host_integration_e2e.py
-          tests/test_opencode_support.py
-          tests/test_reflexio_lock_script.py
-          -q
+      - name: Run pytest suite
+        run: uv --project plugin run pytest tests -q
 
   dependency-platforms:
     name: dependency platforms (${{ matrix.os }})

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,37 @@ jobs:
           make check-locked-project-version
           make check-standalone-lock
 
+  pytest:
+    name: pytest host regressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Install Node test dependencies
+        run: npm ci
+
+      - name: Install test dependencies
+        run: uv sync --project plugin --group dev --python 3.12 --locked
+
+      - name: Run host regression tests
+        run: >
+          uv --project plugin run pytest
+          tests/test_host_integration_e2e.py
+          tests/test_opencode_support.py
+          tests/test_reflexio_lock_script.py
+          -q
+
   dependency-platforms:
     name: dependency platforms (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lockfile:
+    name: standalone lockfile
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Check standalone plugin lock
+        run: |
+          make check-locked-project-version
+          make check-standalone-lock
+
   dependency-platforms:
     name: dependency platforms (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -390,11 +390,12 @@ Install the tarball globally and run the host installer:
 npm install -g /abs/path/claude-smart-<version>.tgz   # path or ./prefix, not a bare name
 claude-smart install                   # Claude Code
 claude-smart install --host codex      # Codex
+claude-smart install --host opencode   # OpenCode
 ```
 
 npm decides the source from the *shape* of the argument: a filesystem path (absolute, or relative with a `./` prefix) is installed as a local tarball, while a bare `claude-smart-<version>.tgz` is treated as a registry package name and fails. Always pass a path.
 
-Restart the host. `claude-smart install` (Claude Code) registers the bundled package root as a local marketplace and runs `claude plugin install claude-smart@reflexioai`; the Codex variant copies the bundled plugin into Codex's marketplace cache. Either way, your local plugin changes are what gets loaded.
+Restart the host. `claude-smart install` (Claude Code) registers the bundled package root as a local marketplace and runs `claude plugin install claude-smart@reflexioai`; the Codex variant copies the bundled plugin into Codex's marketplace cache; the OpenCode variant copies the active npm package to `~/.claude-smart/opencode/claude-smart` and registers that package with a `file://` plugin entry. In all three hosts, your local plugin changes are what gets loaded after rerunning the host installer.
 
 To iterate: edit plugin code, rerun `make package`, reinstall the tarball, rerun `claude-smart install`, restart the host.
 
@@ -413,6 +414,8 @@ Reinstalling the npm package only refreshes the `claude-smart` CLI wrapper — t
 ```bash
 claude plugin uninstall claude-smart@reflexioai   # Claude Code
 claude-smart install
+claude-smart install --host codex                  # Codex
+claude-smart install --host opencode               # OpenCode
 ```
 
 Do **not** use `claude-smart update` for this loop — it wraps `claude plugin update claude-smart@reflexioai`, the end-user path for pulling a newer *published* release from the marketplace. It is version-driven (a same-version rebuild has nothing to update to) and updates from the registered source rather than re-ingesting a tarball you just built. Bumping the patch version with `make bump` sidesteps all version-dedup ambiguity if you'd rather not use `--force`.

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Restart Codex after uninstalling. The uninstaller stops local claude-smart servi
 npx claude-smart install --host opencode
 ```
 
-Then restart OpenCode in your project so it loads the plugin from `opencode.json`, the documented project config file. If that project does not already have a root config but does have `.opencode/opencode.json` or `.opencode/opencode.jsonc`, the installer updates that existing file instead of creating a second config. If both locations exist, the root config wins. Use `--global` to install into `~/.config/opencode/opencode.json` for all OpenCode projects on this machine. When run through `npx`, long-lived local services are prepared from OpenCode's installed plugin package on the next OpenCode launch instead of from npm's temporary `npx` cache.
+Then restart OpenCode in your project so it loads the plugin from `opencode.json`, the documented project config file. If that project does not already have a root config but does have `.opencode/opencode.json` or `.opencode/opencode.jsonc`, the installer updates that existing file instead of creating a second config. If both locations exist, the root config wins. Use `--global` to install into `~/.config/opencode/opencode.json` for all OpenCode projects on this machine. The installer copies the active package to `~/.claude-smart/opencode/claude-smart`, prepares that runtime immediately, and writes a `file://` plugin entry so OpenCode reloads the same prepared package after restart.
 
-OpenCode support is new and uses OpenCode's npm plugin loader to inject relevant learned context before each model request. Learning extraction runs `opencode run --pure` from an isolated temp project, so it uses OpenCode's default model unless you set `CLAUDE_SMART_OPENCODE_MODEL=provider/model`. Set that env var if your normal project config pins a different provider or model.
+OpenCode support is new and uses OpenCode's plugin loader to inject relevant learned context before each model request. Learning extraction runs `opencode run --pure` from an isolated temp project, so it uses OpenCode's default model unless you set `CLAUDE_SMART_OPENCODE_MODEL=provider/model`. Set that env var if your normal project config pins a different provider or model.
 
 To uninstall:
 
@@ -121,7 +121,7 @@ To uninstall:
 npx claude-smart uninstall --host opencode
 ```
 
-Restart OpenCode after uninstalling. The uninstaller removes only the `claude-smart` entry from OpenCode's plugin list; learned data under `~/.reflexio/` and `~/.claude-smart/` is preserved and shared across hosts.
+Restart OpenCode after uninstalling. The uninstaller removes the `claude-smart` entry from OpenCode's plugin list and deletes the copied OpenCode package; learned data under `~/.reflexio/` and `~/.claude-smart/` is preserved and shared across hosts.
 
 Developing the plugin itself? See [DEVELOPER.md](./DEVELOPER.md#developing-locally) for what the installer does, manual toggles via `/plugins`, and clone-based development.
 
@@ -242,6 +242,7 @@ Advanced users can tune claude-smart via environment variables — see [DEVELOPE
 | `~/.codex/config.toml` | Codex plugin state, hook feature flags, and per-hook trust entries after `claude-smart install --host codex`. |
 | `~/.codex/plugins/cache/reflexioai/claude-smart/<version>/` | Codex's cached install of the `claude-smart` plugin from the `ReflexioAI` marketplace. |
 | `opencode.json` / `opencode.jsonc`, or existing `.opencode/opencode.json*` | OpenCode local plugin config patched by `claude-smart install --host opencode`; the installer updates only the claude-smart entry in OpenCode's plugin list. |
+| `~/.claude-smart/opencode/claude-smart/` | OpenCode's stable local copy of the active npm package. OpenCode config points here with `file://` so restarts do not re-resolve `claude-smart` from npm. |
 | `~/.reflexio/plugin-root` | Self-healed symlink to the active plugin dir (managed by `ensure-plugin-root.sh` — written on install, refreshed each `SessionStart`). Claude Code slash commands and Codex shell-command helpers resolve through it, so don't delete it; if you do, the next session will recreate it. |
 | `~/.claude-smart/sessions/{session_id}.jsonl` | Per-session buffer. User turns, assistant turns, tool invocations, `{"published_up_to": N}` watermarks. Safe to inspect and safe to delete — everything past the latest watermark has already been written to reflexio's DB. |
 | `~/.claude-smart/node/current/` | Private Node.js/npm runtime used by hooks and the dashboard after install. |

--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ Under the hood: hooks watch your turns, tool calls, and assistant replies, auto-
 **Citations.** At the end of a reply, the assistant may append a short marker:
 
 ```
-✨ 2 claude-smart learnings applied [cs:s1-252,p1-5aed]
+✨ claude-smart rule applied: [git safety](http://localhost:3001/rules/s1-123) | [brief answer preference](http://localhost:3001/rules/p1-pref) · [⚡Reflexio](https://github.com/ReflexioAI/reflexio)
 ```
 
-That signals a preference (`p…`) or skill (`s…`) materially shaped the reply.
+That signals a preference or skill materially shaped the reply.
 Open the session's detail page in the [dashboard](http://localhost:3001) to see the exact cited item.
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for hooks, data flow, and reflexio details.

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -35,7 +35,7 @@ const {
 } = require("fs");
 const https = require("https");
 const { arch, homedir, platform, release, tmpdir } = require("os");
-const { dirname, join } = require("path");
+const { dirname, join, resolve } = require("path");
 const { fileURLToPath, pathToFileURL } = require("url");
 
 const PLUGIN_SPEC = "claude-smart@reflexioai";
@@ -54,6 +54,8 @@ const REFLEXIO_USER_ID_ENV = "REFLEXIO_USER_ID";
 const REFLEXIO_DIR = join(homedir(), ".reflexio");
 const CLAUDE_SMART_STATE_DIR = join(homedir(), ".claude-smart");
 const OPENCODE_LOCAL_PACKAGE_DIR = join(CLAUDE_SMART_STATE_DIR, "opencode", "claude-smart");
+const OPENCODE_PACKAGE_LOCK_TIMEOUT_MS = 120_000;
+const OPENCODE_PACKAGE_LOCK_STALE_MS = 10 * 60_000;
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
 const PACKAGE_ROOT = dirname(dirname(__filename));
 const CODEX_MARKETPLACE_DIR = join(
@@ -459,6 +461,13 @@ function opencodeLocalPluginSpec(packageRoot = OPENCODE_LOCAL_PACKAGE_DIR) {
   return pathToFileURL(packageRoot).href;
 }
 
+function isOpenCodeLocalPackagePath(packagePath) {
+  return (
+    sameRealPath(packagePath, OPENCODE_LOCAL_PACKAGE_DIR) ||
+    resolve(packagePath) === resolve(OPENCODE_LOCAL_PACKAGE_DIR)
+  );
+}
+
 function isOpenCodeClaudeSmartSpec(spec) {
   if (!spec) return false;
   if (spec === OPENCODE_BARE_PLUGIN_SPEC || spec.startsWith(`${OPENCODE_BARE_PLUGIN_SPEC}@`)) {
@@ -471,13 +480,14 @@ function isOpenCodeClaudeSmartSpec(spec) {
   } catch {
     return false;
   }
+  if (isOpenCodeLocalPackagePath(packagePath)) return true;
   try {
     const manifest = JSON.parse(readFileSync(join(packagePath, "package.json"), "utf8"));
     if (manifest && manifest.name === OPENCODE_BARE_PLUGIN_SPEC) return true;
   } catch {
-    // Fall through to path-name compatibility for stale local specs.
+    // Missing or malformed manifests are not enough to identify arbitrary file specs.
   }
-  return /(^|[\\/])claude-smart[\\/]?$/.test(packagePath);
+  return false;
 }
 
 function patchOpenCodePluginConfig(configPath, { install, pluginSpec = null }) {
@@ -654,22 +664,92 @@ function verifyOpenCodePluginPackage(packageRoot) {
   }
 }
 
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function withOpenCodePackageInstallLock(fn) {
+  const lockDir = join(dirname(OPENCODE_LOCAL_PACKAGE_DIR), ".install.lock");
+  mkdirSync(dirname(OPENCODE_LOCAL_PACKAGE_DIR), { recursive: true });
+  const deadline = Date.now() + OPENCODE_PACKAGE_LOCK_TIMEOUT_MS;
+  while (true) {
+    try {
+      mkdirSync(lockDir);
+      break;
+    } catch (err) {
+      if (!err || err.code !== "EEXIST") throw err;
+      try {
+        if (Date.now() - statSync(lockDir).mtimeMs > OPENCODE_PACKAGE_LOCK_STALE_MS) {
+          rmSync(lockDir, { recursive: true, force: true });
+          continue;
+        }
+      } catch (statErr) {
+        if (statErr && statErr.code !== "ENOENT") throw statErr;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`timed out waiting for OpenCode package install lock at ${lockDir}`);
+      }
+      sleepSync(100);
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+}
+
+function uniqueOpenCodePackagePath(prefix) {
+  return join(
+    dirname(OPENCODE_LOCAL_PACKAGE_DIR),
+    `${prefix}-${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`,
+  );
+}
+
+function replaceOpenCodePluginPackage(stagedPackage, packageRoot) {
+  const backupPackage = uniqueOpenCodePackagePath(".claude-smart-previous");
+  let backupCreated = false;
+  try {
+    if (existsSync(packageRoot)) {
+      renameSync(packageRoot, backupPackage);
+      backupCreated = true;
+    }
+    renameSync(stagedPackage, packageRoot);
+    if (backupCreated) {
+      rmSync(backupPackage, { recursive: true, force: true });
+    }
+  } catch (err) {
+    if (backupCreated && !existsSync(packageRoot) && existsSync(backupPackage)) {
+      renameSync(backupPackage, packageRoot);
+    }
+    throw err;
+  }
+}
+
 function installOpenCodePluginPackage() {
   const packageRoot = OPENCODE_LOCAL_PACKAGE_DIR;
   if (sameRealPath(PACKAGE_ROOT, packageRoot)) {
     verifyOpenCodePluginPackage(packageRoot);
     return packageRoot;
   }
-  rmSync(packageRoot, { recursive: true, force: true });
-  mkdirSync(dirname(packageRoot), { recursive: true });
-  cpSync(PACKAGE_ROOT, packageRoot, {
-    recursive: true,
-    force: true,
-    verbatimSymlinks: false,
-    filter: shouldCopyPath,
+  return withOpenCodePackageInstallLock(() => {
+    const stagedPackage = uniqueOpenCodePackagePath(".claude-smart-copy");
+    rmSync(stagedPackage, { recursive: true, force: true });
+    try {
+      cpSync(PACKAGE_ROOT, stagedPackage, {
+        recursive: true,
+        force: true,
+        verbatimSymlinks: false,
+        filter: shouldCopyPath,
+      });
+      verifyOpenCodePluginPackage(stagedPackage);
+      replaceOpenCodePluginPackage(stagedPackage, packageRoot);
+      verifyOpenCodePluginPackage(packageRoot);
+      return packageRoot;
+    } finally {
+      rmSync(stagedPackage, { recursive: true, force: true });
+    }
   });
-  verifyOpenCodePluginPackage(packageRoot);
-  return packageRoot;
 }
 
 async function bootstrapClaudeCodeInstall() {

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -480,7 +480,8 @@ function isOpenCodeClaudeSmartSpec(spec) {
   return /(^|[\\/])claude-smart[\\/]?$/.test(packagePath);
 }
 
-function patchOpenCodePluginConfig(configPath, { install, pluginSpec = OPENCODE_BARE_PLUGIN_SPEC }) {
+function patchOpenCodePluginConfig(configPath, { install, pluginSpec = null }) {
+  const resolvedPluginSpec = install ? (pluginSpec || opencodeLocalPluginSpec()) : pluginSpec;
   const data = readJsoncObject(configPath);
   for (const field of ["plugins", "plugin"]) {
     if (data[field] !== undefined && !Array.isArray(data[field])) {
@@ -492,7 +493,7 @@ function patchOpenCodePluginConfig(configPath, { install, pluginSpec = OPENCODE_
     ...(Array.isArray(data.plugins) ? data.plugins : []),
   ];
   const kept = current.filter((entry) => !isOpenCodeClaudeSmartSpec(opencodePluginSpec(entry)));
-  const next = install ? [...kept, pluginSpec] : kept;
+  const next = install ? [...kept, resolvedPluginSpec] : kept;
   const changed =
     data.plugins !== undefined ||
     (Array.isArray(data.plugin)

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -645,6 +645,15 @@ function sameRealPath(left, right) {
   }
 }
 
+function pathEntryExists(path) {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function fileSha256(path) {
   return crypto.createHash("sha256").update(readFileSync(path)).digest("hex");
 }
@@ -710,7 +719,7 @@ function replaceOpenCodePluginPackage(stagedPackage, packageRoot) {
   const backupPackage = uniqueOpenCodePackagePath(".claude-smart-previous");
   let backupCreated = false;
   try {
-    if (existsSync(packageRoot)) {
+    if (pathEntryExists(packageRoot)) {
       renameSync(packageRoot, backupPackage);
       backupCreated = true;
     }

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -25,6 +25,7 @@ const {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -34,12 +35,13 @@ const {
 const https = require("https");
 const { arch, homedir, platform, release, tmpdir } = require("os");
 const { dirname, join } = require("path");
+const { fileURLToPath, pathToFileURL } = require("url");
 
 const PLUGIN_SPEC = "claude-smart@reflexioai";
 const CODEX_MARKETPLACE_NAME = "reflexioai";
 const CODEX_MARKETPLACE_DISPLAY_NAME = "ReflexioAI";
 const CODEX_PLUGIN_ID = `claude-smart@${CODEX_MARKETPLACE_NAME}`;
-const OPENCODE_PLUGIN_SPEC = "claude-smart";
+const OPENCODE_BARE_PLUGIN_SPEC = "claude-smart";
 const OPENCODE_CONFIG_NAMES = ["opencode.json", "opencode.jsonc"];
 const REFLEXIO_ENV_PATH = join(homedir(), ".reflexio", ".env");
 const MANAGED_REFLEXIO_URL = "https://www.reflexio.ai/";
@@ -50,6 +52,7 @@ const CLAUDE_SMART_USE_LOCAL_EMBEDDING_ENV = "CLAUDE_SMART_USE_LOCAL_EMBEDDING";
 const REFLEXIO_USER_ID_ENV = "REFLEXIO_USER_ID";
 const REFLEXIO_DIR = join(homedir(), ".reflexio");
 const CLAUDE_SMART_STATE_DIR = join(homedir(), ".claude-smart");
+const OPENCODE_LOCAL_PACKAGE_DIR = join(CLAUDE_SMART_STATE_DIR, "opencode", "claude-smart");
 const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
 const PACKAGE_ROOT = dirname(dirname(__filename));
 const CODEX_MARKETPLACE_DIR = join(
@@ -96,6 +99,7 @@ const COPYTREE_IGNORE_NAMES = new Set([
   ".venv",
   ".pytest_cache",
   ".ruff_cache",
+  ".git",
   "node_modules",
   ".next",
 ]);
@@ -450,7 +454,32 @@ function opencodePluginSpec(entry) {
   return null;
 }
 
-function patchOpenCodePluginConfig(configPath, { install }) {
+function opencodeLocalPluginSpec(packageRoot = OPENCODE_LOCAL_PACKAGE_DIR) {
+  return pathToFileURL(packageRoot).href;
+}
+
+function isOpenCodeClaudeSmartSpec(spec) {
+  if (!spec) return false;
+  if (spec === OPENCODE_BARE_PLUGIN_SPEC || spec.startsWith(`${OPENCODE_BARE_PLUGIN_SPEC}@`)) {
+    return true;
+  }
+  if (!spec.startsWith("file://")) return false;
+  let packagePath = null;
+  try {
+    packagePath = fileURLToPath(spec);
+  } catch {
+    return false;
+  }
+  try {
+    const manifest = JSON.parse(readFileSync(join(packagePath, "package.json"), "utf8"));
+    if (manifest && manifest.name === OPENCODE_BARE_PLUGIN_SPEC) return true;
+  } catch {
+    // Fall through to path-name compatibility for stale local specs.
+  }
+  return /(^|[\\/])claude-smart[\\/]?$/.test(packagePath);
+}
+
+function patchOpenCodePluginConfig(configPath, { install, pluginSpec = OPENCODE_BARE_PLUGIN_SPEC }) {
   const data = readJsoncObject(configPath);
   for (const field of ["plugins", "plugin"]) {
     if (data[field] !== undefined && !Array.isArray(data[field])) {
@@ -461,8 +490,8 @@ function patchOpenCodePluginConfig(configPath, { install }) {
     ...(Array.isArray(data.plugin) ? data.plugin : []),
     ...(Array.isArray(data.plugins) ? data.plugins : []),
   ];
-  const kept = current.filter((entry) => opencodePluginSpec(entry) !== OPENCODE_PLUGIN_SPEC);
-  const next = install ? [...kept, OPENCODE_PLUGIN_SPEC] : kept;
+  const kept = current.filter((entry) => !isOpenCodeClaudeSmartSpec(opencodePluginSpec(entry)));
+  const next = install ? [...kept, pluginSpec] : kept;
   const changed =
     data.plugins !== undefined ||
     (Array.isArray(data.plugin)
@@ -482,10 +511,6 @@ function patchOpenCodePluginConfig(configPath, { install }) {
   mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, JSON.stringify(data, null, 2) + "\n");
   return { changed: true, configPath, backupPath };
-}
-
-function isNpxPackageRoot(path) {
-  return path.split(/[\\/]+/).includes("_npx");
 }
 
 function hasExtractionProvider() {
@@ -600,6 +625,51 @@ function forcePluginRoot(pluginRoot) {
   }
 }
 
+function sameRealPath(left, right) {
+  try {
+    return realpathSync(left) === realpathSync(right);
+  } catch {
+    return false;
+  }
+}
+
+function fileSha256(path) {
+  return crypto.createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function verifyOpenCodePluginPackage(packageRoot) {
+  const sourceScript = join(PACKAGE_ROOT, "plugin", "scripts", "smart-install.sh");
+  const copiedScript = join(packageRoot, "plugin", "scripts", "smart-install.sh");
+  for (const file of [join(packageRoot, "package.json"), copiedScript]) {
+    if (!existsSync(file)) {
+      throw new Error(`OpenCode local plugin package is missing ${file}`);
+    }
+  }
+  if (fileSha256(sourceScript) !== fileSha256(copiedScript)) {
+    throw new Error(
+      "OpenCode local plugin package does not match the installed claude-smart package",
+    );
+  }
+}
+
+function installOpenCodePluginPackage() {
+  const packageRoot = OPENCODE_LOCAL_PACKAGE_DIR;
+  if (sameRealPath(PACKAGE_ROOT, packageRoot)) {
+    verifyOpenCodePluginPackage(packageRoot);
+    return packageRoot;
+  }
+  rmSync(packageRoot, { recursive: true, force: true });
+  mkdirSync(dirname(packageRoot), { recursive: true });
+  cpSync(PACKAGE_ROOT, packageRoot, {
+    recursive: true,
+    force: true,
+    verbatimSymlinks: false,
+    filter: shouldCopyPath,
+  });
+  verifyOpenCodePluginPackage(packageRoot);
+  return packageRoot;
+}
+
 async function bootstrapClaudeCodeInstall() {
   const pluginRoot = findClaudeCodePluginRoot();
   if (!pluginRoot) {
@@ -692,6 +762,18 @@ function runChecked(command, args, options = {}) {
     child.on("exit", (code) => resolve(typeof code === "number" ? code : 1));
     child.on("error", () => resolve(1));
   });
+}
+
+function runSilentStatus(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env || process.env,
+    shell: isWindows() && /\.(?:cmd|bat)$/i.test(command),
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  if (result.error || result.signal) return 1;
+  return typeof result.status === "number" ? result.status : 1;
 }
 
 function runPluginService(pluginRoot, scriptName, subcommand, envOverrides = {}) {
@@ -1092,6 +1174,59 @@ async function installVendoredReflexio(pluginRoot, uv, env) {
   if (code !== 0) throw new Error(`vendored Reflexio install failed in ${pluginRoot}`);
 }
 
+async function syncPluginPythonEnv(pluginRoot, uv, env) {
+  let code = await runChecked(
+    uv,
+    ["sync", "--locked", "--python", "3.12", "--quiet"],
+    { cwd: pluginRoot, env },
+  );
+  if (code === 0) return;
+
+  const lockIsFresh = runSilentStatus(
+    uv,
+    ["lock", "--check", "--python", "3.12"],
+    { cwd: pluginRoot, env },
+  ) === 0;
+  if (lockIsFresh) {
+    process.stderr.write(
+      `warning: quiet uv sync failed in ${pluginRoot}; retrying with full output.\n`,
+    );
+    code = await runChecked(
+      uv,
+      ["sync", "--locked", "--python", "3.12"],
+      { cwd: pluginRoot, env },
+    );
+    if (code !== 0) throw new Error(`uv sync failed in ${pluginRoot}`);
+    return;
+  }
+
+  process.stderr.write(
+    "warning: plugin/uv.lock is out of sync; refreshing local lockfile and retrying uv sync.\n",
+  );
+  code = await runChecked(
+    uv,
+    ["lock", "--python", "3.12"],
+    { cwd: pluginRoot, env },
+  );
+  if (code !== 0) throw new Error(`uv lock failed in ${pluginRoot}`);
+  code = await runChecked(
+    uv,
+    ["sync", "--python", "3.12", "--quiet"],
+    { cwd: pluginRoot, env },
+  );
+  if (code !== 0) {
+    process.stderr.write(
+      `warning: quiet uv sync failed in ${pluginRoot} after refreshing plugin/uv.lock; retrying with full output.\n`,
+    );
+    code = await runChecked(
+      uv,
+      ["sync", "--python", "3.12"],
+      { cwd: pluginRoot, env },
+    );
+  }
+  if (code !== 0) throw new Error(`uv sync failed in ${pluginRoot}`);
+}
+
 async function bootstrapPluginRuntime(pluginRoot, options = {}) {
   assertSupportedRuntimePlatform();
   process.stdout.write("Preparing claude-smart runtime for hooks...\n");
@@ -1113,27 +1248,12 @@ async function bootstrapPluginRuntime(pluginRoot, options = {}) {
     );
     if (lockCode !== 0) throw new Error(`uv lock failed in ${pluginRoot}`);
   }
-  let code = await runChecked(
-    uv,
-    ["sync", "--locked", "--python", "3.12", "--quiet"],
-    { cwd: pluginRoot, env },
-  );
-  if (code !== 0) {
-    process.stderr.write(
-      `warning: quiet uv sync failed in ${pluginRoot}; retrying with full output.\n`,
-    );
-    code = await runChecked(
-      uv,
-      ["sync", "--locked", "--python", "3.12"],
-      { cwd: pluginRoot, env },
-    );
-  }
-  if (code !== 0) throw new Error(`uv sync failed in ${pluginRoot}`);
+  await syncPluginPythonEnv(pluginRoot, uv, env);
   await installVendoredReflexio(pluginRoot, uv, env);
 
   const dashboardDir = join(pluginRoot, "dashboard");
   if (existsSync(dashboardDir)) {
-    code = await runChecked(nodeRuntime.npm, ["ci"], { cwd: dashboardDir, env });
+    let code = await runChecked(nodeRuntime.npm, ["ci"], { cwd: dashboardDir, env });
     if (code !== 0) throw new Error(`npm ci failed in ${dashboardDir}`);
     code = await runChecked(nodeRuntime.npm, ["run", "build"], { cwd: dashboardDir, env });
     if (code !== 0) throw new Error(`npm run build failed in ${dashboardDir}`);
@@ -1169,9 +1289,10 @@ function printHelp() {
       "  7. Restart Codex.",
       "",
       "OpenCode install:",
-      "  1. Adds \"claude-smart\" to OpenCode's plugin list in opencode.json",
-      "  2. Prepares local services now for stable installs; npx prepares on next OpenCode launch",
-      "  3. Restart OpenCode.",
+      `  1. Copies this package to ${OPENCODE_LOCAL_PACKAGE_DIR}`,
+      "  2. Adds that local file:// package to OpenCode's plugin list in opencode.json",
+      "  3. Prepares local services now from the copied plugin runtime",
+      "  4. Restart OpenCode.",
       "",
       "Update:",
       "  npx claude-smart update                        Reinstall Claude Code support from this package",
@@ -1894,43 +2015,44 @@ async function runInstallOpenCode(args) {
     process.exit(1);
   }
 
-  const pluginRoot = join(PACKAGE_ROOT, "plugin");
-  let result;
-  if (isNpxPackageRoot(PACKAGE_ROOT)) {
-    try {
-      result = patchOpenCodePluginConfig(opencodeConfigPath(args), { install: true });
-    } catch (err) {
-      process.stderr.write(`error: could not update OpenCode config: ${err && err.message ? err.message : err}\n`);
-      process.exit(1);
-    }
-    process.stdout.write(
-      "Skipped starting claude-smart services from npx's temporary package cache; OpenCode will prepare the runtime from its installed plugin package on next launch.\n",
+  let packageRoot;
+  try {
+    packageRoot = installOpenCodePluginPackage();
+  } catch (err) {
+    process.stderr.write(
+      `error: could not prepare claude-smart OpenCode package: ${err && err.message ? err.message : err}\n`,
     );
-  } else {
-    try {
-      await bootstrapPluginRuntime(pluginRoot, { readOnly, patchCodexHooks: false });
-    } catch (err) {
-      process.stderr.write(
-        `error: claude-smart OpenCode setup failed during dependency bootstrap: ${err && err.message ? err.message : err}\n`,
-      );
-      process.exit(1);
-    }
-    try {
-      result = patchOpenCodePluginConfig(opencodeConfigPath(args), { install: true });
-    } catch (err) {
-      process.stderr.write(`error: could not update OpenCode config: ${err && err.message ? err.message : err}\n`);
-      stopClaudeSmartServices(pluginRoot);
-      process.exit(1);
-    }
-    if (readOnly) {
-      process.stdout.write("Installed read-only hook manifest; publish interactions hooks are disabled.\n");
-    }
-    if (startBackendService(pluginRoot, "opencode")) {
-      process.stdout.write("Started claude-smart backend service.\n");
-    }
-    if (refreshDashboardService(pluginRoot)) {
-      process.stdout.write("Refreshed claude-smart dashboard service.\n");
-    }
+    process.exit(1);
+  }
+  const pluginRoot = join(packageRoot, "plugin");
+  const pluginSpec = opencodeLocalPluginSpec(packageRoot);
+  let result;
+  try {
+    await bootstrapPluginRuntime(pluginRoot, { readOnly, patchCodexHooks: false });
+  } catch (err) {
+    process.stderr.write(
+      `error: claude-smart OpenCode setup failed during dependency bootstrap: ${err && err.message ? err.message : err}\n`,
+    );
+    process.exit(1);
+  }
+  try {
+    result = patchOpenCodePluginConfig(opencodeConfigPath(args), {
+      install: true,
+      pluginSpec,
+    });
+  } catch (err) {
+    process.stderr.write(`error: could not update OpenCode config: ${err && err.message ? err.message : err}\n`);
+    stopClaudeSmartServices(pluginRoot);
+    process.exit(1);
+  }
+  if (readOnly) {
+    process.stdout.write("Installed read-only hook manifest; publish interactions hooks are disabled.\n");
+  }
+  if (startBackendService(pluginRoot, "opencode")) {
+    process.stdout.write("Started claude-smart backend service.\n");
+  }
+  if (refreshDashboardService(pluginRoot)) {
+    process.stdout.write("Refreshed claude-smart dashboard service.\n");
   }
   if (result.backupPath) {
     process.stdout.write(`Saved a comment-preserving backup of your previous config at ${result.backupPath}.\n`);
@@ -1938,7 +2060,8 @@ async function runInstallOpenCode(args) {
   process.stdout.write(
     [
       "",
-      `${result.changed ? "Updated" : "OpenCode config already includes"} "${OPENCODE_PLUGIN_SPEC}" in ${result.configPath}.`,
+      `${result.changed ? "Updated" : "OpenCode config already includes"} "${pluginSpec}" in ${result.configPath}.`,
+      `Prepared claude-smart OpenCode package at ${packageRoot}.`,
       "claude-smart OpenCode support is installed.",
       "Restart OpenCode in your project so it loads the plugin.",
       "",
@@ -1975,6 +2098,7 @@ async function runUninstallCodex() {
 
 async function runUninstallOpenCode(args) {
   stopClaudeSmartServices(join(PACKAGE_ROOT, "plugin"));
+  stopClaudeSmartServices(join(OPENCODE_LOCAL_PACKAGE_DIR, "plugin"));
   let result;
   try {
     result = patchOpenCodePluginConfig(opencodeConfigPath(args), { install: false });
@@ -1985,12 +2109,13 @@ async function runUninstallOpenCode(args) {
   if (result.backupPath) {
     process.stdout.write(`Saved a comment-preserving backup of your previous config at ${result.backupPath}.\n`);
   }
+  rmSync(OPENCODE_LOCAL_PACKAGE_DIR, { recursive: true, force: true });
   process.stdout.write(
     [
       "",
       result.changed
-        ? `Removed "${OPENCODE_PLUGIN_SPEC}" from ${result.configPath}.`
-        : `OpenCode config did not include "${OPENCODE_PLUGIN_SPEC}".`,
+        ? `Removed claude-smart OpenCode plugin entries from ${result.configPath}.`
+        : "OpenCode config did not include claude-smart.",
       "Restart OpenCode to apply.",
       ...LOCAL_DATA_NOTICE,
       "",
@@ -2050,7 +2175,8 @@ module.exports = {
   configureReflexioSetup,
   patchCodexHooksForNode,
   opencodeConfigPath,
-  isNpxPackageRoot,
+  opencodeLocalPluginSpec,
+  installOpenCodePluginPackage,
   patchOpenCodePluginConfig,
   hasExtractionProvider,
   platformSupportError,

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -27,6 +27,7 @@ const {
   readdirSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -2110,6 +2111,11 @@ async function runUninstallOpenCode(args) {
     process.stdout.write(`Saved a comment-preserving backup of your previous config at ${result.backupPath}.\n`);
   }
   rmSync(OPENCODE_LOCAL_PACKAGE_DIR, { recursive: true, force: true });
+  try {
+    rmdirSync(dirname(OPENCODE_LOCAL_PACKAGE_DIR));
+  } catch {
+    // Keep the parent when it still contains future OpenCode state.
+  }
   process.stdout.write(
     [
       "",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -43,9 +43,10 @@ npx claude-smart install --host opencode
 ```
 
 Then restart OpenCode in your project so it loads the plugin from `opencode.json`
-or your existing `.opencode/opencode.json*` config. OpenCode installs reuse the
-same local Preferences, Project-specific skills, and Shared skills as Claude Code
-and Codex.
+or your existing `.opencode/opencode.json*` config. The installer copies the
+active npm package to `~/.claude-smart/opencode/claude-smart` and registers that
+stable local package with `file://`. OpenCode installs reuse the same local
+Preferences, Project-specific skills, and Shared skills as Claude Code and Codex.
 
 ## Uninstall
 
@@ -76,8 +77,9 @@ Restart Codex after uninstalling. Local data under `~/.reflexio/` and
 npx claude-smart uninstall --host opencode
 ```
 
-Restart OpenCode after uninstalling. Local data under `~/.reflexio/` and
-`~/.claude-smart/` is preserved and shared across supported hosts.
+Restart OpenCode after uninstalling. The copied OpenCode package is removed, but
+local learning data under `~/.reflexio/` and `~/.claude-smart/` is preserved and
+shared across supported hosts.
 
 ## License
 

--- a/plugin/opencode/dist/server.mjs
+++ b/plugin/opencode/dist/server.mjs
@@ -1,11 +1,85 @@
 import { spawn } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { AssistantBuffer } from "./assistant-buffer.js";
 import { sessionIDFrom } from "./internal.js";
 import { chatMessagePayload, eventPayload, stopPayload, toolAfterPayload } from "./payload.js";
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
-const PLUGIN_ROOT = resolve(MODULE_DIR, "../..");
+function homeDir() {
+    return process.env.HOME || homedir();
+}
+function textFilePluginRoot() {
+    try {
+        return readFileSync(join(homeDir(), ".reflexio", "plugin-root.txt"), "utf8").trim() || undefined;
+    }
+    catch {
+        return undefined;
+    }
+}
+function isPluginRoot(candidate) {
+    return !!candidate
+        && existsSync(join(candidate, "pyproject.toml"))
+        && existsSync(join(candidate, "uv.lock"))
+        && existsSync(join(candidate, "scripts", "hook_entry.sh"));
+}
+function canonicalPluginRoot(candidate) {
+    if (!isPluginRoot(candidate))
+        return undefined;
+    try {
+        return realpathSync(candidate);
+    }
+    catch {
+        return undefined;
+    }
+}
+function pathParts(candidate) {
+    return candidate.split(/[\\/]+/).filter(Boolean);
+}
+function isDescendantOrSame(child, parent) {
+    const path = relative(parent, child);
+    return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+function isReflexioSessionCopy(candidate) {
+    try {
+        const reflexioRoot = realpathSync(join(homeDir(), ".reflexio"));
+        return isDescendantOrSame(candidate, reflexioRoot);
+    }
+    catch {
+        return false;
+    }
+}
+function isTransientPackageRoot(candidate) {
+    return pathParts(candidate).includes("_npx") || isReflexioSessionCopy(candidate);
+}
+function resolvePluginRoot() {
+    const current = resolve(MODULE_DIR, "../..");
+    const explicit = canonicalPluginRoot(process.env.CLAUDE_SMART_PLUGIN_ROOT);
+    if (explicit)
+        return explicit;
+    const currentRoot = canonicalPluginRoot(current);
+    if (currentRoot && !isTransientPackageRoot(currentRoot))
+        return currentRoot;
+    const candidates = [
+        join(homeDir(), ".reflexio", "plugin-root"),
+        textFilePluginRoot(),
+    ];
+    for (const candidate of candidates) {
+        const root = canonicalPluginRoot(candidate);
+        if (root)
+            return root;
+    }
+    if (currentRoot)
+        return currentRoot;
+    try {
+        return realpathSync(current);
+    }
+    catch {
+        return current;
+    }
+}
+const PLUGIN_ROOT = resolvePluginRoot();
 const SCRIPTS_DIR = resolve(PLUGIN_ROOT, "scripts");
 const HOOK_ENTRY = resolve(SCRIPTS_DIR, "hook_entry.sh");
 const BACKEND_SERVICE = resolve(SCRIPTS_DIR, "backend-service.sh");

--- a/plugin/opencode/server.mts
+++ b/plugin/opencode/server.mts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process"
-import { dirname, resolve } from "node:path"
+import { existsSync, readFileSync, realpathSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { AssistantBuffer } from "./assistant-buffer.js"
@@ -20,7 +22,82 @@ type EventInput = {
 }
 
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url))
-const PLUGIN_ROOT = resolve(MODULE_DIR, "../..")
+
+function homeDir(): string {
+  return process.env.HOME || homedir()
+}
+
+function textFilePluginRoot(): string | undefined {
+  try {
+    return readFileSync(join(homeDir(), ".reflexio", "plugin-root.txt"), "utf8").trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isPluginRoot(candidate: string | undefined): candidate is string {
+  return !!candidate
+    && existsSync(join(candidate, "pyproject.toml"))
+    && existsSync(join(candidate, "uv.lock"))
+    && existsSync(join(candidate, "scripts", "hook_entry.sh"))
+}
+
+function canonicalPluginRoot(candidate: string | undefined): string | undefined {
+  if (!isPluginRoot(candidate)) return undefined
+  try {
+    return realpathSync(candidate)
+  } catch {
+    return undefined
+  }
+}
+
+function pathParts(candidate: string): string[] {
+  return candidate.split(/[\\/]+/).filter(Boolean)
+}
+
+function isDescendantOrSame(child: string, parent: string): boolean {
+  const path = relative(parent, child)
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path))
+}
+
+function isReflexioSessionCopy(candidate: string): boolean {
+  try {
+    const reflexioRoot = realpathSync(join(homeDir(), ".reflexio"))
+    return isDescendantOrSame(candidate, reflexioRoot)
+  } catch {
+    return false
+  }
+}
+
+function isTransientPackageRoot(candidate: string): boolean {
+  return pathParts(candidate).includes("_npx") || isReflexioSessionCopy(candidate)
+}
+
+function resolvePluginRoot(): string {
+  const current = resolve(MODULE_DIR, "../..")
+  const explicit = canonicalPluginRoot(process.env.CLAUDE_SMART_PLUGIN_ROOT)
+  if (explicit) return explicit
+
+  const currentRoot = canonicalPluginRoot(current)
+  if (currentRoot && !isTransientPackageRoot(currentRoot)) return currentRoot
+
+  const candidates = [
+    join(homeDir(), ".reflexio", "plugin-root"),
+    textFilePluginRoot(),
+  ]
+  for (const candidate of candidates) {
+    const root = canonicalPluginRoot(candidate)
+    if (root) return root
+  }
+  if (currentRoot) return currentRoot
+  try {
+    return realpathSync(current)
+  } catch {
+    return current
+  }
+}
+
+const PLUGIN_ROOT = resolvePluginRoot()
 const SCRIPTS_DIR = resolve(PLUGIN_ROOT, "scripts")
 const HOOK_ENTRY = resolve(SCRIPTS_DIR, "hook_entry.sh")
 const BACKEND_SERVICE = resolve(SCRIPTS_DIR, "backend-service.sh")

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -465,7 +465,13 @@ if [ -d "$PLUGIN_ROOT/.venv" ]; then
 fi
 echo "[claude-smart] running uv sync..." >&2
 if ! uv sync --locked --python 3.12 --quiet >&2; then
-  write_failure "uv sync failed in $PLUGIN_ROOT — run 'uv sync --locked --python 3.12' there to diagnose"
+  if uv lock --check --python 3.12 >/dev/null 2>&1; then
+    write_failure "uv sync failed in $PLUGIN_ROOT — run 'uv sync --locked --python 3.12' there to diagnose"
+  fi
+  echo "[claude-smart] plugin/uv.lock is out of sync; refreshing local lockfile and retrying uv sync" >&2
+  if ! uv lock --python 3.12 >&2 || ! uv sync --python 3.12 --quiet >&2; then
+    write_failure "uv sync failed in $PLUGIN_ROOT after refreshing plugin/uv.lock — run 'uv lock --python 3.12 && uv sync --python 3.12' there to diagnose"
+  fi
 fi
 # Defend against a stale lockfile silently dropping the project install.
 # When plugin/uv.lock pins a different claude-smart version than pyproject.toml,

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -21,6 +21,9 @@ Exposes the following subcommands:
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable
+from dataclasses import dataclass
+from hashlib import sha256
 import json
 import os
 import re
@@ -29,9 +32,9 @@ import shutil
 import subprocess
 import sys
 import time
-from collections.abc import Iterable
-from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from claude_smart import context_format, cs_cite, env_config, ids, publish, state
 from claude_smart.reflexio_adapter import Adapter
@@ -56,7 +59,7 @@ _CODEX_PLUGIN_CACHE_DIR = (
     / "claude-smart"
 )
 _CODEX_CLI_TIMEOUT_SECONDS = 30
-_OPENCODE_PLUGIN_SPEC = "claude-smart"
+_OPENCODE_BARE_PLUGIN_SPEC = "claude-smart"
 _OPENCODE_CONFIG_NAMES = ("opencode.json", "opencode.jsonc")
 _REFLEXIO_UNREACHABLE_MSG = (
     "Failed to reach reflexio. Check ~/.claude-smart/backend.log "
@@ -72,6 +75,7 @@ _BACKEND_SCRIPT = _SCRIPTS_DIR / "backend-service.sh"
 _DASHBOARD_SCRIPT = _SCRIPTS_DIR / "dashboard-service.sh"
 _REFLEXIO_DIR = Path.home() / ".reflexio"
 _STATE_DIR = Path.home() / ".claude-smart"
+_OPENCODE_LOCAL_PACKAGE_DIR = _STATE_DIR / "opencode" / "claude-smart"
 _LOCAL_DATA_NOTICE = (
     "Local data was kept so reinstalling claude-smart can reuse your learned "
     "rules, sessions, logs, and local Reflexio data.\n"
@@ -113,6 +117,7 @@ _COPYTREE_IGNORE = shutil.ignore_patterns(
     "*.pyo",
     ".pytest_cache",
     ".ruff_cache",
+    ".git",
     ".next",
     "node_modules",
 )
@@ -1080,9 +1085,37 @@ def _opencode_plugin_spec(entry: object) -> str | None:
     return None
 
 
+def _opencode_local_plugin_spec(
+    package_root: Path = _OPENCODE_LOCAL_PACKAGE_DIR,
+) -> str:
+    return package_root.resolve(strict=False).as_uri()
+
+
+def _is_opencode_claude_smart_spec(spec: str | None) -> bool:
+    if not spec:
+        return False
+    if spec == _OPENCODE_BARE_PLUGIN_SPEC or spec.startswith(
+        f"{_OPENCODE_BARE_PLUGIN_SPEC}@"
+    ):
+        return True
+    parsed = urlparse(spec)
+    if parsed.scheme != "file":
+        return False
+    package_path = Path(url2pathname(parsed.path))
+    try:
+        manifest = json.loads((package_path / "package.json").read_text())
+        if manifest.get("name") == _OPENCODE_BARE_PLUGIN_SPEC:
+            return True
+    except (OSError, json.JSONDecodeError):
+        pass
+    return package_path.name == _OPENCODE_BARE_PLUGIN_SPEC
+
+
 def _patch_opencode_plugin_config(
-    config_path: Path, *, install: bool
+    config_path: Path, *, install: bool, plugin_spec: str | None = None
 ) -> tuple[bool, Path]:
+    if plugin_spec is None:
+        plugin_spec = _OPENCODE_BARE_PLUGIN_SPEC
     data = _read_jsonc_object(config_path)
     for field in ("plugins", "plugin"):
         value = data.get(field)
@@ -1100,9 +1133,9 @@ def _patch_opencode_plugin_config(
     kept = [
         item
         for item in plugins
-        if _opencode_plugin_spec(item) != _OPENCODE_PLUGIN_SPEC
+        if not _is_opencode_claude_smart_spec(_opencode_plugin_spec(item))
     ]
-    next_plugins = [*kept, _OPENCODE_PLUGIN_SPEC] if install else kept
+    next_plugins = [*kept, plugin_spec] if install else kept
     if isinstance(current_plugin, list):
         changed = ("plugins" in data) or next_plugins != current_plugin
     else:
@@ -1144,6 +1177,41 @@ def _opencode_install_supported_from_this_package() -> bool:
     return (_SCRIPTS_DIR / "smart-install.sh").is_file()
 
 
+def _file_sha256(path: Path) -> str:
+    return sha256(path.read_bytes()).hexdigest()
+
+
+def _same_real_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve(strict=True) == right.resolve(strict=True)
+    except OSError:
+        return False
+
+
+def _verify_opencode_plugin_package(package_root: Path) -> None:
+    source_script = _PLUGIN_ROOT / "scripts" / "smart-install.sh"
+    copied_script = package_root / "plugin" / "scripts" / "smart-install.sh"
+    for path in (package_root / "package.json", copied_script):
+        if not path.exists():
+            raise OSError(f"OpenCode local plugin package is missing {path}")
+    if _file_sha256(source_script) != _file_sha256(copied_script):
+        raise OSError(
+            "OpenCode local plugin package does not match the installed claude-smart package"
+        )
+
+
+def _install_opencode_plugin_package() -> Path:
+    package_root = _OPENCODE_LOCAL_PACKAGE_DIR
+    if _same_real_path(_REPO_ROOT, package_root):
+        _verify_opencode_plugin_package(package_root)
+        return package_root
+    shutil.rmtree(package_root, ignore_errors=True)
+    package_root.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(_REPO_ROOT, package_root, ignore=_COPYTREE_IGNORE)
+    _verify_opencode_plugin_package(package_root)
+    return package_root
+
+
 def _bootstrap_opencode_install(read_only: bool) -> tuple[bool, str]:
     if not _opencode_install_supported_from_this_package():
         return (
@@ -1152,22 +1220,28 @@ def _bootstrap_opencode_install(read_only: bool) -> tuple[bool, str]:
             "Run `npx claude-smart install --host opencode`.",
         )
     try:
-        _force_plugin_root(_PLUGIN_ROOT)
+        package_root = _install_opencode_plugin_package()
+    except OSError as exc:
+        return False, str(exc)
+    plugin_root = package_root / "plugin"
+    try:
+        _force_plugin_root(plugin_root)
     except OSError as exc:
         return False, str(exc)
     bash = _resolve_bash()
     if not bash:
         return False, "bash is required to bootstrap claude-smart dependencies"
-    result = subprocess.run([bash, str(_SCRIPTS_DIR / "smart-install.sh")], cwd=_PLUGIN_ROOT)
+    scripts_dir = plugin_root / "scripts"
+    result = subprocess.run([bash, str(scripts_dir / "smart-install.sh")], cwd=plugin_root)
     if result.returncode != 0:
-        return False, f"smart-install.sh failed in {_PLUGIN_ROOT}"
+        return False, f"smart-install.sh failed in {plugin_root}"
     if _INSTALL_FAILURE_MARKER.is_file():
         first_line = _INSTALL_FAILURE_MARKER.read_text().splitlines()
         reason = (first_line[0].strip() if first_line else "") or "unknown error"
         return False, reason
     if read_only:
-        _prune_publish_hooks_for_read_only(_PLUGIN_ROOT)
-    return True, str(_PLUGIN_ROOT)
+        _prune_publish_hooks_for_read_only(plugin_root)
+    return True, str(package_root)
 
 
 def cmd_install_opencode(args: argparse.Namespace) -> int:
@@ -1181,24 +1255,30 @@ def cmd_install_opencode(args: argparse.Namespace) -> int:
     if not _has_extraction_provider():
         sys.stderr.write(_extraction_provider_error())
         return 1
-    bootstrapped, message = _bootstrap_opencode_install(read_only)
+    bootstrapped, package_root_text = _bootstrap_opencode_install(read_only)
     if not bootstrapped:
         sys.stderr.write(
-            f"error: claude-smart OpenCode setup failed during dependency bootstrap: {message}\n"
+            f"error: claude-smart OpenCode setup failed during dependency bootstrap: {package_root_text}\n"
         )
         return 1
+    package_root = Path(package_root_text)
+    plugin_spec = _opencode_local_plugin_spec(package_root)
     config_path = _opencode_config_path(
         global_config=bool(getattr(args, "global_config", False))
     )
     try:
-        changed, config_path = _patch_opencode_plugin_config(config_path, install=True)
+        changed, config_path = _patch_opencode_plugin_config(
+            config_path,
+            install=True,
+            plugin_spec=plugin_spec,
+        )
     except ValueError as exc:
         sys.stderr.write(f"error: {exc}\n")
         return 1
     action = "Updated" if changed else "OpenCode config already includes"
     sys.stdout.write(
-        f"{action} `{_OPENCODE_PLUGIN_SPEC}` in {config_path}.\n"
-        f"Prepared claude-smart runtime at {message}.\n"
+        f"{action} `{plugin_spec}` in {config_path}.\n"
+        f"Prepared claude-smart runtime at {package_root / 'plugin'}.\n"
         "Restart OpenCode in your project so it loads the plugin.\n"
     )
     return 0
@@ -1517,6 +1597,13 @@ def cmd_uninstall_codex(_args: argparse.Namespace) -> int:
 def cmd_uninstall_opencode(args: argparse.Namespace) -> int:
     _run_service(_DASHBOARD_SCRIPT, "stop")
     _run_service(_BACKEND_SCRIPT, "stop")
+    local_scripts = _OPENCODE_LOCAL_PACKAGE_DIR / "plugin" / "scripts"
+    for script in (
+        local_scripts / "dashboard-service.sh",
+        local_scripts / "backend-service.sh",
+    ):
+        if script.exists():
+            _run_service(script, "stop")
     config_path = _opencode_config_path(
         global_config=bool(getattr(args, "global_config", False))
     )
@@ -1525,10 +1612,11 @@ def cmd_uninstall_opencode(args: argparse.Namespace) -> int:
     except ValueError as exc:
         sys.stderr.write(f"error: {exc}\n")
         return 1
+    shutil.rmtree(_OPENCODE_LOCAL_PACKAGE_DIR, ignore_errors=True)
     if changed:
-        sys.stdout.write(f"Removed `{_OPENCODE_PLUGIN_SPEC}` from {config_path}.\n")
+        sys.stdout.write(f"Removed claude-smart OpenCode plugin entries from {config_path}.\n")
     else:
-        sys.stdout.write(f"OpenCode config did not include `{_OPENCODE_PLUGIN_SPEC}`.\n")
+        sys.stdout.write("OpenCode config did not include claude-smart.\n")
     sys.stdout.write(
         "Restart OpenCode to apply. "
         f"{_LOCAL_DATA_NOTICE}"

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -1343,6 +1343,7 @@ def cmd_install_opencode(args: argparse.Namespace) -> int:
         )
         return 1
     package_root = Path(package_root_text)
+    plugin_root = package_root / "plugin"
     plugin_spec = _opencode_local_plugin_spec(package_root)
     config_path = _opencode_config_path(
         global_config=bool(getattr(args, "global_config", False))
@@ -1359,7 +1360,7 @@ def cmd_install_opencode(args: argparse.Namespace) -> int:
     action = "Updated" if changed else "OpenCode config already includes"
     sys.stdout.write(
         f"{action} `{plugin_spec}` in {config_path}.\n"
-        f"Prepared claude-smart runtime at {package_root / 'plugin'}.\n"
+        f"Prepared claude-smart runtime at {plugin_root}.\n"
         "Restart OpenCode in your project so it loads the plugin.\n"
     )
     return 0

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -21,7 +21,8 @@ Exposes the following subcommands:
 from __future__ import annotations
 
 import argparse
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
 import json
@@ -76,6 +77,8 @@ _DASHBOARD_SCRIPT = _SCRIPTS_DIR / "dashboard-service.sh"
 _REFLEXIO_DIR = Path.home() / ".reflexio"
 _STATE_DIR = Path.home() / ".claude-smart"
 _OPENCODE_LOCAL_PACKAGE_DIR = _STATE_DIR / "opencode" / "claude-smart"
+_OPENCODE_PACKAGE_LOCK_TIMEOUT_SECONDS = 120.0
+_OPENCODE_PACKAGE_LOCK_STALE_SECONDS = 10 * 60.0
 _LOCAL_DATA_NOTICE = (
     "Local data was kept so reinstalling claude-smart can reuse your learned "
     "rules, sessions, logs, and local Reflexio data.\n"
@@ -1091,6 +1094,17 @@ def _opencode_local_plugin_spec(
     return package_root.resolve(strict=False).as_uri()
 
 
+def _is_default_opencode_package_path(package_path: Path) -> bool:
+    if _same_real_path(package_path, _OPENCODE_LOCAL_PACKAGE_DIR):
+        return True
+    try:
+        return package_path.resolve(strict=False) == _OPENCODE_LOCAL_PACKAGE_DIR.resolve(
+            strict=False
+        )
+    except OSError:
+        return False
+
+
 def _is_opencode_claude_smart_spec(spec: str | None) -> bool:
     if not spec:
         return False
@@ -1102,13 +1116,15 @@ def _is_opencode_claude_smart_spec(spec: str | None) -> bool:
     if parsed.scheme != "file":
         return False
     package_path = Path(url2pathname(parsed.path))
+    if _is_default_opencode_package_path(package_path):
+        return True
     try:
         manifest = json.loads((package_path / "package.json").read_text())
         if manifest.get("name") == _OPENCODE_BARE_PLUGIN_SPEC:
             return True
     except (OSError, json.JSONDecodeError):
         pass
-    return package_path.name == _OPENCODE_BARE_PLUGIN_SPEC
+    return False
 
 
 def _patch_opencode_plugin_config(
@@ -1204,15 +1220,76 @@ def _verify_opencode_plugin_package(package_root: Path) -> None:
         )
 
 
+@contextmanager
+def _opencode_package_install_lock(package_root: Path) -> Iterator[None]:
+    lock_dir = package_root.parent / ".install.lock"
+    package_root.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + _OPENCODE_PACKAGE_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            lock_dir.mkdir()
+            break
+        except FileExistsError:
+            try:
+                stale = (
+                    time.time() - lock_dir.stat().st_mtime
+                    > _OPENCODE_PACKAGE_LOCK_STALE_SECONDS
+                )
+            except OSError:
+                stale = False
+            if stale:
+                shutil.rmtree(lock_dir, ignore_errors=True)
+                continue
+            if time.monotonic() >= deadline:
+                raise OSError(
+                    f"timed out waiting for OpenCode package install lock at {lock_dir}"
+                )
+            time.sleep(0.1)
+    try:
+        yield
+    finally:
+        shutil.rmtree(lock_dir, ignore_errors=True)
+
+
+def _unique_opencode_package_path(parent: Path, prefix: str) -> Path:
+    return parent / f"{prefix}-{os.getpid()}-{time.monotonic_ns()}"
+
+
+def _replace_opencode_plugin_package(staged_package: Path, package_root: Path) -> None:
+    backup_package = _unique_opencode_package_path(
+        package_root.parent, ".claude-smart-previous"
+    )
+    backup_created = False
+    try:
+        if package_root.exists() or package_root.is_symlink():
+            package_root.rename(backup_package)
+            backup_created = True
+        staged_package.rename(package_root)
+        if backup_created:
+            shutil.rmtree(backup_package, ignore_errors=True)
+    except OSError:
+        if backup_created and not package_root.exists() and backup_package.exists():
+            backup_package.rename(package_root)
+        raise
+
+
 def _install_opencode_plugin_package() -> Path:
     package_root = _OPENCODE_LOCAL_PACKAGE_DIR
     if _same_real_path(_REPO_ROOT, package_root):
         _verify_opencode_plugin_package(package_root)
         return package_root
-    shutil.rmtree(package_root, ignore_errors=True)
-    package_root.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(_REPO_ROOT, package_root, ignore=_COPYTREE_IGNORE)
-    _verify_opencode_plugin_package(package_root)
+    with _opencode_package_install_lock(package_root):
+        staged_package = _unique_opencode_package_path(
+            package_root.parent, ".claude-smart-copy"
+        )
+        shutil.rmtree(staged_package, ignore_errors=True)
+        try:
+            shutil.copytree(_REPO_ROOT, staged_package, ignore=_COPYTREE_IGNORE)
+            _verify_opencode_plugin_package(staged_package)
+            _replace_opencode_plugin_package(staged_package, package_root)
+            _verify_opencode_plugin_package(package_root)
+        finally:
+            shutil.rmtree(staged_package, ignore_errors=True)
     return package_root
 
 

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -1114,8 +1114,8 @@ def _is_opencode_claude_smart_spec(spec: str | None) -> bool:
 def _patch_opencode_plugin_config(
     config_path: Path, *, install: bool, plugin_spec: str | None = None
 ) -> tuple[bool, Path]:
-    if plugin_spec is None:
-        plugin_spec = _OPENCODE_BARE_PLUGIN_SPEC
+    if install and plugin_spec is None:
+        plugin_spec = _opencode_local_plugin_spec()
     data = _read_jsonc_object(config_path)
     for field in ("plugins", "plugin"):
         value = data.get(field)
@@ -1135,7 +1135,11 @@ def _patch_opencode_plugin_config(
         for item in plugins
         if not _is_opencode_claude_smart_spec(_opencode_plugin_spec(item))
     ]
-    next_plugins = [*kept, plugin_spec] if install else kept
+    if install:
+        assert plugin_spec is not None
+        next_plugins = [*kept, plugin_spec]
+    else:
+        next_plugins = kept
     if isinstance(current_plugin, list):
         changed = ("plugins" in data) or next_plugins != current_plugin
     else:

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -1613,6 +1613,10 @@ def cmd_uninstall_opencode(args: argparse.Namespace) -> int:
         sys.stderr.write(f"error: {exc}\n")
         return 1
     shutil.rmtree(_OPENCODE_LOCAL_PACKAGE_DIR, ignore_errors=True)
+    try:
+        _OPENCODE_LOCAL_PACKAGE_DIR.parent.rmdir()
+    except OSError:
+        pass
     if changed:
         sys.stdout.write(f"Removed claude-smart OpenCode plugin entries from {config_path}.\n")
     else:

--- a/scripts/check-reflexio-lock.py
+++ b/scripts/check-reflexio-lock.py
@@ -7,7 +7,6 @@ import argparse
 import json
 import re
 import sys
-import tomllib
 from pathlib import Path
 
 DEPENDENCY_RE = re.compile(r'"reflexio-ai[^"]*"')
@@ -58,6 +57,8 @@ def read_vendor_version(vendor: Path) -> str:
             f"reflexio.lock.json requires vendored Reflexio but {vendor} is missing; "
             "run bash scripts/release-with-reflexio.sh before npm publish"
         )
+    import tomllib
+
     with pyproject.open("rb") as handle:
         data = tomllib.load(handle)
     project = data.get("project", {})

--- a/scripts/check-reflexio-lock.py
+++ b/scripts/check-reflexio-lock.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 DEPENDENCY_RE = re.compile(r'"reflexio-ai[^"]*"')
+PROJECT_STRING_RE = re.compile(r'^([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"\s*(?:#.*)?$')
 PACKAGE_NAME = "reflexio-ai"
 REPO_URL = "https://github.com/ReflexioAI/reflexio.git"
 VALID_SOURCES = {"pypi", "vendor"}
@@ -57,11 +58,21 @@ def read_vendor_version(vendor: Path) -> str:
             f"reflexio.lock.json requires vendored Reflexio but {vendor} is missing; "
             "run bash scripts/release-with-reflexio.sh before npm publish"
         )
-    import tomllib
+    project: dict[str, str] = {}
+    in_project = False
+    for raw_line in pyproject.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_project = line == "[project]"
+            continue
+        if not in_project:
+            continue
+        match = PROJECT_STRING_RE.match(line)
+        if match:
+            project[match.group(1)] = match.group(2)
 
-    with pyproject.open("rb") as handle:
-        data = tomllib.load(handle)
-    project = data.get("project", {})
     name = project.get("name")
     version = project.get("version")
     if name != PACKAGE_NAME:

--- a/scripts/standalone-lock.sh
+++ b/scripts/standalone-lock.sh
@@ -62,13 +62,13 @@ rsync -a \
 unset VIRTUAL_ENV
 
 if [ "$mode" = "--write" ]; then
-  (cd "$tmp" && uv lock --refresh-package reflexio-ai >&2)
+  (cd "$tmp" && uv lock --python 3.12 --refresh-package reflexio-ai >&2)
   cp "$tmp/uv.lock" "$plugin_dir/uv.lock"
   echo "→ wrote standalone plugin/uv.lock"
 else
   # --check: verify the committed lock would not change when resolved
   # standalone. uv lock --check (alias --locked) is non-mutating.
-  if (cd "$tmp" && uv lock --check >&2); then
+  if (cd "$tmp" && uv lock --check --python 3.12 >&2); then
     echo "→ ok: plugin/uv.lock is standalone-consistent"
   else
     echo "error: plugin/uv.lock is STALE when resolved standalone (outside the" >&2

--- a/tests/host_learning_harness.py
+++ b/tests/host_learning_harness.py
@@ -1,0 +1,284 @@
+"""Reusable happy-path harness for claude-smart host learning flows."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+
+class FakeReflexioAdapter:
+    def __init__(self, host_label: str) -> None:
+        self.host_label = host_label
+        self.url = "http://localhost:8071/"
+        self.search_calls: list[dict[str, Any]] = []
+        self.publish_calls: list[dict[str, Any]] = []
+        self.extraction_defaults: list[dict[str, int]] = []
+        self.optimizer_defaults: list[dict[str, Any]] = []
+
+    def fetch_stall_state(self) -> None:
+        return None
+
+    def apply_extraction_defaults(self, *, window_size: int, stride_size: int) -> bool:
+        self.extraction_defaults.append(
+            {"window_size": window_size, "stride_size": stride_size}
+        )
+        return True
+
+    def apply_optimizer_defaults(
+        self, *, script_path: str, timeout_seconds: int = 300
+    ) -> bool:
+        self.optimizer_defaults.append(
+            {"script_path": script_path, "timeout_seconds": timeout_seconds}
+        )
+        return True
+
+    def search_all(
+        self, *, project_id: str, query: str, top_k: int
+    ) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
+        from claude_smart import runtime
+
+        self.search_calls.append(
+            {
+                "project_id": project_id,
+                "query": query,
+                "top_k": top_k,
+                "host": runtime.host(),
+            }
+        )
+        return (
+            [
+                {
+                    "user_playbook_id": f"user-{self.host_label}",
+                    "content": f"{self.host_label} project skill",
+                    "trigger": "matching prompt",
+                }
+            ],
+            [
+                {
+                    "agent_playbook_id": f"agent-{self.host_label}",
+                    "content": f"{self.host_label} shared skill",
+                }
+            ],
+            [
+                {
+                    "profile_id": f"profile-{self.host_label}",
+                    "content": f"{self.host_label} preference",
+                }
+            ],
+        )
+
+    def publish(
+        self,
+        *,
+        session_id: str,
+        project_id: str,
+        interactions: list[dict[str, Any]],
+        force_extraction: bool = False,
+        override_learning_stall: bool = False,
+        skip_aggregation: bool = False,
+    ) -> bool:
+        from claude_smart import runtime
+
+        self.publish_calls.append(
+            {
+                "session_id": session_id,
+                "project_id": project_id,
+                "interactions": interactions,
+                "force_extraction": force_extraction,
+                "override_learning_stall": override_learning_stall,
+                "skip_aggregation": skip_aggregation,
+                "host": runtime.host(),
+                "agent_version": runtime.agent_version(),
+            }
+        )
+        return True
+
+
+@contextmanager
+def _redirected_stdio(payload: dict[str, Any]):
+    old_stdin = sys.stdin
+    old_stdout = sys.stdout
+    stdout = io.StringIO()
+    sys.stdin = io.StringIO(json.dumps(payload))
+    sys.stdout = stdout
+    try:
+        yield stdout
+    finally:
+        sys.stdin = old_stdin
+        sys.stdout = old_stdout
+
+
+def _run_hook(host: str, event: str, payload: dict[str, Any]) -> dict[str, Any]:
+    from claude_smart import hook
+
+    with _redirected_stdio(payload) as stdout:
+        assert hook.main([host, event]) == 0
+    output = stdout.getvalue().strip()
+    assert output, f"{host} {event} produced no hook response"
+    return json.loads(output)
+
+
+def _claude_code_transcript(path: Path, *, assistant_text: str) -> Path:
+    transcript = path / "claude-code-transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": {"content": "Use memory"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": assistant_text}]
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    return transcript
+
+
+def run_host_learning_happy_path(
+    host: str,
+    *,
+    work_root: Path,
+    expected_plugin_root: Path | None = None,
+    expected_state_dir: Path | None = None,
+) -> dict[str, Any]:
+    import claude_smart
+    from claude_smart import context_inject, publish, runtime, state
+    from claude_smart.events import session_start
+
+    loaded_from = Path(claude_smart.__file__).resolve()
+    if expected_plugin_root is not None:
+        expected_src = (expected_plugin_root / "src").resolve()
+        try:
+            loaded_from.relative_to(expected_src)
+        except ValueError as exc:
+            raise AssertionError(
+                f"loaded {loaded_from}, expected installed plugin root {expected_src}"
+            ) from exc
+
+    fake_reflexio = FakeReflexioAdapter(host_label=host)
+    original_context_adapter = context_inject.Adapter
+    original_publish_adapter = publish.Adapter
+    original_session_start_adapter = session_start._adapter
+    previous_host = runtime.host()
+    context_inject.Adapter = lambda: fake_reflexio
+    publish.Adapter = lambda: fake_reflexio
+    session_start._adapter = lambda: fake_reflexio
+    try:
+        project = work_root / f"{host}-learning-e2e-project"
+        project.mkdir(parents=True, exist_ok=True)
+        session_id = f"learning-session-{host}"
+        prompt = f"Use learned context for {host}"
+        assistant_text = (
+            f"{host} final answer\n\n"
+            f"✨ claude-smart rule applied: [{host} project skill]"
+            "(http://localhost:3001/rules/s2-user)"
+        )
+
+        session_start_output = _run_hook(
+            host,
+            "session-start",
+            {"session_id": session_id, "cwd": str(project)},
+        )
+        assert session_start_output["continue"] is True
+
+        user_prompt_output = _run_hook(
+            host,
+            "user-prompt",
+            {"session_id": session_id, "cwd": str(project), "prompt": prompt},
+        )
+        additional_context = user_prompt_output["hookSpecificOutput"][
+            "additionalContext"
+        ]
+        assert f"{host} project skill" in additional_context
+        assert f"{host} shared skill" in additional_context
+        assert f"{host} preference" in additional_context
+        assert "claude-smart rule applied" in additional_context
+
+        post_tool_output = _run_hook(
+            host,
+            "post-tool",
+            {
+                "session_id": session_id,
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo ok"},
+                "tool_response": {"stdout": "ok"},
+            },
+        )
+        assert post_tool_output["continue"] is True
+
+        stop_payload: dict[str, Any] = {"session_id": session_id, "cwd": str(project)}
+        if host == runtime.HOST_CLAUDE_CODE:
+            stop_payload["transcript_path"] = str(
+                _claude_code_transcript(project, assistant_text=assistant_text)
+            )
+        else:
+            stop_payload["last_assistant_message"] = assistant_text
+
+        stop_output = _run_hook(host, "stop", stop_payload)
+        assert stop_output["continue"] is True
+
+        assert fake_reflexio.extraction_defaults == [
+            {"window_size": 5, "stride_size": 3}
+        ]
+        assert fake_reflexio.search_calls == [
+            {
+                "project_id": project.name,
+                "query": prompt,
+                "top_k": 3,
+                "host": host,
+            }
+        ]
+        assert len(fake_reflexio.publish_calls) == 1
+        publish_call = fake_reflexio.publish_calls[0]
+        assert publish_call["session_id"] == session_id
+        assert publish_call["project_id"] == project.name
+        assert publish_call["force_extraction"] is False
+        assert publish_call["skip_aggregation"] is False
+        assert publish_call["host"] == host
+        assert publish_call["agent_version"] == runtime.HOST_CLAUDE_CODE
+
+        interactions = publish_call["interactions"]
+        assert [item["role"] for item in interactions] == ["User", "Assistant"]
+        assert interactions[0]["content"] == prompt
+        assert interactions[1]["content"] == assistant_text
+        assert interactions[1]["tools_used"] == [
+            {
+                "tool_name": "Bash",
+                "status": "success",
+                "tool_data": {"input": {"command": "echo ok"}, "output": "ok"},
+            }
+        ]
+        assert interactions[1]["citations"] == [
+            {
+                "kind": "playbook",
+                "real_id": f"user-{host}",
+                "tag": "s2-user",
+                "title": f"{host} project skill",
+            }
+        ]
+
+        _, unpublished = state.unpublished_slice(state.read_all(session_id))
+        assert unpublished == []
+        assert state.session_path(session_id).exists()
+        if expected_state_dir is not None:
+            assert expected_state_dir in state.session_path(session_id).parents
+        return {
+            "host": host,
+            "loaded_from": str(loaded_from),
+            "session_path": str(state.session_path(session_id)),
+            "published": len(interactions),
+        }
+    finally:
+        context_inject.Adapter = original_context_adapter
+        publish.Adapter = original_publish_adapter
+        session_start._adapter = original_session_start_adapter
+        runtime.set_host(previous_host)

--- a/tests/host_learning_harness.py
+++ b/tests/host_learning_harness.py
@@ -151,7 +151,7 @@ def run_host_learning_happy_path(
     expected_state_dir: Path | None = None,
 ) -> dict[str, Any]:
     import claude_smart
-    from claude_smart import context_inject, publish, runtime, state
+    from claude_smart import context_inject, cs_cite, publish, runtime, state
     from claude_smart.events import session_start
 
     loaded_from = Path(claude_smart.__file__).resolve()
@@ -177,11 +177,11 @@ def run_host_learning_happy_path(
         project.mkdir(parents=True, exist_ok=True)
         session_id = f"learning-session-{host}"
         prompt = f"Use learned context for {host}"
-        assistant_text = (
-            f"{host} final answer\n\n"
-            f"✨ claude-smart rule applied: [{host} project skill]"
-            "(http://localhost:3001/rules/s2-user)"
+        citation_marker = cs_cite.build_marker(
+            f"[{host} project skill](http://localhost:3001/rules/s2-user)",
+            "markdown",
         )
+        assistant_text = f"{host} final answer\n\n{citation_marker}"
 
         session_start_output = _run_hook(
             host,
@@ -201,7 +201,9 @@ def run_host_learning_happy_path(
         assert f"{host} project skill" in additional_context
         assert f"{host} shared skill" in additional_context
         assert f"{host} preference" in additional_context
-        assert "claude-smart rule applied" in additional_context
+        assert cs_cite.MARKER_PREFIX in additional_context
+        assert cs_cite.marker_attribution("markdown") in additional_context
+        assert "✨ N claude-smart learnings applied" not in additional_context
 
         post_tool_output = _run_hook(
             host,

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -3,8 +3,8 @@
 #
 # Simulates a fresh user environment: sandboxed HOME, no prior reflexio
 # state, no prior claude-smart state. Exercises the two hook-driven
-# long-lived services (backend on :8071, dashboard on :3001) and asserts
-# they come up healthy.
+# long-lived services (backend on :8071, embedding service on :8072, dashboard
+# on :3001) and asserts they come up healthy.
 #
 # Assumes a working install environment: uv, node, npm, python3 already
 # on PATH. The GitHub Actions matrix controls the node version; uv is
@@ -29,6 +29,7 @@ REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 PLUGIN_ROOT="$REPO_ROOT/plugin"
 
 BACKEND_PORT=8071
+EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"
 DASHBOARD_PORT=3001
 
 # Sandbox HOME so real ~/.reflexio, ~/.claude-smart, ~/.claude stay
@@ -178,6 +179,12 @@ stage_backend() {
   log "backend: polling http://127.0.0.1:$BACKEND_PORT/health (20s)"
   if ! poll_200 "http://127.0.0.1:$BACKEND_PORT/health" 20; then
     fail "backend /health did not return 200 within 20s"
+  fi
+  if [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}" = "1" ]; then
+    log "backend: polling http://127.0.0.1:$EMBEDDING_PORT/health (120s)"
+    if ! poll_200 "http://127.0.0.1:$EMBEDDING_PORT/health" 120; then
+      fail "embedding service /health did not return 200 within 120s"
+    fi
   fi
   log "backend: ok"
 }

--- a/tests/test_host_integration_e2e.py
+++ b/tests/test_host_integration_e2e.py
@@ -1,0 +1,247 @@
+"""Contained happy-path E2E coverage for host hook integration."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest  # type: ignore[reportMissingImports]
+
+from claude_smart import context_inject, hook, publish, runtime, state
+from claude_smart.events import session_start
+
+
+@dataclass
+class _FakeReflexioAdapter:
+    host_label: str
+    url: str = "http://localhost:8071/"
+    search_calls: list[dict[str, Any]] = field(default_factory=list)
+    publish_calls: list[dict[str, Any]] = field(default_factory=list)
+    extraction_defaults: list[dict[str, int]] = field(default_factory=list)
+
+    def fetch_stall_state(self) -> None:
+        return None
+
+    def apply_extraction_defaults(self, *, window_size: int, stride_size: int) -> bool:
+        self.extraction_defaults.append(
+            {"window_size": window_size, "stride_size": stride_size}
+        )
+        return True
+
+    def apply_optimizer_defaults(
+        self, *, script_path: str, timeout_seconds: int = 300
+    ) -> bool:
+        del script_path, timeout_seconds
+        return True
+
+    def search_all(
+        self, *, project_id: str, query: str, top_k: int
+    ) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
+        self.search_calls.append(
+            {
+                "project_id": project_id,
+                "query": query,
+                "top_k": top_k,
+                "host": runtime.host(),
+            }
+        )
+        return (
+            [
+                {
+                    "user_playbook_id": f"user-{self.host_label}",
+                    "content": f"{self.host_label} project skill",
+                    "trigger": "matching prompt",
+                }
+            ],
+            [
+                {
+                    "agent_playbook_id": f"agent-{self.host_label}",
+                    "content": f"{self.host_label} shared skill",
+                }
+            ],
+            [
+                {
+                    "profile_id": f"profile-{self.host_label}",
+                    "content": f"{self.host_label} preference",
+                }
+            ],
+        )
+
+    def publish(
+        self,
+        *,
+        session_id: str,
+        project_id: str,
+        interactions: list[dict[str, Any]],
+        force_extraction: bool = False,
+        override_learning_stall: bool = False,
+        skip_aggregation: bool = False,
+    ) -> bool:
+        self.publish_calls.append(
+            {
+                "session_id": session_id,
+                "project_id": project_id,
+                "interactions": interactions,
+                "force_extraction": force_extraction,
+                "override_learning_stall": override_learning_stall,
+                "skip_aggregation": skip_aggregation,
+                "host": runtime.host(),
+                "agent_version": runtime.agent_version(),
+            }
+        )
+        return True
+
+
+def _install_fake_reflexio(monkeypatch: pytest.MonkeyPatch, fake: _FakeReflexioAdapter) -> None:
+    monkeypatch.setattr(context_inject, "Adapter", lambda: fake)
+    monkeypatch.setattr(publish, "Adapter", lambda: fake)
+    monkeypatch.setattr(session_start, "_adapter", lambda: fake)
+
+
+def _run_hook(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    host: str,
+    event: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    assert hook.main([host, event]) == 0
+
+    output = stdout.getvalue().strip()
+    assert output
+    return json.loads(output)
+
+
+def _claude_code_transcript(tmp_path: Path, *, assistant_text: str) -> Path:
+    transcript = tmp_path / "claude-code-transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": {"content": "Use memory"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": assistant_text}]
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    return transcript
+
+
+@pytest.mark.parametrize(
+    "host",
+    [runtime.HOST_CLAUDE_CODE, runtime.HOST_CODEX, runtime.HOST_OPENCODE],
+)
+def test_host_happy_path_retrieves_context_buffers_tools_and_publishes(
+    host: str,
+    monkeypatch: pytest.MonkeyPatch,
+    session_dir: Path,
+    tmp_path: Path,
+) -> None:
+    fake_reflexio = _FakeReflexioAdapter(host_label=host)
+    _install_fake_reflexio(monkeypatch, fake_reflexio)
+    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", str(tmp_path / "hook.log"))
+    monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
+
+    project = tmp_path / f"{host}-project"
+    project.mkdir()
+    session_id = f"session-{host}"
+    prompt = f"Use learned context for {host}"
+    assistant_text = f"{host} final answer"
+
+    session_start_output = _run_hook(
+        monkeypatch,
+        host=host,
+        event="session-start",
+        payload={"session_id": session_id, "cwd": str(project)},
+    )
+    assert session_start_output["continue"] is True
+
+    user_prompt_output = _run_hook(
+        monkeypatch,
+        host=host,
+        event="user-prompt",
+        payload={"session_id": session_id, "cwd": str(project), "prompt": prompt},
+    )
+    additional_context = user_prompt_output["hookSpecificOutput"]["additionalContext"]
+    assert f"{host} project skill" in additional_context
+    assert f"{host} shared skill" in additional_context
+    assert f"{host} preference" in additional_context
+
+    post_tool_output = _run_hook(
+        monkeypatch,
+        host=host,
+        event="post-tool",
+        payload={
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo ok"},
+            "tool_response": {"stdout": "ok"},
+        },
+    )
+    assert post_tool_output["continue"] is True
+
+    stop_payload: dict[str, Any] = {"session_id": session_id, "cwd": str(project)}
+    if host == runtime.HOST_CLAUDE_CODE:
+        stop_payload["transcript_path"] = str(
+            _claude_code_transcript(tmp_path, assistant_text=assistant_text)
+        )
+    else:
+        stop_payload["last_assistant_message"] = assistant_text
+
+    stop_output = _run_hook(
+        monkeypatch,
+        host=host,
+        event="stop",
+        payload=stop_payload,
+    )
+    assert stop_output["continue"] is True
+
+    assert fake_reflexio.extraction_defaults == [
+        {"window_size": 5, "stride_size": 3}
+    ]
+    assert fake_reflexio.search_calls == [
+        {
+            "project_id": project.name,
+            "query": prompt,
+            "top_k": 3,
+            "host": host,
+        }
+    ]
+    assert len(fake_reflexio.publish_calls) == 1
+    publish_call = fake_reflexio.publish_calls[0]
+    assert publish_call["session_id"] == session_id
+    assert publish_call["project_id"] == project.name
+    assert publish_call["force_extraction"] is False
+    assert publish_call["skip_aggregation"] is False
+    assert publish_call["host"] == host
+    assert publish_call["agent_version"] == runtime.HOST_CLAUDE_CODE
+
+    interactions = publish_call["interactions"]
+    assert [item["role"] for item in interactions] == ["User", "Assistant"]
+    assert interactions[0]["content"] == prompt
+    assert interactions[1]["content"] == assistant_text
+    assert interactions[1]["tools_used"] == [
+        {
+            "tool_name": "Bash",
+            "status": "success",
+            "tool_data": {"input": {"command": "echo ok"}, "output": "ok"},
+        }
+    ]
+
+    _, unpublished = state.unpublished_slice(state.read_all(session_id))
+    assert unpublished == []
+    assert Path(session_dir) in state.session_path(session_id).parents

--- a/tests/test_host_integration_e2e.py
+++ b/tests/test_host_integration_e2e.py
@@ -2,246 +2,25 @@
 
 from __future__ import annotations
 
-import io
-import json
-import sys
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
 import pytest  # type: ignore[reportMissingImports]
 
-from claude_smart import context_inject, hook, publish, runtime, state
-from claude_smart.events import session_start
-
-
-@dataclass
-class _FakeReflexioAdapter:
-    host_label: str
-    url: str = "http://localhost:8071/"
-    search_calls: list[dict[str, Any]] = field(default_factory=list)
-    publish_calls: list[dict[str, Any]] = field(default_factory=list)
-    extraction_defaults: list[dict[str, int]] = field(default_factory=list)
-
-    def fetch_stall_state(self) -> None:
-        return None
-
-    def apply_extraction_defaults(self, *, window_size: int, stride_size: int) -> bool:
-        self.extraction_defaults.append(
-            {"window_size": window_size, "stride_size": stride_size}
-        )
-        return True
-
-    def apply_optimizer_defaults(
-        self, *, script_path: str, timeout_seconds: int = 300
-    ) -> bool:
-        del script_path, timeout_seconds
-        return True
-
-    def search_all(
-        self, *, project_id: str, query: str, top_k: int
-    ) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
-        self.search_calls.append(
-            {
-                "project_id": project_id,
-                "query": query,
-                "top_k": top_k,
-                "host": runtime.host(),
-            }
-        )
-        return (
-            [
-                {
-                    "user_playbook_id": f"user-{self.host_label}",
-                    "content": f"{self.host_label} project skill",
-                    "trigger": "matching prompt",
-                }
-            ],
-            [
-                {
-                    "agent_playbook_id": f"agent-{self.host_label}",
-                    "content": f"{self.host_label} shared skill",
-                }
-            ],
-            [
-                {
-                    "profile_id": f"profile-{self.host_label}",
-                    "content": f"{self.host_label} preference",
-                }
-            ],
-        )
-
-    def publish(
-        self,
-        *,
-        session_id: str,
-        project_id: str,
-        interactions: list[dict[str, Any]],
-        force_extraction: bool = False,
-        override_learning_stall: bool = False,
-        skip_aggregation: bool = False,
-    ) -> bool:
-        self.publish_calls.append(
-            {
-                "session_id": session_id,
-                "project_id": project_id,
-                "interactions": interactions,
-                "force_extraction": force_extraction,
-                "override_learning_stall": override_learning_stall,
-                "skip_aggregation": skip_aggregation,
-                "host": runtime.host(),
-                "agent_version": runtime.agent_version(),
-            }
-        )
-        return True
-
-
-def _install_fake_reflexio(monkeypatch: pytest.MonkeyPatch, fake: _FakeReflexioAdapter) -> None:
-    monkeypatch.setattr(context_inject, "Adapter", lambda: fake)
-    monkeypatch.setattr(publish, "Adapter", lambda: fake)
-    monkeypatch.setattr(session_start, "_adapter", lambda: fake)
-
-
-def _run_hook(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    host: str,
-    event: str,
-    payload: dict[str, Any],
-) -> dict[str, Any]:
-    stdout = io.StringIO()
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
-    monkeypatch.setattr(sys, "stdout", stdout)
-
-    assert hook.main([host, event]) == 0
-
-    output = stdout.getvalue().strip()
-    assert output
-    return json.loads(output)
-
-
-def _claude_code_transcript(tmp_path: Path, *, assistant_text: str) -> Path:
-    transcript = tmp_path / "claude-code-transcript.jsonl"
-    transcript.write_text(
-        "\n".join(
-            [
-                json.dumps({"type": "user", "message": {"content": "Use memory"}}),
-                json.dumps(
-                    {
-                        "type": "assistant",
-                        "message": {
-                            "content": [{"type": "text", "text": assistant_text}]
-                        },
-                    }
-                ),
-            ]
-        )
-        + "\n"
-    )
-    return transcript
+from claude_smart import runtime
+from tests.host_learning_harness import run_host_learning_happy_path
 
 
 @pytest.mark.parametrize(
     "host",
     [runtime.HOST_CLAUDE_CODE, runtime.HOST_CODEX, runtime.HOST_OPENCODE],
 )
-def test_host_happy_path_retrieves_context_buffers_tools_and_publishes(
+def test_host_happy_path_applies_learning_buffers_tools_and_publishes(
     host: str,
-    monkeypatch: pytest.MonkeyPatch,
     session_dir: Path,
     tmp_path: Path,
 ) -> None:
-    fake_reflexio = _FakeReflexioAdapter(host_label=host)
-    _install_fake_reflexio(monkeypatch, fake_reflexio)
-    monkeypatch.setenv("CLAUDE_SMART_HOOK_LOG", str(tmp_path / "hook.log"))
-    monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
-
-    project = tmp_path / f"{host}-project"
-    project.mkdir()
-    session_id = f"session-{host}"
-    prompt = f"Use learned context for {host}"
-    assistant_text = f"{host} final answer"
-
-    session_start_output = _run_hook(
-        monkeypatch,
-        host=host,
-        event="session-start",
-        payload={"session_id": session_id, "cwd": str(project)},
+    run_host_learning_happy_path(
+        host,
+        work_root=tmp_path,
+        expected_state_dir=session_dir,
     )
-    assert session_start_output["continue"] is True
-
-    user_prompt_output = _run_hook(
-        monkeypatch,
-        host=host,
-        event="user-prompt",
-        payload={"session_id": session_id, "cwd": str(project), "prompt": prompt},
-    )
-    additional_context = user_prompt_output["hookSpecificOutput"]["additionalContext"]
-    assert f"{host} project skill" in additional_context
-    assert f"{host} shared skill" in additional_context
-    assert f"{host} preference" in additional_context
-
-    post_tool_output = _run_hook(
-        monkeypatch,
-        host=host,
-        event="post-tool",
-        payload={
-            "session_id": session_id,
-            "tool_name": "Bash",
-            "tool_input": {"command": "echo ok"},
-            "tool_response": {"stdout": "ok"},
-        },
-    )
-    assert post_tool_output["continue"] is True
-
-    stop_payload: dict[str, Any] = {"session_id": session_id, "cwd": str(project)}
-    if host == runtime.HOST_CLAUDE_CODE:
-        stop_payload["transcript_path"] = str(
-            _claude_code_transcript(tmp_path, assistant_text=assistant_text)
-        )
-    else:
-        stop_payload["last_assistant_message"] = assistant_text
-
-    stop_output = _run_hook(
-        monkeypatch,
-        host=host,
-        event="stop",
-        payload=stop_payload,
-    )
-    assert stop_output["continue"] is True
-
-    assert fake_reflexio.extraction_defaults == [
-        {"window_size": 5, "stride_size": 3}
-    ]
-    assert fake_reflexio.search_calls == [
-        {
-            "project_id": project.name,
-            "query": prompt,
-            "top_k": 3,
-            "host": host,
-        }
-    ]
-    assert len(fake_reflexio.publish_calls) == 1
-    publish_call = fake_reflexio.publish_calls[0]
-    assert publish_call["session_id"] == session_id
-    assert publish_call["project_id"] == project.name
-    assert publish_call["force_extraction"] is False
-    assert publish_call["skip_aggregation"] is False
-    assert publish_call["host"] == host
-    assert publish_call["agent_version"] == runtime.HOST_CLAUDE_CODE
-
-    interactions = publish_call["interactions"]
-    assert [item["role"] for item in interactions] == ["User", "Assistant"]
-    assert interactions[0]["content"] == prompt
-    assert interactions[1]["content"] == assistant_text
-    assert interactions[1]["tools_used"] == [
-        {
-            "tool_name": "Bash",
-            "status": "success",
-            "tool_data": {"input": {"command": "echo ok"}, "output": "ok"},
-        }
-    ]
-
-    _, unpublished = state.unpublished_slice(state.read_all(session_id))
-    assert unpublished == []
-    assert Path(session_dir) in state.session_path(session_id).parents

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -75,7 +76,7 @@ def _write_bootstrap_uv(path: Path, *, mode: str) -> None:
         'printf "uv %s\\n" "$*" >> "$HOME/uv.log"\n'
         "create_python() {\n"
         '  mkdir -p "$PWD/.venv/bin"\n'
-        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        f'  printf "#!/bin/sh\\nexec {shlex.quote(sys.executable)} \\"\\$@\\"\\n" > "$PWD/.venv/bin/python"\n'
         '  chmod +x "$PWD/.venv/bin/python"\n'
         "}\n"
         'case "$*" in\n'
@@ -2504,14 +2505,210 @@ process.stdin.on("data", (chunk) => {
     )
 
 
+def _write_fake_claude_installer(path: Path) -> None:
+    _write_executable(
+        path,
+        """#!/bin/sh
+set -eu
+printf 'claude %s\\n' "$*" >> "$HOME/claude.log"
+cmd="${1-} ${2-} ${3-}"
+
+if [ "$cmd" = "plugin marketplace add" ]; then
+  printf '%s\\n' "$4" > "$HOME/claude-marketplace-source"
+  exit 0
+fi
+
+if [ "$cmd" = "plugin install claude-smart@reflexioai" ]; then
+  source="$(cat "$HOME/claude-marketplace-source")"
+  version="$(awk -F'"' '/^version =/{print $2; exit}' "$source/plugin/pyproject.toml")"
+  dest="$HOME/.claude/plugins/cache/reflexioai/claude-smart/$version"
+  rm -rf "$dest"
+  mkdir -p "$(dirname "$dest")"
+  cp -R "$source/plugin" "$dest"
+  exit 0
+fi
+
+exit 0
+""",
+    )
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _npm_install_global_tarball(tarball: Path, *, prefix: Path, env: dict[str, str]) -> None:
+    npm = shutil.which("npm")
+    if not npm:
+        pytest.skip("npm is required for package install smoke tests")
+    result = subprocess.run(
+        [
+            npm,
+            "install",
+            "-g",
+            "--prefix",
+            str(prefix),
+            "--ignore-scripts",
+            "--audit=false",
+            "--fund=false",
+            str(tarball),
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _assert_matching_smart_install_hash(
+    host_plugin_root: Path, installed_package: Path
+) -> None:
+    assert _sha256(host_plugin_root / "scripts" / "smart-install.sh") == _sha256(
+        installed_package / "plugin" / "scripts" / "smart-install.sh"
+    )
+
+
+def _assert_installed_host_learning_e2e(
+    host_plugin_root: Path,
+    *,
+    host: str,
+    home: Path,
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / f"{host}-installed-learning-e2e.py"
+    script.write_text(
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "from tests.host_learning_harness import run_host_learning_happy_path\n"
+        "result = run_host_learning_happy_path(\n"
+        "    sys.argv[2],\n"
+        "    work_root=Path(os.environ['HOME']),\n"
+        "    expected_plugin_root=Path(sys.argv[1]),\n"
+        "    expected_state_dir=Path(os.environ['CLAUDE_SMART_STATE_DIR']),\n"
+        ")\n"
+        "print(json.dumps(result))\n"
+    )
+
+    env = os.environ.copy()
+    pythonpath_entries = [str(host_plugin_root / "src"), str(REPO_ROOT)]
+    if env.get("PYTHONPATH"):
+        pythonpath_entries.append(env["PYTHONPATH"])
+    env.update(
+        {
+            "HOME": str(home),
+            "PYTHONPATH": os.pathsep.join(pythonpath_entries),
+            "CLAUDE_SMART_STATE_DIR": str(home / ".claude-smart" / f"{host}-sessions"),
+            "CLAUDE_SMART_HOOK_LOG": str(
+                home / ".claude-smart" / f"{host}-hook.log"
+            ),
+            "CLAUDE_SMART_ENABLE_OPTIMIZER": "0",
+            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
+            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
+        }
+    )
+    for key in ["REFLEXIO_URL", "REFLEXIO_API_KEY", "REFLEXIO_USER_ID"]:
+        env.pop(key, None)
+    venv_python = host_plugin_root / ".venv" / "bin" / "python"
+    assert venv_python.exists()
+    result = subprocess.run(
+        [str(venv_python), str(script), str(host_plugin_root), host],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_claude_code_fresh_tarball_install_prepares_matching_cache(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("tarball smoke uses POSIX npm bin paths")
+    node = shutil.which("node")
+    if not node or not shutil.which("npm"):
+        pytest.skip("node and npm are required for package install smoke tests")
+
+    tarball = _pack_claude_smart_tarball(tmp_path)
+    home = tmp_path / "home"
+    prefix = tmp_path / "npm-prefix"
+    fake_bin = tmp_path / "fake-bin"
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    project = tmp_path / "project"
+    for path in [home, prefix, fake_bin, private_node, uv_bin, project]:
+        path.mkdir(parents=True, exist_ok=True)
+    _write_fake_claude_installer(fake_bin / "claude")
+    _write_executable(private_node / "node", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        private_node / "npm",
+        '#!/bin/sh\nprintf "npm %s\\n" "$*" >> "$HOME/npm.log"\nexit 0\n',
+    )
+    _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
+
+    env = os.environ.copy()
+    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": test_path,
+            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
+            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
+            "CLAUDE_SMART_TEST_PLATFORM": "linux",
+            "CLAUDE_SMART_TEST_ARCH": "x64",
+        }
+    )
+    _npm_install_global_tarball(tarball, prefix=prefix, env=env)
+
+    result = subprocess.run(
+        [str(prefix / "bin" / "claude-smart"), "install"],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "claude-smart installed and dependencies are prepared." in result.stdout
+    assert not (home / ".claude-smart" / "install-failed").exists()
+
+    installed_package = prefix / "lib" / "node_modules" / "claude-smart"
+    version = next(
+        line.split("=", 1)[1].strip().strip('"')
+        for line in (installed_package / "plugin" / "pyproject.toml").read_text().splitlines()
+        if line.strip().startswith("version =")
+    )
+    cache_plugin = (
+        home / ".claude" / "plugins" / "cache" / "reflexioai" / "claude-smart" / version
+    )
+    assert (cache_plugin / "pyproject.toml").exists()
+    assert (cache_plugin / "scripts" / "hook_entry.sh").exists()
+    assert (cache_plugin / ".venv" / "bin" / "python").exists()
+    _assert_matching_smart_install_hash(cache_plugin, installed_package)
+    _assert_installed_host_learning_e2e(
+        cache_plugin,
+        host="claude-code",
+        home=home,
+        tmp_path=tmp_path,
+    )
+    assert (home / ".reflexio" / "plugin-root").resolve() == cache_plugin.resolve()
+    claude_log = (home / "claude.log").read_text()
+    assert f"claude plugin marketplace add {installed_package}" in claude_log
+    assert "claude plugin install claude-smart@reflexioai" in claude_log
+
+
 def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
     tmp_path: Path,
 ) -> None:
     if os.name == "nt":
         pytest.skip("tarball smoke uses POSIX npm bin paths")
     node = shutil.which("node")
-    npm = shutil.which("npm")
-    if not node or not npm:
+    if not node or not shutil.which("npm"):
         pytest.skip("node and npm are required for package install smoke tests")
 
     tarball = _pack_claude_smart_tarball(tmp_path)
@@ -2543,25 +2740,7 @@ def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
             "CLAUDE_SMART_TEST_ARCH": "x64",
         }
     )
-    install_result = subprocess.run(
-        [
-            npm,
-            "install",
-            "-g",
-            "--prefix",
-            str(prefix),
-            "--ignore-scripts",
-            "--audit=false",
-            "--fund=false",
-            str(tarball),
-        ],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=120,
-    )
-    assert install_result.returncode == 0, install_result.stderr
+    _npm_install_global_tarball(tarball, prefix=prefix, env=env)
 
     env["PATH"] = test_path
     result = subprocess.run(
@@ -2578,6 +2757,7 @@ def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
     assert "claude-smart Codex support is installed." in result.stdout
     assert not (home / ".claude-smart" / "install-failed").exists()
 
+    installed_package = prefix / "lib" / "node_modules" / "claude-smart"
     version = json.loads(
         (REPO_ROOT / "plugin" / ".codex-plugin" / "plugin.json").read_text()
     )["version"]
@@ -2598,7 +2778,14 @@ def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
         assert (root / "uv.lock").exists()
         assert (root / "scripts" / "hook_entry.sh").exists()
         assert (root / "opencode" / "dist" / "server.mjs").exists()
+        _assert_matching_smart_install_hash(root, installed_package)
     assert (cache_plugin / ".venv" / "bin" / "python").exists()
+    _assert_installed_host_learning_e2e(
+        cache_plugin,
+        host="codex",
+        home=home,
+        tmp_path=tmp_path,
+    )
 
     codex_config = (home / ".codex" / "config.toml").read_text()
     assert "hooks = true" in codex_config
@@ -2642,8 +2829,7 @@ def test_opencode_fresh_tarball_install_uses_local_file_plugin(
     if os.name == "nt":
         pytest.skip("tarball smoke uses POSIX npm bin paths")
     node = shutil.which("node")
-    npm = shutil.which("npm")
-    if not node or not npm:
+    if not node or not shutil.which("npm"):
         pytest.skip("node and npm are required for package install smoke tests")
 
     tarball = _pack_claude_smart_tarball(tmp_path)
@@ -2677,25 +2863,7 @@ def test_opencode_fresh_tarball_install_uses_local_file_plugin(
             "CLAUDE_SMART_TEST_ARCH": "x64",
         }
     )
-    install_result = subprocess.run(
-        [
-            npm,
-            "install",
-            "-g",
-            "--prefix",
-            str(prefix),
-            "--ignore-scripts",
-            "--audit=false",
-            "--fund=false",
-            str(tarball),
-        ],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=120,
-    )
-    assert install_result.returncode == 0, install_result.stderr
+    _npm_install_global_tarball(tarball, prefix=prefix, env=env)
 
     result = subprocess.run(
         [
@@ -2724,12 +2892,15 @@ def test_opencode_fresh_tarball_install_uses_local_file_plugin(
     local_package = Path(plugin_spec.removeprefix("file://"))
     installed_package = prefix / "lib" / "node_modules" / "claude-smart"
     local_script = local_package / "plugin" / "scripts" / "smart-install.sh"
-    installed_script = installed_package / "plugin" / "scripts" / "smart-install.sh"
     assert local_script.exists()
-    assert hashlib.sha256(local_script.read_bytes()).hexdigest() == hashlib.sha256(
-        installed_script.read_bytes()
-    ).hexdigest()
+    _assert_matching_smart_install_hash(local_package / "plugin", installed_package)
     assert (local_package / "plugin" / ".venv" / "bin" / "python").exists()
+    _assert_installed_host_learning_e2e(
+        local_package / "plugin",
+        host="opencode",
+        home=home,
+        tmp_path=tmp_path,
+    )
     assert not (home / ".claude-smart" / "install-failed").exists()
     assert "uv sync --locked --python 3.12 --quiet" in (home / "uv.log").read_text()
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -225,6 +225,7 @@ def _run_private_node_install(
     env = _isolated_env(tmp_path)
     env["CLAUDE_SMART_INSTALL_PRIVATE_NODE_ONLY"] = "1"
     env["CLAUDE_SMART_NODE_BASE_URL"] = base_url
+    env["CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS"] = "0"
     env["PATH"] = _minimal_path(
         tmp_path,
         "dirname",
@@ -235,13 +236,18 @@ def _run_private_node_install(
         "awk",
         "sed",
         "tar",
+        "gzip",
         "ln",
         "mv",
         "cp",
+        "sleep",
         "sha256sum",
         "shasum",
         "openssl",
     )
+    bin_dir = tmp_path / "bin"
+    _write_executable(bin_dir / "node", "#!/bin/sh\nprintf '%s\\n' 'v0.0.0'\n")
+    _write_executable(bin_dir / "npm", "#!/bin/sh\nexit 1\n")
     return subprocess.run(
         ["/bin/bash", str(SMART_INSTALL)],
         env=env,
@@ -3354,6 +3360,7 @@ def test_codex_claude_compat_accepts_stream_json_flags(tmp_path: Path) -> None:
         "  fi\n"
         "  shift || exit 1\n"
         "done\n"
+        "while IFS= read -r _line; do :; done\n"
         "printf 'stream reply' > \"$out\"\n"
     )
     codex.chmod(codex.stat().st_mode | stat.S_IXUSR)
@@ -3538,7 +3545,7 @@ def test_codex_hook_reflexio_env_file_overrides_stale_managed_process_env(
     uv.write_text(
         "#!/bin/sh\n"
         'printf \'{"hookSpecificOutput":{"hookEventName":"PostToolUse",'
-        '\\"additionalContext\\":\\"%s|%s|%s|%s\\"}}\\n\' '
+        '"additionalContext":"%s|%s|%s|%s"}}\\n\' '
         '"$REFLEXIO_URL" "$REFLEXIO_API_KEY" '
         '"$CLAUDE_SMART_USE_LOCAL_CLI" "$CLAUDE_SMART_READ_ONLY"\n'
     )

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -2562,6 +2562,66 @@ def _npm_install_global_tarball(tarball: Path, *, prefix: Path, env: dict[str, s
     assert result.returncode == 0, result.stderr
 
 
+def _install_opencode_tarball_fixture(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path, dict[str, str], subprocess.CompletedProcess[str]]:
+    if os.name == "nt":
+        pytest.skip("tarball smoke uses POSIX npm bin paths")
+    node = shutil.which("node")
+    if not node or not shutil.which("npm"):
+        pytest.skip("node and npm are required for package install smoke tests")
+
+    tarball = _pack_claude_smart_tarball(tmp_path)
+    home = tmp_path / "home"
+    prefix = tmp_path / "npm-prefix"
+    fake_bin = tmp_path / "fake-bin"
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    project = tmp_path / "project"
+    xdg = tmp_path / "xdg"
+    for path in [home, prefix, fake_bin, private_node, uv_bin, project, xdg]:
+        path.mkdir(parents=True, exist_ok=True)
+    _write_executable(fake_bin / "opencode", "#!/bin/sh\nexit 0\n")
+    _write_executable(private_node / "node", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        private_node / "npm",
+        '#!/bin/sh\nprintf "npm %s\\n" "$*" >> "$HOME/npm.log"\nexit 0\n',
+    )
+    _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
+
+    env = os.environ.copy()
+    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(xdg),
+            "PATH": test_path,
+            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
+            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
+            "CLAUDE_SMART_TEST_PLATFORM": "linux",
+            "CLAUDE_SMART_TEST_ARCH": "x64",
+        }
+    )
+    _npm_install_global_tarball(tarball, prefix=prefix, env=env)
+
+    result = subprocess.run(
+        [
+            str(prefix / "bin" / "claude-smart"),
+            "install",
+            "--host",
+            "opencode",
+            "--global",
+        ],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    return home, prefix, project, xdg, env, result
+
+
 def _assert_matching_smart_install_hash(
     host_plugin_root: Path, installed_package: Path
 ) -> None:
@@ -2826,59 +2886,8 @@ def test_package_tarball_ships_fresh_uv_lock(tmp_path: Path) -> None:
 def test_opencode_fresh_tarball_install_uses_local_file_plugin(
     tmp_path: Path,
 ) -> None:
-    if os.name == "nt":
-        pytest.skip("tarball smoke uses POSIX npm bin paths")
-    node = shutil.which("node")
-    if not node or not shutil.which("npm"):
-        pytest.skip("node and npm are required for package install smoke tests")
-
-    tarball = _pack_claude_smart_tarball(tmp_path)
-    home = tmp_path / "home"
-    prefix = tmp_path / "npm-prefix"
-    fake_bin = tmp_path / "fake-bin"
-    private_node = home / ".claude-smart" / "node" / "current" / "bin"
-    uv_bin = home / ".local" / "bin"
-    project = tmp_path / "project"
-    xdg = tmp_path / "xdg"
-    for path in [home, prefix, fake_bin, private_node, uv_bin, project, xdg]:
-        path.mkdir(parents=True, exist_ok=True)
-    _write_executable(fake_bin / "opencode", "#!/bin/sh\nexit 0\n")
-    _write_executable(private_node / "node", "#!/bin/sh\nexit 0\n")
-    _write_executable(
-        private_node / "npm",
-        '#!/bin/sh\nprintf "npm %s\\n" "$*" >> "$HOME/npm.log"\nexit 0\n',
-    )
-    _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
-
-    env = os.environ.copy()
-    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
-    env.update(
-        {
-            "HOME": str(home),
-            "XDG_CONFIG_HOME": str(xdg),
-            "PATH": test_path,
-            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
-            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
-            "CLAUDE_SMART_TEST_PLATFORM": "linux",
-            "CLAUDE_SMART_TEST_ARCH": "x64",
-        }
-    )
-    _npm_install_global_tarball(tarball, prefix=prefix, env=env)
-
-    result = subprocess.run(
-        [
-            str(prefix / "bin" / "claude-smart"),
-            "install",
-            "--host",
-            "opencode",
-            "--global",
-        ],
-        cwd=project,
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=120,
+    home, prefix, _project, xdg, _env, result = _install_opencode_tarball_fixture(
+        tmp_path
     )
 
     assert result.returncode == 0, result.stderr
@@ -2903,6 +2912,66 @@ def test_opencode_fresh_tarball_install_uses_local_file_plugin(
     )
     assert not (home / ".claude-smart" / "install-failed").exists()
     assert "uv sync --locked --python 3.12 --quiet" in (home / "uv.log").read_text()
+
+
+def test_opencode_fresh_tarball_uninstall_removes_plugin_and_keeps_data(
+    tmp_path: Path,
+) -> None:
+    home, prefix, project, xdg, env, install_result = (
+        _install_opencode_tarball_fixture(tmp_path)
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    config_path = xdg / "opencode" / "opencode.json"
+    plugin_spec = json.loads(config_path.read_text())["plugin"][0]
+    local_package = Path(plugin_spec.removeprefix("file://"))
+    assert local_package.exists()
+
+    session_file = home / ".claude-smart" / "sessions" / "keep.jsonl"
+    reflexio_data = home / ".reflexio" / "data" / "keep.sqlite"
+    session_file.parent.mkdir(parents=True)
+    reflexio_data.parent.mkdir(parents=True)
+    session_file.write_text("{}\n")
+    reflexio_data.write_text("keep\n")
+    config_path.write_text(
+        json.dumps(
+            {
+                "plugin": [
+                    "other-plugin",
+                    "claude-smart",
+                    plugin_spec,
+                ],
+                "theme": "system",
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [
+            str(prefix / "bin" / "claude-smart"),
+            "uninstall",
+            "--host",
+            "opencode",
+            "--global",
+        ],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Removed claude-smart OpenCode plugin entries" in result.stdout
+    assert json.loads(config_path.read_text()) == {
+        "plugin": ["other-plugin"],
+        "theme": "system",
+    }
+    assert not local_package.exists()
+    assert not (home / ".claude-smart" / "opencode").exists()
+    assert session_file.exists()
+    assert reflexio_data.exists()
 
 
 def test_node_installer_bootstraps_runtime_with_private_node_and_uv(

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -54,6 +54,60 @@ def _isolated_env(tmp_path: Path) -> dict[str, str]:
     return env
 
 
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _write_bootstrap_uv(path: Path, *, mode: str) -> None:
+    """Fake uv for bootstrap matrix tests.
+
+    Modes:
+    - fresh: locked sync succeeds and no lock refresh is expected.
+    - stale: locked sync fails, lock check fails, lock refresh + unlocked sync succeeds.
+    - non_lock_failure: locked sync fails, lock check passes, full locked retry fails.
+    """
+    assert mode in {"fresh", "stale", "non_lock_failure"}
+    _write_executable(
+        path,
+        "#!/bin/sh\n"
+        f"mode={mode!r}\n"
+        'printf "uv %s\\n" "$*" >> "$HOME/uv.log"\n'
+        "create_python() {\n"
+        '  mkdir -p "$PWD/.venv/bin"\n'
+        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        '  chmod +x "$PWD/.venv/bin/python"\n'
+        "}\n"
+        'case "$*" in\n'
+        '  "sync --locked --python 3.12 --quiet")\n'
+        '    if [ "$mode" = "fresh" ]; then create_python; exit 0; fi\n'
+        "    exit 1\n"
+        "    ;;\n"
+        '  "lock --check --python 3.12")\n'
+        '    if [ "$mode" = "stale" ]; then exit 1; fi\n'
+        "    exit 0\n"
+        "    ;;\n"
+        '  "lock --python 3.12")\n'
+        '    if [ "$mode" = "stale" ]; then printf "fresh\\n" > "$PWD/uv.lock"; exit 0; fi\n'
+        '    printf "unexpected lock refresh\\n" >&2\n'
+        "    exit 22\n"
+        "    ;;\n"
+        '  "sync --python 3.12 --quiet")\n'
+        '    if [ "$mode" = "stale" ]; then create_python; exit 0; fi\n'
+        '    printf "unexpected unlocked sync\\n" >&2\n'
+        "    exit 23\n"
+        "    ;;\n"
+        '  "sync --locked --python 3.12")\n'
+        '    if [ "$mode" = "non_lock_failure" ]; then exit 1; fi\n'
+        "    create_python\n"
+        "    exit 0\n"
+        "    ;;\n"
+        "esac\n"
+        'if [ "$1" = "pip" ]; then exit 0; fi\n'
+        "exit 0\n",
+    )
+
+
 def _claude_plugin_cache_version_dir(tmp_path: Path) -> Path:
     """Return the cache dir that real `claude plugin install` would populate.
 
@@ -1452,6 +1506,146 @@ def test_smart_install_installs_vendored_reflexio(tmp_path: Path) -> None:
     assert f"--reinstall --no-deps {vendor}" in uv_log
 
 
+def _prepare_smart_install_sync_fixture(
+    tmp_path: Path, *, mode: str
+) -> tuple[Path, Path, dict[str, str]]:
+    plugin_root = tmp_path / "plugin"
+    scripts = plugin_root / "scripts"
+    fake_bin = tmp_path / "bin"
+    scripts.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(SMART_INSTALL, scripts / "smart-install.sh")
+    shutil.copy2(LIB, scripts / "_lib.sh")
+    shutil.copy2(
+        REPO_ROOT / "plugin" / "scripts" / "ensure-plugin-root.sh",
+        scripts / "ensure-plugin-root.sh",
+    )
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    (plugin_root / "uv.lock").write_text("locked\n")
+    _write_bootstrap_uv(fake_bin / "uv", mode=mode)
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    return plugin_root, scripts / "smart-install.sh", env
+
+
+def test_smart_install_refreshes_stale_lock_before_retrying_sync(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    scripts = plugin_root / "scripts"
+    fake_bin = tmp_path / "bin"
+    scripts.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(SMART_INSTALL, scripts / "smart-install.sh")
+    shutil.copy2(LIB, scripts / "_lib.sh")
+    shutil.copy2(
+        REPO_ROOT / "plugin" / "scripts" / "ensure-plugin-root.sh",
+        scripts / "ensure-plugin-root.sh",
+    )
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    (plugin_root / "uv.lock").write_text("stale\n")
+
+    uv = fake_bin / "uv"
+    uv.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$HOME/uv.log"\n'
+        'if [ "$1 $2 $3" = "sync --locked --python" ]; then\n'
+        "  exit 1\n"
+        "fi\n"
+        'if [ "$1 $2 $3" = "lock --check --python" ]; then\n'
+        "  exit 1\n"
+        "fi\n"
+        'if [ "$1" = "lock" ]; then\n'
+        '  printf "fresh\\n" > "$PWD/uv.lock"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "sync" ]; then\n'
+        '  mkdir -p "$PWD/.venv/bin"\n'
+        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        '  chmod +x "$PWD/.venv/bin/python"\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+    env = _isolated_env(tmp_path)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(scripts / "smart-install.sh")],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "plugin/uv.lock is out of sync; refreshing local lockfile" in result.stderr
+    assert not (tmp_path / ".claude-smart" / "install-failed").exists()
+    assert (tmp_path / ".claude-smart" / "install-complete").exists()
+    assert (plugin_root / "uv.lock").read_text() == "fresh\n"
+    assert (tmp_path / "uv.log").read_text().splitlines()[:4] == [
+        "sync --locked --python 3.12 --quiet",
+        "lock --check --python 3.12",
+        "lock --python 3.12",
+        "sync --python 3.12 --quiet",
+    ]
+
+
+def test_smart_install_locked_sync_success_does_not_refresh_lock(
+    tmp_path: Path,
+) -> None:
+    plugin_root, smart_install, env = _prepare_smart_install_sync_fixture(
+        tmp_path, mode="fresh"
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(smart_install)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "plugin/uv.lock is out of sync" not in result.stderr
+    assert not (tmp_path / ".claude-smart" / "install-failed").exists()
+    assert (tmp_path / ".claude-smart" / "install-complete").exists()
+    assert (plugin_root / "uv.lock").read_text() == "locked\n"
+    assert (tmp_path / "uv.log").read_text().splitlines()[:1] == [
+        "uv sync --locked --python 3.12 --quiet",
+    ]
+
+
+def test_smart_install_non_lock_sync_failure_stays_strict(tmp_path: Path) -> None:
+    plugin_root, smart_install, env = _prepare_smart_install_sync_fixture(
+        tmp_path, mode="non_lock_failure"
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(smart_install)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    marker = tmp_path / ".claude-smart" / "install-failed"
+    assert result.returncode == 0
+    assert marker.exists()
+    assert "uv sync failed" in marker.read_text()
+    assert "plugin/uv.lock is out of sync" not in result.stderr
+    assert (plugin_root / "uv.lock").read_text() == "locked\n"
+    uv_lines = (tmp_path / "uv.log").read_text().splitlines()
+    assert uv_lines[:2] == [
+        "uv sync --locked --python 3.12 --quiet",
+        "uv lock --check --python 3.12",
+    ]
+    assert "uv lock --python 3.12" not in uv_lines
+    assert "uv sync --python 3.12 --quiet" not in uv_lines
+
+
 @pytest.mark.parametrize(
     "copy_dirname",
     [
@@ -2182,6 +2376,364 @@ def test_node_installer_does_not_treat_global_node_as_private_runtime(
     assert "Intel Mac is not supported" in result.stdout
 
 
+def _prepare_node_bootstrap_sync_fixture(
+    tmp_path: Path, *, mode: str
+) -> tuple[Path, Path, dict[str, str]]:
+    home = tmp_path / "home"
+    plugin_root = tmp_path / "plugin"
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    plugin_root.mkdir(parents=True)
+    private_node.mkdir(parents=True)
+    uv_bin.mkdir(parents=True)
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    (plugin_root / "uv.lock").write_text("locked\n")
+    _write_executable(private_node / "node", "#!/bin/sh\nexit 0\n")
+    _write_executable(private_node / "npm", "#!/bin/sh\nexit 0\n")
+    _write_bootstrap_uv(uv_bin / "uv", mode=mode)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "CLAUDE_SMART_TEST_PLATFORM": "darwin",
+            "CLAUDE_SMART_TEST_ARCH": "arm64",
+            "CLAUDE_SMART_TEST_RELEASE": "23.0.0",
+        }
+    )
+    return home, plugin_root, env
+
+
+def _run_node_bootstrap(
+    tmp_path: Path, *, mode: str
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for installer wrapper tests")
+    home, plugin_root, env = _prepare_node_bootstrap_sync_fixture(tmp_path, mode=mode)
+    script = (
+        f"const installer = require({json.dumps(str(NODE_INSTALLER))});"
+        f"installer.bootstrapPluginRuntime({json.dumps(str(plugin_root))}, "
+        "{ patchCodexHooks: false })"
+        ".then(() => console.log('done'))"
+        ".catch((err) => { console.error(err.message); process.exit(1); });"
+    )
+    result = subprocess.run(
+        [node, "-e", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    return result, home, plugin_root
+
+
+def _pack_claude_smart_tarball(tmp_path: Path) -> Path:
+    npm = shutil.which("npm")
+    if not npm:
+        pytest.skip("npm is required for package install smoke tests")
+    pack_dir = tmp_path / "pack"
+    pack_dir.mkdir()
+    result = subprocess.run(
+        [
+            npm,
+            "pack",
+            "--ignore-scripts",
+            "--pack-destination",
+            str(pack_dir),
+            str(REPO_ROOT),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    tarballs = sorted(pack_dir.glob("claude-smart-*.tgz"))
+    assert len(tarballs) == 1, result.stdout
+    return tarballs[0]
+
+
+def _write_fake_codex(path: Path) -> None:
+    _write_executable(
+        path,
+        """#!/usr/bin/env node
+const fs = require("fs");
+const home = process.env.HOME || ".";
+const args = process.argv.slice(2);
+fs.appendFileSync(`${home}/codex.log`, `codex ${args.join(" ")}\\n`);
+
+if (args[0] === "features" && args[1] === "enable") {
+  process.exit(1);
+}
+
+if (args[0] !== "app-server") {
+  process.exit(0);
+}
+
+process.stdin.setEncoding("utf8");
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) >= 0) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+    if (!message.id) continue;
+    if (message.method === "hooks/list") {
+      process.stdout.write(JSON.stringify({
+        id: message.id,
+        result: {
+          data: [{
+            hooks: [{
+              pluginId: "claude-smart@reflexioai",
+              key: "claude-smart@reflexioai:SessionStart:0",
+              currentHash: "hash-session-start"
+            }]
+          }]
+        }
+      }) + "\\n");
+    } else {
+      process.stdout.write(JSON.stringify({ id: message.id, result: {} }) + "\\n");
+    }
+  }
+});
+""",
+    )
+
+
+def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("tarball smoke uses POSIX npm bin paths")
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    if not node or not npm:
+        pytest.skip("node and npm are required for package install smoke tests")
+
+    tarball = _pack_claude_smart_tarball(tmp_path)
+    home = tmp_path / "home"
+    prefix = tmp_path / "npm-prefix"
+    fake_bin = tmp_path / "fake-bin"
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    project = tmp_path / "project"
+    for path in [home, prefix, fake_bin, private_node, uv_bin, project]:
+        path.mkdir(parents=True, exist_ok=True)
+    _write_fake_codex(fake_bin / "codex")
+    _write_executable(private_node / "node", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        private_node / "npm",
+        '#!/bin/sh\nprintf "npm %s\\n" "$*" >> "$HOME/npm.log"\nexit 0\n',
+    )
+    _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
+
+    env = os.environ.copy()
+    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": test_path,
+            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
+            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
+            "CLAUDE_SMART_TEST_PLATFORM": "linux",
+            "CLAUDE_SMART_TEST_ARCH": "x64",
+        }
+    )
+    install_result = subprocess.run(
+        [
+            npm,
+            "install",
+            "-g",
+            "--prefix",
+            str(prefix),
+            "--ignore-scripts",
+            "--audit=false",
+            "--fund=false",
+            str(tarball),
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    env["PATH"] = test_path
+    result = subprocess.run(
+        [str(prefix / "bin" / "claude-smart"), "install", "--host", "codex"],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "claude-smart Codex support is installed." in result.stdout
+    assert not (home / ".claude-smart" / "install-failed").exists()
+
+    version = json.loads(
+        (REPO_ROOT / "plugin" / ".codex-plugin" / "plugin.json").read_text()
+    )["version"]
+    marketplace_plugin = (
+        home / ".claude" / "plugins" / "marketplaces" / "reflexioai" / "plugin"
+    )
+    cache_plugin = (
+        home
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / version
+    )
+    for root in [marketplace_plugin, cache_plugin]:
+        assert (root / "pyproject.toml").exists()
+        assert (root / "uv.lock").exists()
+        assert (root / "scripts" / "hook_entry.sh").exists()
+        assert (root / "opencode" / "dist" / "server.mjs").exists()
+    assert (cache_plugin / ".venv" / "bin" / "python").exists()
+
+    codex_config = (home / ".codex" / "config.toml").read_text()
+    assert "hooks = true" in codex_config
+    assert "plugin_hooks = true" in codex_config
+    assert '[plugins."claude-smart@reflexioai"]' in codex_config
+    assert '[hooks.state."claude-smart@reflexioai:SessionStart:0"]' in codex_config
+    assert 'trusted_hash = "hash-session-start"' in codex_config
+    assert "uv sync --locked --python 3.12 --quiet" in (home / "uv.log").read_text()
+    codex_log = (home / "codex.log").read_text()
+    assert "codex plugin marketplace add" in codex_log
+    assert "codex features enable hooks" in codex_log
+    assert "codex features enable plugin_hooks" in codex_log
+
+
+def test_package_tarball_ships_fresh_uv_lock(tmp_path: Path) -> None:
+    uv = shutil.which("uv")
+    if not uv:
+        pytest.skip("uv is required for package lock smoke tests")
+
+    tarball = _pack_claude_smart_tarball(tmp_path)
+    extract_dir = tmp_path / "extract"
+    extract_dir.mkdir()
+    with tarfile.open(tarball) as archive:
+        archive.extractall(extract_dir)
+
+    result = subprocess.run(
+        [uv, "lock", "--check", "--python", "3.12", "--project", "plugin"],
+        cwd=extract_dir / "package",
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_opencode_fresh_tarball_install_uses_local_file_plugin(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("tarball smoke uses POSIX npm bin paths")
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    if not node or not npm:
+        pytest.skip("node and npm are required for package install smoke tests")
+
+    tarball = _pack_claude_smart_tarball(tmp_path)
+    home = tmp_path / "home"
+    prefix = tmp_path / "npm-prefix"
+    fake_bin = tmp_path / "fake-bin"
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    project = tmp_path / "project"
+    xdg = tmp_path / "xdg"
+    for path in [home, prefix, fake_bin, private_node, uv_bin, project, xdg]:
+        path.mkdir(parents=True, exist_ok=True)
+    _write_executable(fake_bin / "opencode", "#!/bin/sh\nexit 0\n")
+    _write_executable(private_node / "node", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        private_node / "npm",
+        '#!/bin/sh\nprintf "npm %s\\n" "$*" >> "$HOME/npm.log"\nexit 0\n',
+    )
+    _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
+
+    env = os.environ.copy()
+    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(xdg),
+            "PATH": test_path,
+            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
+            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
+            "CLAUDE_SMART_TEST_PLATFORM": "linux",
+            "CLAUDE_SMART_TEST_ARCH": "x64",
+        }
+    )
+    install_result = subprocess.run(
+        [
+            npm,
+            "install",
+            "-g",
+            "--prefix",
+            str(prefix),
+            "--ignore-scripts",
+            "--audit=false",
+            "--fund=false",
+            str(tarball),
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    result = subprocess.run(
+        [
+            str(prefix / "bin" / "claude-smart"),
+            "install",
+            "--host",
+            "opencode",
+            "--global",
+        ],
+        cwd=project,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "claude-smart OpenCode support is installed." in result.stdout
+    config = json.loads((xdg / "opencode" / "opencode.json").read_text())
+    assert len(config["plugin"]) == 1
+    plugin_spec = config["plugin"][0]
+    assert plugin_spec.startswith("file://")
+    assert plugin_spec != "claude-smart"
+
+    local_package = Path(plugin_spec.removeprefix("file://"))
+    installed_package = prefix / "lib" / "node_modules" / "claude-smart"
+    local_script = local_package / "plugin" / "scripts" / "smart-install.sh"
+    installed_script = installed_package / "plugin" / "scripts" / "smart-install.sh"
+    assert local_script.exists()
+    assert hashlib.sha256(local_script.read_bytes()).hexdigest() == hashlib.sha256(
+        installed_script.read_bytes()
+    ).hexdigest()
+    assert (local_package / "plugin" / ".venv" / "bin" / "python").exists()
+    assert not (home / ".claude-smart" / "install-failed").exists()
+    assert "uv sync --locked --python 3.12 --quiet" in (home / "uv.log").read_text()
+
+
 def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
     tmp_path: Path,
 ) -> None:
@@ -2332,6 +2884,114 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
             assert f'"{token}"' in cmd, f"index {idx} expected token {token!r}: {cmd}"
     user_prompt_cmd = parsed["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
     assert '"hook"' in user_prompt_cmd and '"user-prompt"' in user_prompt_cmd
+
+
+def test_node_installer_refreshes_stale_lock_before_retrying_sync(
+    tmp_path: Path,
+) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for installer wrapper tests")
+
+    home = tmp_path / "home"
+    plugin_root = tmp_path / "plugin"
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    plugin_root.mkdir(parents=True)
+    private_node.mkdir(parents=True)
+    uv_bin.mkdir(parents=True)
+    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
+    (plugin_root / "uv.lock").write_text("stale\n")
+    (private_node / "node").write_text("#!/bin/sh\nexit 0\n")
+    (private_node / "npm").write_text("#!/bin/sh\nexit 0\n")
+    (uv_bin / "uv").write_text(
+        "#!/bin/sh\n"
+        'printf "uv %s\\n" "$*" >> "$HOME/uv.log"\n'
+        'if [ "$1 $2 $3" = "sync --locked --python" ]; then\n'
+        "  exit 1\n"
+        "fi\n"
+        'if [ "$1 $2 $3" = "lock --check --python" ]; then\n'
+        "  exit 1\n"
+        "fi\n"
+        'if [ "$1" = "lock" ]; then\n'
+        '  printf "fresh\\n" > "$PWD/uv.lock"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "sync" ]; then\n'
+        '  mkdir -p "$PWD/.venv/bin"\n'
+        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        '  chmod +x "$PWD/.venv/bin/python"\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    for executable in [private_node / "node", private_node / "npm", uv_bin / "uv"]:
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+    script = (
+        f"const installer = require({json.dumps(str(NODE_INSTALLER))});"
+        f"installer.bootstrapPluginRuntime({json.dumps(str(plugin_root))}, "
+        "{ patchCodexHooks: false })"
+        ".then(() => console.log('done'))"
+        ".catch((err) => { console.error(err.message); process.exit(1); });"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "CLAUDE_SMART_TEST_PLATFORM": "darwin",
+            "CLAUDE_SMART_TEST_ARCH": "arm64",
+            "CLAUDE_SMART_TEST_RELEASE": "23.0.0",
+        }
+    )
+    result = subprocess.run(
+        [node, "-e", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "plugin/uv.lock is out of sync; refreshing local lockfile" in result.stderr
+    assert "done" in result.stdout
+    assert (plugin_root / "uv.lock").read_text() == "fresh\n"
+    assert (home / "uv.log").read_text().splitlines()[:4] == [
+        "uv sync --locked --python 3.12 --quiet",
+        "uv lock --check --python 3.12",
+        "uv lock --python 3.12",
+        "uv sync --python 3.12 --quiet",
+    ]
+
+
+def test_node_installer_locked_sync_success_does_not_refresh_lock(
+    tmp_path: Path,
+) -> None:
+    result, home, plugin_root = _run_node_bootstrap(tmp_path, mode="fresh")
+
+    assert result.returncode == 0, result.stderr
+    assert "plugin/uv.lock is out of sync" not in result.stderr
+    assert "done" in result.stdout
+    assert (plugin_root / "uv.lock").read_text() == "locked\n"
+    assert (home / "uv.log").read_text().splitlines()[:1] == [
+        "uv sync --locked --python 3.12 --quiet",
+    ]
+
+
+def test_node_installer_non_lock_sync_failure_stays_strict(tmp_path: Path) -> None:
+    result, home, plugin_root = _run_node_bootstrap(
+        tmp_path, mode="non_lock_failure"
+    )
+
+    assert result.returncode == 1
+    assert "uv sync failed" in result.stderr
+    assert "plugin/uv.lock is out of sync" not in result.stderr
+    assert (plugin_root / "uv.lock").read_text() == "locked\n"
+    assert (home / "uv.log").read_text().splitlines()[:3] == [
+        "uv sync --locked --python 3.12 --quiet",
+        "uv lock --check --python 3.12",
+        "uv sync --locked --python 3.12",
+    ]
 
 
 def test_node_installer_read_only_prunes_publish_hooks(tmp_path: Path) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1522,7 +1522,8 @@ def _prepare_smart_install_sync_fixture(
         scripts / "ensure-plugin-root.sh",
     )
     (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
-    (plugin_root / "uv.lock").write_text("locked\n")
+    lock_contents = "stale\n" if mode == "stale" else "locked\n"
+    (plugin_root / "uv.lock").write_text(lock_contents)
     _write_bootstrap_uv(fake_bin / "uv", mode=mode)
 
     env = _isolated_env(tmp_path)
@@ -1533,48 +1534,11 @@ def _prepare_smart_install_sync_fixture(
 def test_smart_install_refreshes_stale_lock_before_retrying_sync(
     tmp_path: Path,
 ) -> None:
-    plugin_root = tmp_path / "plugin"
-    scripts = plugin_root / "scripts"
-    fake_bin = tmp_path / "bin"
-    scripts.mkdir(parents=True)
-    fake_bin.mkdir()
-    shutil.copy2(SMART_INSTALL, scripts / "smart-install.sh")
-    shutil.copy2(LIB, scripts / "_lib.sh")
-    shutil.copy2(
-        REPO_ROOT / "plugin" / "scripts" / "ensure-plugin-root.sh",
-        scripts / "ensure-plugin-root.sh",
+    plugin_root, smart_install, env = _prepare_smart_install_sync_fixture(
+        tmp_path, mode="stale"
     )
-    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
-    (plugin_root / "uv.lock").write_text("stale\n")
-
-    uv = fake_bin / "uv"
-    uv.write_text(
-        "#!/bin/sh\n"
-        'printf "%s\\n" "$*" >> "$HOME/uv.log"\n'
-        'if [ "$1 $2 $3" = "sync --locked --python" ]; then\n'
-        "  exit 1\n"
-        "fi\n"
-        'if [ "$1 $2 $3" = "lock --check --python" ]; then\n'
-        "  exit 1\n"
-        "fi\n"
-        'if [ "$1" = "lock" ]; then\n'
-        '  printf "fresh\\n" > "$PWD/uv.lock"\n'
-        "  exit 0\n"
-        "fi\n"
-        'if [ "$1" = "sync" ]; then\n'
-        '  mkdir -p "$PWD/.venv/bin"\n'
-        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
-        '  chmod +x "$PWD/.venv/bin/python"\n'
-        "  exit 0\n"
-        "fi\n"
-        "exit 0\n"
-    )
-    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
-
-    env = _isolated_env(tmp_path)
-    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     result = subprocess.run(
-        ["/bin/bash", "--noprofile", "--norc", str(scripts / "smart-install.sh")],
+        ["/bin/bash", "--noprofile", "--norc", str(smart_install)],
         env=env,
         text=True,
         capture_output=True,
@@ -1587,10 +1551,10 @@ def test_smart_install_refreshes_stale_lock_before_retrying_sync(
     assert (tmp_path / ".claude-smart" / "install-complete").exists()
     assert (plugin_root / "uv.lock").read_text() == "fresh\n"
     assert (tmp_path / "uv.log").read_text().splitlines()[:4] == [
-        "sync --locked --python 3.12 --quiet",
-        "lock --check --python 3.12",
-        "lock --python 3.12",
-        "sync --python 3.12 --quiet",
+        "uv sync --locked --python 3.12 --quiet",
+        "uv lock --check --python 3.12",
+        "uv lock --python 3.12",
+        "uv sync --python 3.12 --quiet",
     ]
 
 
@@ -2388,7 +2352,8 @@ def _prepare_node_bootstrap_sync_fixture(
     private_node.mkdir(parents=True)
     uv_bin.mkdir(parents=True)
     (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
-    (plugin_root / "uv.lock").write_text("locked\n")
+    lock_contents = "stale\n" if mode == "stale" else "locked\n"
+    (plugin_root / "uv.lock").write_text(lock_contents)
     _write_executable(private_node / "node", "#!/bin/sh\nexit 0\n")
     _write_executable(private_node / "npm", "#!/bin/sh\nexit 0\n")
     _write_bootstrap_uv(uv_bin / "uv", mode=mode)
@@ -3129,68 +3094,7 @@ def test_node_installer_bootstraps_runtime_with_private_node_and_uv(
 def test_node_installer_refreshes_stale_lock_before_retrying_sync(
     tmp_path: Path,
 ) -> None:
-    node = shutil.which("node")
-    if not node:
-        pytest.skip("node is required for installer wrapper tests")
-
-    home = tmp_path / "home"
-    plugin_root = tmp_path / "plugin"
-    private_node = home / ".claude-smart" / "node" / "current" / "bin"
-    uv_bin = home / ".local" / "bin"
-    plugin_root.mkdir(parents=True)
-    private_node.mkdir(parents=True)
-    uv_bin.mkdir(parents=True)
-    (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
-    (plugin_root / "uv.lock").write_text("stale\n")
-    (private_node / "node").write_text("#!/bin/sh\nexit 0\n")
-    (private_node / "npm").write_text("#!/bin/sh\nexit 0\n")
-    (uv_bin / "uv").write_text(
-        "#!/bin/sh\n"
-        'printf "uv %s\\n" "$*" >> "$HOME/uv.log"\n'
-        'if [ "$1 $2 $3" = "sync --locked --python" ]; then\n'
-        "  exit 1\n"
-        "fi\n"
-        'if [ "$1 $2 $3" = "lock --check --python" ]; then\n'
-        "  exit 1\n"
-        "fi\n"
-        'if [ "$1" = "lock" ]; then\n'
-        '  printf "fresh\\n" > "$PWD/uv.lock"\n'
-        "  exit 0\n"
-        "fi\n"
-        'if [ "$1" = "sync" ]; then\n'
-        '  mkdir -p "$PWD/.venv/bin"\n'
-        '  printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
-        '  chmod +x "$PWD/.venv/bin/python"\n'
-        "  exit 0\n"
-        "fi\n"
-        "exit 0\n"
-    )
-    for executable in [private_node / "node", private_node / "npm", uv_bin / "uv"]:
-        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
-
-    script = (
-        f"const installer = require({json.dumps(str(NODE_INSTALLER))});"
-        f"installer.bootstrapPluginRuntime({json.dumps(str(plugin_root))}, "
-        "{ patchCodexHooks: false })"
-        ".then(() => console.log('done'))"
-        ".catch((err) => { console.error(err.message); process.exit(1); });"
-    )
-    env = os.environ.copy()
-    env.update(
-        {
-            "HOME": str(home),
-            "CLAUDE_SMART_TEST_PLATFORM": "darwin",
-            "CLAUDE_SMART_TEST_ARCH": "arm64",
-            "CLAUDE_SMART_TEST_RELEASE": "23.0.0",
-        }
-    )
-    result = subprocess.run(
-        [node, "-e", script],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    result, home, plugin_root = _run_node_bootstrap(tmp_path, mode="stale")
 
     assert result.returncode == 0, result.stderr
     assert "plugin/uv.lock is out of sync; refreshing local lockfile" in result.stderr

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -36,7 +36,9 @@ def _read_json(path: str) -> dict[str, Any]:
     return json.loads((REPO_ROOT / path).read_text())
 
 
-def _run_node_script(script: str, *args: str) -> subprocess.CompletedProcess[str] | None:
+def _run_node_script(
+    script: str, *args: str, timeout: float | None = 120
+) -> subprocess.CompletedProcess[str] | None:
     node = shutil_which_node()
     if node is None:
         return None
@@ -45,6 +47,7 @@ def _run_node_script(script: str, *args: str) -> subprocess.CompletedProcess[str
         text=True,
         capture_output=True,
         check=False,
+        timeout=timeout,
     )
 
 
@@ -71,6 +74,54 @@ def _write_fake_bash_recorder(tmp_path: Path, *, user_prompt_context: str = "") 
     return fake_bash
 
 
+def _write_minimal_plugin_root(root: Path, *, name: str = "claude-smart") -> None:
+    (root / "scripts").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(f"[project]\nname = \"{name}\"\n")
+    (root / "uv.lock").write_text("")
+    (root / "scripts" / "hook_entry.sh").write_text("#!/bin/sh\n")
+
+
+def _copy_opencode_dist(root: Path) -> Path:
+    dist = root / "opencode" / "dist"
+    shutil.copytree(REPO_ROOT / "plugin" / "opencode" / "dist", dist)
+    return dist / "server.mjs"
+
+
+def _run_opencode_server_and_read_calls(
+    *,
+    tmp_path: Path,
+    import_path: Path,
+    home: Path,
+    extra_env: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    log_path = tmp_path / "calls.jsonl"
+    _write_fake_bash_recorder(tmp_path)
+    env_lines = ""
+    for key, value in (extra_env or {}).items():
+        env_lines += f"process.env[{json.dumps(key)}] = {json.dumps(value)};\n"
+    script = f"""
+      process.env.PATH = {json.dumps(str(tmp_path))} + ":" + process.env.PATH;
+      process.env.CALL_LOG = {json.dumps(str(log_path))};
+      process.env.HOME = {json.dumps(str(home))};
+      delete process.env.CLAUDE_SMART_PLUGIN_ROOT;
+      {env_lines}
+      import({json.dumps(str(import_path))}).then(async (mod) => {{
+        const plugin = await mod.default.server({{ directory: "/repo" }});
+        await plugin["chat.message"]({{ sessionID: "s1" }}, {{ message: {{ content: "remember" }} }});
+        process.stdout.write(require("fs").readFileSync(process.env.CALL_LOG, "utf8"));
+      }}).catch((err) => {{
+        console.error(err);
+        process.exit(1);
+      }});
+    """
+
+    result = _run_node_script(script)
+    assert result is not None
+
+    assert result.returncode == 0, result.stderr
+    return [json.loads(line) for line in result.stdout.strip().split("\n")]
+
+
 def test_package_exposes_opencode_server_entrypoint() -> None:
     package = _read_json("package.json")
 
@@ -90,6 +141,39 @@ def test_opencode_package_includes_local_cli_bridge() -> None:
         "opencode-claude-compat.js",
     ):
         assert (REPO_ROOT / "plugin" / "scripts" / name).is_file()
+
+
+def test_opencode_hook_bootstrap_lockfile_matches_pyproject() -> None:
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv is not installed")
+    assert uv is not None
+
+    result = subprocess.run(
+        [
+            uv,
+            "lock",
+            "--check",
+            "--python",
+            "3.12",
+            "--project",
+            str(REPO_ROOT / "plugin"),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_package_target_checks_uv_lock_freshness() -> None:
+    makefile = (REPO_ROOT / "Makefile").read_text()
+
+    assert "check-uv-lock:" in makefile
+    assert "uv lock --check --python 3.12 --project plugin" in makefile
+    assert "package: check-vendor-reflexio check-locked-project-version check-uv-lock" in makefile
 
 
 def test_opencode_bridge_does_not_call_pre_tool() -> None:
@@ -252,6 +336,9 @@ def test_opencode_config_patch_preserves_legacy_plugin_field_and_unrelated(
 def test_opencode_config_patch_uninstall_removes_only_claude_smart(
     tmp_path: Path,
 ) -> None:
+    package_root = tmp_path / "local-package"
+    package_root.mkdir()
+    (package_root / "package.json").write_text('{"name":"claude-smart"}\n')
     config = tmp_path / ".opencode" / "opencode.json"
     config.parent.mkdir()
     config.write_text(
@@ -260,6 +347,7 @@ def test_opencode_config_patch_uninstall_removes_only_claude_smart(
                 "plugin": [
                     "other-plugin",
                     "claude-smart",
+                    package_root.as_uri(),
                     ["another-plugin", {"enabled": True}],
                 ],
                 "model": "anthropic/claude-sonnet-4",
@@ -291,6 +379,37 @@ def test_opencode_config_patch_install_dedupes_existing_entries(
 
     assert changed is True
     assert json.loads(config.read_text())["plugin"] == ["other-plugin", "claude-smart"]
+
+
+def test_opencode_config_patch_installs_local_file_spec_and_removes_bare_name(
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "local-package"
+    package_root.mkdir()
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "plugin": [
+                    "other-plugin",
+                    "claude-smart",
+                    "file:///old/cache/node_modules/claude-smart",
+                ]
+            }
+        )
+    )
+
+    changed, _ = cli._patch_opencode_plugin_config(
+        config,
+        install=True,
+        plugin_spec=package_root.as_uri(),
+    )
+
+    assert changed is True
+    assert json.loads(config.read_text())["plugin"] == [
+        "other-plugin",
+        package_root.as_uri(),
+    ]
 
 
 def test_opencode_config_patch_fresh_config_uses_current_plugin_field(
@@ -541,7 +660,7 @@ def test_opencode_backend_service_prefers_opencode_bridge() -> None:
 
 def test_opencode_cli_bridge_translates_claude_contract(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     bridge = REPO_ROOT / "plugin" / "scripts" / "opencode-claude-compat.js"
     fake_opencode = tmp_path / "opencode"
     call_log = tmp_path / "calls.json"
@@ -624,7 +743,7 @@ process.stdout.write(JSON.stringify({{
 
 def test_opencode_cli_bridge_pipes_large_prompt_via_stdin(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     bridge = REPO_ROOT / "plugin" / "scripts" / "opencode-claude-compat.js"
     fake_opencode = tmp_path / "opencode"
     call_log = tmp_path / "calls.json"
@@ -679,7 +798,7 @@ def test_opencode_cli_bridge_pipes_large_prompt_via_stdin(tmp_path: Path) -> Non
 
 def test_node_installer_accepts_opencode_only_extraction_provider(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     fake_opencode = tmp_path / "opencode"
     fake_opencode.write_text("#!/bin/sh\nexit 0\n")
     fake_opencode.chmod(0o755)
@@ -720,33 +839,81 @@ def _isolated_installer_env(tmp_path: Path) -> dict[str, str]:
     return env
 
 
-def test_node_opencode_install_from_npx_root_patches_config_without_bootstrap(
+def _write_minimal_node_package_root(package_root: Path) -> None:
+    bin_dir = package_root / "bin"
+    scripts = package_root / "plugin" / "scripts"
+    bin_dir.mkdir(parents=True)
+    scripts.mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "bin" / "claude-smart.js", bin_dir / "claude-smart.js")
+    (package_root / "package.json").write_text(
+        json.dumps({"name": "claude-smart", "version": "0.0.0"}) + "\n"
+    )
+    (package_root / "plugin" / "pyproject.toml").write_text(
+        "[project]\nname='claude-smart'\n"
+    )
+    (package_root / "plugin" / "uv.lock").write_text("version = 1\n")
+    smart_install = scripts / "smart-install.sh"
+    smart_install.write_text("#!/bin/sh\nexit 0\n")
+    smart_install.chmod(0o755)
+
+
+def _seed_private_node_and_uv(env: dict[str, str]) -> None:
+    home = Path(env["HOME"])
+    private_node = home / ".claude-smart" / "node" / "current" / "bin"
+    uv_bin = home / ".local" / "bin"
+    private_node.mkdir(parents=True, exist_ok=True)
+    uv_bin.mkdir(parents=True, exist_ok=True)
+    for path in [private_node / "node", private_node / "npm"]:
+        path.write_text("#!/bin/sh\nexit 0\n")
+        path.chmod(0o755)
+    uv = uv_bin / "uv"
+    uv.write_text(
+        "#!/bin/sh\n"
+        'printf "uv %s\\n" "$*" >> "$HOME/uv.log"\n'
+        'mkdir -p "$PWD/.venv/bin"\n'
+        'printf "#!/bin/sh\\nexit 0\\n" > "$PWD/.venv/bin/python"\n'
+        'chmod +x "$PWD/.venv/bin/python"\n'
+        "exit 0\n"
+    )
+    uv.chmod(0o755)
+
+
+def test_node_opencode_install_from_npx_root_patches_config_to_local_file_package(
     tmp_path: Path,
 ) -> None:
     node = shutil_which_node()
     if node is None:
         return
     package_root = tmp_path / "_npx" / "abc" / "node_modules" / "claude-smart"
-    bin_dir = package_root / "bin"
-    bin_dir.mkdir(parents=True)
-    shutil.copy2(REPO_ROOT / "bin" / "claude-smart.js", bin_dir / "claude-smart.js")
+    _write_minimal_node_package_root(package_root)
     project = tmp_path / "project"
     project.mkdir()
+    env = _isolated_installer_env(tmp_path)
+    _seed_private_node_and_uv(env)
 
     result = subprocess.run(
-        [node, str(bin_dir / "claude-smart.js"), "install", "--host", "opencode"],
+        [
+            node,
+            str(package_root / "bin" / "claude-smart.js"),
+            "install",
+            "--host",
+            "opencode",
+        ],
         cwd=project,
-        env=_isolated_installer_env(tmp_path),
+        env=env,
         text=True,
         capture_output=True,
         check=False,
     )
 
     assert result.returncode == 0, result.stderr
-    assert "npx's temporary package cache" in result.stdout
-    assert json.loads((project / "opencode.json").read_text()) == {
-        "plugin": ["claude-smart"]
-    }
+    parsed = json.loads((project / "opencode.json").read_text())
+    plugin_spec = parsed["plugin"][0]
+    assert plugin_spec.startswith("file://")
+    assert plugin_spec != "claude-smart"
+    local_package = Path(plugin_spec.removeprefix("file://"))
+    assert local_package == Path(env["HOME"]) / ".claude-smart" / "opencode" / "claude-smart"
+    assert (local_package / "plugin" / "scripts" / "smart-install.sh").exists()
 
 
 def test_node_opencode_install_stable_root_bootstrap_failure_leaves_config_unchanged(
@@ -759,6 +926,9 @@ def test_node_opencode_install_stable_root_bootstrap_failure_leaves_config_uncha
     bin_dir = package_root / "bin"
     bin_dir.mkdir(parents=True)
     shutil.copy2(REPO_ROOT / "bin" / "claude-smart.js", bin_dir / "claude-smart.js")
+    (package_root / "package.json").write_text(
+        json.dumps({"name": "claude-smart", "version": "0.0.0"}) + "\n"
+    )
     project = tmp_path / "project"
     project.mkdir()
     config = project / "opencode.json"
@@ -775,7 +945,7 @@ def test_node_opencode_install_stable_root_bootstrap_failure_leaves_config_uncha
     )
 
     assert result.returncode != 0
-    assert "dependency bootstrap" in result.stderr
+    assert "could not prepare claude-smart OpenCode package" in result.stderr
     assert config.read_text() == original
 
 
@@ -793,7 +963,7 @@ def test_opencode_install_patches_project_config_after_bootstrap(
 
     assert rc == 0
     parsed = json.loads((tmp_path / "opencode.json").read_text())
-    assert parsed["plugin"] == ["claude-smart"]
+    assert parsed["plugin"] == ["file:///plugin"]
     assert "Restart OpenCode" in capsys.readouterr().out
 
 
@@ -816,7 +986,7 @@ def test_opencode_install_patches_existing_dot_opencode_config(
     assert not (tmp_path / "opencode.json").exists()
     assert json.loads(legacy_config.read_text())["plugin"] == [
         "other-plugin",
-        "claude-smart",
+        "file:///plugin",
     ]
 
 
@@ -836,13 +1006,13 @@ def test_opencode_install_migrates_existing_plugins_field(
 
     parsed = json.loads(config.read_text())
     assert rc == 0
-    assert parsed["plugin"] == ["other-plugin", "claude-smart"]
+    assert parsed["plugin"] == ["other-plugin", "file:///plugin"]
     assert "plugins" not in parsed
 
 
 def test_node_installer_patches_opencode_jsonc(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     config = tmp_path / "opencode.jsonc"
     config.write_text('{"plugin": ["other",], // keep parseable\n"theme": "system"}\n')
     script = (
@@ -860,11 +1030,48 @@ def test_node_installer_patches_opencode_jsonc(tmp_path: Path) -> None:
     assert parsed["theme"] == "system"
 
 
+def test_node_installer_patches_opencode_to_local_file_spec(tmp_path: Path) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    config = tmp_path / "opencode.json"
+    local_package = tmp_path / "local-package"
+    local_package.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "plugin": [
+                    "other",
+                    "claude-smart",
+                    "file:///old/cache/node_modules/claude-smart",
+                ]
+            }
+        )
+    )
+    script = (
+        f"const installer = require({json.dumps(str(REPO_ROOT / 'bin' / 'claude-smart.js'))});"
+        f"const spec = installer.opencodeLocalPluginSpec({json.dumps(str(local_package))});"
+        f"installer.patchOpenCodePluginConfig({json.dumps(str(config))}, {{ install: true, pluginSpec: spec }});"
+        "process.stdout.write(require('fs').readFileSync(process.argv[1], 'utf8'));"
+    )
+
+    result = _run_node_script(script, str(config))
+    assert result is not None
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["plugin"] == [
+        "other",
+        local_package.as_uri(),
+    ]
+
+
 def test_node_installer_uninstalls_and_preserves_other_plugin_shapes(
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
+    local_package = tmp_path / "local-package"
+    local_package.mkdir()
+    (local_package / "package.json").write_text('{"name":"claude-smart"}\n')
     config = tmp_path / "opencode.json"
     config.write_text(
         json.dumps(
@@ -873,6 +1080,7 @@ def test_node_installer_uninstalls_and_preserves_other_plugin_shapes(
                     "claude-smart",
                     "other",
                     ["tuple-plugin", {"enabled": True}],
+                    local_package.as_uri(),
                     "claude-smart",
                 ],
                 "theme": "system",
@@ -896,7 +1104,7 @@ def test_node_installer_uninstalls_and_preserves_other_plugin_shapes(
 
 def test_node_installer_migrates_existing_plugins_field(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     config = tmp_path / "opencode.json"
     config.write_text(json.dumps({"plugins": ["other"], "theme": "system"}))
     script = (
@@ -917,7 +1125,7 @@ def test_node_installer_migrates_existing_plugins_field(tmp_path: Path) -> None:
 
 def test_node_installer_uninstall_migrates_existing_plugins_field(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     config = tmp_path / "opencode.json"
     config.write_text(json.dumps({"plugins": ["claude-smart", "other", "claude-smart"]}))
     script = (
@@ -935,7 +1143,7 @@ def test_node_installer_uninstall_migrates_existing_plugins_field(tmp_path: Path
 
 def test_node_installer_uninstall_noops_without_plugin_array(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     config = tmp_path / "opencode.json"
     config.write_text(json.dumps({"theme": "system"}))
     script = (
@@ -968,7 +1176,7 @@ def test_node_jsonc_parser_preserves_comma_brace_inside_strings() -> None:
 
 def test_node_jsonc_parser_skips_comments_after_trailing_commas() -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     script = (
         f"const installer = require({json.dumps(str(REPO_ROOT / 'bin' / 'claude-smart.js'))});"
         "process.stdout.write(installer.stripJsonc('{\"plugin\":[\"other\", // note\\n], /* end */}\\n'));"
@@ -983,7 +1191,7 @@ def test_node_jsonc_parser_skips_comments_after_trailing_commas() -> None:
 
 def test_node_installer_backs_up_jsonc_config(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     config = tmp_path / "opencode.jsonc"
     original = '{\n  // keep my notes\n  "plugin": ["other"]\n}\n'
     config.write_text(original)
@@ -1007,7 +1215,7 @@ def test_node_installer_project_config_path_uses_root_by_default_and_legacy_if_p
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     script = (
         f"const installer = require({json.dumps(str(REPO_ROOT / 'bin' / 'claude-smart.js'))});"
         "const fs = require('fs');"
@@ -1030,28 +1238,9 @@ def test_node_installer_project_config_path_uses_root_by_default_and_legacy_if_p
     }
 
 
-def test_node_installer_detects_npx_package_root() -> None:
-    if shutil_which_node() is None:
-        return
-    script = (
-        f"const installer = require({json.dumps(str(REPO_ROOT / 'bin' / 'claude-smart.js'))});"
-        "process.stdout.write(JSON.stringify({"
-        "unix: installer.isNpxPackageRoot('/home/me/.npm/_npx/abc/node_modules/claude-smart'),"
-        "win: installer.isNpxPackageRoot('C:\\\\Users\\\\me\\\\AppData\\\\Local\\\\npm-cache\\\\_npx\\\\abc\\\\node_modules\\\\claude-smart'),"
-        "global: installer.isNpxPackageRoot('/opt/homebrew/lib/node_modules/claude-smart')"
-        "}));"
-    )
-
-    result = _run_node_script(script)
-    assert result is not None
-
-    assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout) == {"unix": True, "win": True, "global": False}
-
-
 def test_node_installer_skips_backup_for_plain_json(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     config = tmp_path / "opencode.json"
     config.write_text(json.dumps({"plugin": ["other"]}))
     script = (
@@ -1073,7 +1262,7 @@ def test_node_installer_rejects_non_array_plugin_without_rewrite(
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     config = tmp_path / "opencode.json"
     original = json.dumps({"plugin": "other", "theme": "system"})
     config.write_text(original)
@@ -1099,7 +1288,7 @@ def test_node_installer_rejects_non_array_plugin_without_rewrite(
 
 def test_node_opencode_payload_normalizes_tool_contracts() -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     script = f"""
       import({json.dumps(str(REPO_ROOT / "plugin" / "opencode" / "dist" / "payload.js"))}).then((payload) => {{
         const edit = payload.toolAfterPayload(
@@ -1188,7 +1377,7 @@ def test_node_opencode_server_injects_cached_context_for_session_ids(
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     fake_bash = tmp_path / "bash"
     fake_bash.write_text(
         "#!/bin/sh\n"
@@ -1229,7 +1418,7 @@ def test_node_opencode_server_injects_cached_context_for_session_ids(
 
 def test_node_opencode_server_tolerates_closed_child_stdin(tmp_path: Path) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     fake_bash = tmp_path / "bash"
     fake_bash.write_text("#!/bin/sh\nexit 0\n")
     fake_bash.chmod(0o755)
@@ -1253,11 +1442,143 @@ def test_node_opencode_server_tolerates_closed_child_stdin(tmp_path: Path) -> No
     assert result.stdout == "ok"
 
 
+def test_node_opencode_server_prefers_current_plugin_root_when_valid(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    stale_root = tmp_path / "stale-plugin"
+    _write_minimal_plugin_root(stale_root, name="stale")
+    home = tmp_path / "home"
+    (home / ".reflexio").mkdir(parents=True)
+    (home / ".reflexio" / "plugin-root").symlink_to(stale_root)
+
+    calls = _run_opencode_server_and_read_calls(
+        tmp_path=tmp_path,
+        import_path=REPO_ROOT / "plugin" / "opencode" / "dist" / "server.mjs",
+        home=home,
+    )
+
+    assert Path(calls[0]["script"]) == (
+        REPO_ROOT / "plugin" / "scripts" / "hook_entry.sh"
+    )
+
+
+def test_node_opencode_server_uses_stable_root_when_current_is_dist_only(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    stable_root = tmp_path / "stable-plugin"
+    _write_minimal_plugin_root(stable_root)
+    dist_only_root = tmp_path / "dist-only-plugin"
+    import_path = _copy_opencode_dist(dist_only_root)
+    home = tmp_path / "home"
+    (home / ".reflexio").mkdir(parents=True)
+    (home / ".reflexio" / "plugin-root").symlink_to(stable_root)
+
+    calls = _run_opencode_server_and_read_calls(
+        tmp_path=tmp_path,
+        import_path=import_path,
+        home=home,
+    )
+
+    assert Path(calls[0]["script"]) == stable_root / "scripts" / "hook_entry.sh"
+
+
+def test_node_opencode_server_explicit_plugin_root_overrides_current_and_stable(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    explicit_root = tmp_path / "explicit-plugin"
+    stable_root = tmp_path / "stable-plugin"
+    _write_minimal_plugin_root(explicit_root, name="explicit")
+    _write_minimal_plugin_root(stable_root, name="stable")
+    home = tmp_path / "home"
+    (home / ".reflexio").mkdir(parents=True)
+    (home / ".reflexio" / "plugin-root").symlink_to(stable_root)
+
+    calls = _run_opencode_server_and_read_calls(
+        tmp_path=tmp_path,
+        import_path=REPO_ROOT / "plugin" / "opencode" / "dist" / "server.mjs",
+        home=home,
+        extra_env={"CLAUDE_SMART_PLUGIN_ROOT": str(explicit_root)},
+    )
+
+    assert Path(calls[0]["script"]) == explicit_root / "scripts" / "hook_entry.sh"
+
+
+def test_node_opencode_server_uses_text_root_when_symlink_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    stable_root = tmp_path / "stable-plugin"
+    _write_minimal_plugin_root(stable_root)
+    dist_only_root = tmp_path / "dist-only-plugin"
+    import_path = _copy_opencode_dist(dist_only_root)
+    home = tmp_path / "home"
+    (home / ".reflexio").mkdir(parents=True)
+    (home / ".reflexio" / "plugin-root.txt").write_text(f"{stable_root}\n")
+
+    calls = _run_opencode_server_and_read_calls(
+        tmp_path=tmp_path,
+        import_path=import_path,
+        home=home,
+    )
+
+    assert Path(calls[0]["script"]) == stable_root / "scripts" / "hook_entry.sh"
+
+
+def test_node_opencode_server_treats_npx_current_root_as_transient(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    stable_root = tmp_path / "stable-plugin"
+    _write_minimal_plugin_root(stable_root)
+    npx_root = tmp_path / "_npx" / "12345" / "node_modules" / "claude-smart" / "plugin"
+    _write_minimal_plugin_root(npx_root, name="npx")
+    import_path = _copy_opencode_dist(npx_root)
+    home = tmp_path / "home"
+    (home / ".reflexio").mkdir(parents=True)
+    (home / ".reflexio" / "plugin-root").symlink_to(stable_root)
+
+    calls = _run_opencode_server_and_read_calls(
+        tmp_path=tmp_path,
+        import_path=import_path,
+        home=home,
+    )
+
+    assert Path(calls[0]["script"]) == stable_root / "scripts" / "hook_entry.sh"
+
+
+def test_node_opencode_server_falls_back_to_transient_root_without_stable_candidate(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    npx_root = tmp_path / "_npx" / "12345" / "node_modules" / "claude-smart" / "plugin"
+    _write_minimal_plugin_root(npx_root, name="npx")
+    import_path = _copy_opencode_dist(npx_root)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    calls = _run_opencode_server_and_read_calls(
+        tmp_path=tmp_path,
+        import_path=import_path,
+        home=home,
+    )
+
+    assert Path(calls[0]["script"]) == npx_root / "scripts" / "hook_entry.sh"
+
+
 def test_node_opencode_server_dispatches_lifecycle_tool_idle_and_dispose(
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     log_path = tmp_path / "calls.jsonl"
     _write_fake_bash_recorder(tmp_path, user_prompt_context="learned context")
     script = f"""
@@ -1311,7 +1632,7 @@ def test_node_opencode_server_dispose_flushes_active_session_without_idle(
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     log_path = tmp_path / "calls.jsonl"
     _write_fake_bash_recorder(tmp_path)
     script = f"""
@@ -1349,7 +1670,7 @@ def test_node_opencode_server_text_complete_flushes_once(
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     log_path = tmp_path / "calls.jsonl"
     _write_fake_bash_recorder(tmp_path)
     script = f"""
@@ -1387,7 +1708,7 @@ def test_node_opencode_server_keeps_multi_segment_assistant_text(
     tmp_path: Path,
 ) -> None:
     if shutil_which_node() is None:
-        return
+        pytest.skip("node is not installed")
     log_path = tmp_path / "calls.jsonl"
     _write_fake_bash_recorder(tmp_path)
     script = f"""

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -1289,6 +1289,62 @@ def test_node_opencode_install_copy_failure_preserves_existing_local_package(
     assert parsed["entries"] == ["claude-smart"]
 
 
+def test_node_opencode_install_replaces_broken_local_package_symlink(
+    tmp_path: Path,
+) -> None:
+    node = shutil_which_node()
+    if node is None:
+        pytest.skip("node is not installed")
+    assert node is not None
+    package_root = tmp_path / "global" / "node_modules" / "claude-smart"
+    _write_minimal_node_package_root(package_root)
+    env = _isolated_installer_env(tmp_path)
+    local_package = (
+        Path(env["HOME"]) / ".claude-smart" / "opencode" / "claude-smart"
+    )
+    local_package.parent.mkdir(parents=True)
+    local_package.symlink_to(tmp_path / "missing-package")
+    script = (
+        "const fs = require('fs');"
+        "const path = require('path');"
+        "const target = path.join(process.env.HOME, '.claude-smart', 'opencode', 'claude-smart');"
+        "const realRenameSync = fs.renameSync;"
+        "fs.renameSync = function(src, dst) {"
+        "  let targetIsSymlink = false;"
+        "  try { targetIsSymlink = fs.lstatSync(target).isSymbolicLink(); } catch {}"
+        "  if (dst === target && targetIsSymlink) {"
+        "    const err = new Error('cannot replace broken symlink');"
+        "    err.code = 'ENOTDIR';"
+        "    throw err;"
+        "  }"
+        "  return realRenameSync(src, dst);"
+        "};"
+        f"const installer = require({json.dumps(str(package_root / 'bin' / 'claude-smart.js'))});"
+        "const packageRoot = installer.installOpenCodePluginPackage();"
+        "process.stdout.write(JSON.stringify({"
+        "  packageRoot,"
+        "  isSymlink: fs.lstatSync(target).isSymbolicLink(),"
+        "  hasManifest: fs.existsSync(path.join(target, 'package.json'))"
+        "}));"
+    )
+
+    result = subprocess.run(
+        [node, "-e", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(result.stdout)
+    assert parsed == {
+        "packageRoot": str(local_package),
+        "isSymlink": False,
+        "hasManifest": True,
+    }
+
+
 def test_node_installer_migrates_existing_plugins_field(tmp_path: Path) -> None:
     if shutil_which_node() is None:
         pytest.skip("node is not installed")

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -168,12 +168,15 @@ def test_opencode_hook_bootstrap_lockfile_matches_pyproject() -> None:
     assert result.returncode == 0, result.stderr or result.stdout
 
 
-def test_package_target_checks_uv_lock_freshness() -> None:
+def test_package_target_checks_standalone_lock_freshness() -> None:
     makefile = (REPO_ROOT / "Makefile").read_text()
 
-    assert "check-uv-lock:" in makefile
-    assert "uv lock --check --python 3.12 --project plugin" in makefile
-    assert "package: check-vendor-reflexio check-locked-project-version check-uv-lock" in makefile
+    assert "check-standalone-lock:" in makefile
+    assert "bash scripts/standalone-lock.sh --check" in makefile
+    assert (
+        "package: check-vendor-reflexio check-locked-project-version "
+        "check-standalone-lock"
+    ) in makefile
 
 
 def test_opencode_bridge_does_not_call_pre_tool() -> None:

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -317,6 +317,7 @@ def test_opencode_learning_loop_buffers_injects_tools_and_publishes(
 def test_opencode_config_patch_preserves_legacy_plugin_field_and_unrelated(
     tmp_path: Path,
 ) -> None:
+    plugin_spec = cli._opencode_local_plugin_spec()
     config = tmp_path / ".opencode" / "opencode.jsonc"
     config.parent.mkdir()
     config.write_text(
@@ -333,7 +334,7 @@ def test_opencode_config_patch_preserves_legacy_plugin_field_and_unrelated(
     assert path == config
     parsed = json.loads(config.read_text())
     assert parsed["theme"] == "system"
-    assert parsed["plugin"] == ["other-plugin", "claude-smart"]
+    assert parsed["plugin"] == ["other-plugin", plugin_spec]
 
 
 def test_opencode_config_patch_uninstall_removes_only_claude_smart(
@@ -372,6 +373,7 @@ def test_opencode_config_patch_uninstall_removes_only_claude_smart(
 def test_opencode_config_patch_install_dedupes_existing_entries(
     tmp_path: Path,
 ) -> None:
+    plugin_spec = cli._opencode_local_plugin_spec()
     config = tmp_path / ".opencode" / "opencode.json"
     config.parent.mkdir()
     config.write_text(
@@ -381,7 +383,7 @@ def test_opencode_config_patch_install_dedupes_existing_entries(
     changed, _ = cli._patch_opencode_plugin_config(config, install=True)
 
     assert changed is True
-    assert json.loads(config.read_text())["plugin"] == ["other-plugin", "claude-smart"]
+    assert json.loads(config.read_text())["plugin"] == ["other-plugin", plugin_spec]
 
 
 def test_opencode_config_patch_installs_local_file_spec_and_removes_bare_name(
@@ -418,17 +420,19 @@ def test_opencode_config_patch_installs_local_file_spec_and_removes_bare_name(
 def test_opencode_config_patch_fresh_config_uses_current_plugin_field(
     tmp_path: Path,
 ) -> None:
+    plugin_spec = cli._opencode_local_plugin_spec()
     config = tmp_path / "opencode.json"
 
     changed, _ = cli._patch_opencode_plugin_config(config, install=True)
 
     assert changed is True
-    assert json.loads(config.read_text()) == {"plugin": ["claude-smart"]}
+    assert json.loads(config.read_text()) == {"plugin": [plugin_spec]}
 
 
 def test_opencode_config_patch_migrates_existing_plugins_field(
     tmp_path: Path,
 ) -> None:
+    plugin_spec = cli._opencode_local_plugin_spec()
     config = tmp_path / "opencode.json"
     config.write_text(json.dumps({"plugins": ["other-plugin"], "theme": "system"}))
 
@@ -436,7 +440,7 @@ def test_opencode_config_patch_migrates_existing_plugins_field(
 
     parsed = json.loads(config.read_text())
     assert changed is True
-    assert parsed["plugin"] == ["other-plugin", "claude-smart"]
+    assert parsed["plugin"] == ["other-plugin", plugin_spec]
     assert "plugins" not in parsed
     assert parsed["theme"] == "system"
 
@@ -514,6 +518,7 @@ def test_opencode_config_patch_uninstall_noops_without_plugin_array(
 
 
 def test_opencode_config_patch_backs_up_jsonc_config(tmp_path: Path) -> None:
+    plugin_spec = cli._opencode_local_plugin_spec()
     config = tmp_path / ".opencode" / "opencode.jsonc"
     config.parent.mkdir()
     original = (
@@ -529,7 +534,7 @@ def test_opencode_config_patch_backs_up_jsonc_config(tmp_path: Path) -> None:
 
     assert changed is True
     assert config.with_suffix(config.suffix + ".bak").read_text() == original
-    assert json.loads(config.read_text())["plugin"] == ["other-plugin", "claude-smart"]
+    assert json.loads(config.read_text())["plugin"] == ["other-plugin", plugin_spec]
 
 
 def test_opencode_config_patch_skips_backup_for_plain_json(tmp_path: Path) -> None:
@@ -886,7 +891,7 @@ def test_node_opencode_install_from_npx_root_patches_config_to_local_file_packag
 ) -> None:
     node = shutil_which_node()
     if node is None:
-        return
+        pytest.skip("node is not installed")
     package_root = tmp_path / "_npx" / "abc" / "node_modules" / "claude-smart"
     _write_minimal_node_package_root(package_root)
     project = tmp_path / "project"
@@ -924,7 +929,7 @@ def test_node_opencode_install_stable_root_bootstrap_failure_leaves_config_uncha
 ) -> None:
     node = shutil_which_node()
     if node is None:
-        return
+        pytest.skip("node is not installed")
     package_root = tmp_path / "global" / "node_modules" / "claude-smart"
     bin_dir = package_root / "bin"
     bin_dir.mkdir(parents=True)
@@ -1029,7 +1034,9 @@ def test_node_installer_patches_opencode_jsonc(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     parsed = json.loads(result.stdout)
-    assert parsed["plugin"] == ["other", "claude-smart"]
+    assert parsed["plugin"][0] == "other"
+    assert parsed["plugin"][1].startswith("file://")
+    assert parsed["plugin"][1] != "claude-smart"
     assert parsed["theme"] == "system"
 
 
@@ -1109,10 +1116,13 @@ def test_node_installer_migrates_existing_plugins_field(tmp_path: Path) -> None:
     if shutil_which_node() is None:
         pytest.skip("node is not installed")
     config = tmp_path / "opencode.json"
+    local_package = tmp_path / "local-package"
+    local_package.mkdir()
     config.write_text(json.dumps({"plugins": ["other"], "theme": "system"}))
     script = (
         f"const installer = require({json.dumps(str(REPO_ROOT / 'bin' / 'claude-smart.js'))});"
-        f"installer.patchOpenCodePluginConfig({json.dumps(str(config))}, {{install: true}});"
+        f"const spec = installer.opencodeLocalPluginSpec({json.dumps(str(local_package))});"
+        f"installer.patchOpenCodePluginConfig({json.dumps(str(config))}, {{ install: true, pluginSpec: spec }});"
         "process.stdout.write(require('fs').readFileSync(process.argv[1], 'utf8'));"
     )
 
@@ -1121,7 +1131,7 @@ def test_node_installer_migrates_existing_plugins_field(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     parsed = json.loads(result.stdout)
-    assert parsed["plugin"] == ["other", "claude-smart"]
+    assert parsed["plugin"] == ["other", local_package.as_uri()]
     assert "plugins" not in parsed
     assert parsed["theme"] == "system"
 
@@ -1196,11 +1206,14 @@ def test_node_installer_backs_up_jsonc_config(tmp_path: Path) -> None:
     if shutil_which_node() is None:
         pytest.skip("node is not installed")
     config = tmp_path / "opencode.jsonc"
+    local_package = tmp_path / "local-package"
+    local_package.mkdir()
     original = '{\n  // keep my notes\n  "plugin": ["other"]\n}\n'
     config.write_text(original)
     script = (
         f"const installer = require({json.dumps(str(REPO_ROOT / 'bin' / 'claude-smart.js'))});"
-        f"const result = installer.patchOpenCodePluginConfig({json.dumps(str(config))}, {{install: true}});"
+        f"const spec = installer.opencodeLocalPluginSpec({json.dumps(str(local_package))});"
+        f"const result = installer.patchOpenCodePluginConfig({json.dumps(str(config))}, {{ install: true, pluginSpec: spec }});"
         "process.stdout.write(JSON.stringify({ result, text: require('fs').readFileSync(process.argv[1], 'utf8'), backup: require('fs').readFileSync(`${process.argv[1]}.bak`, 'utf8') }));"
     )
 
@@ -1211,7 +1224,7 @@ def test_node_installer_backs_up_jsonc_config(tmp_path: Path) -> None:
     parsed = json.loads(result.stdout)
     assert parsed["result"]["backupPath"] == f"{config}.bak"
     assert parsed["backup"] == original
-    assert json.loads(parsed["text"])["plugin"] == ["other", "claude-smart"]
+    assert json.loads(parsed["text"])["plugin"] == ["other", local_package.as_uri()]
 
 
 def test_node_installer_project_config_path_uses_root_by_default_and_legacy_if_present(

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -391,6 +391,9 @@ def test_opencode_config_patch_installs_local_file_spec_and_removes_bare_name(
 ) -> None:
     package_root = tmp_path / "local-package"
     package_root.mkdir()
+    old_package = tmp_path / "old-cache" / "node_modules" / "claude-smart"
+    old_package.mkdir(parents=True)
+    (old_package / "package.json").write_text('{"name":"claude-smart"}\n')
     config = tmp_path / "opencode.json"
     config.write_text(
         json.dumps(
@@ -398,7 +401,7 @@ def test_opencode_config_patch_installs_local_file_spec_and_removes_bare_name(
                 "plugin": [
                     "other-plugin",
                     "claude-smart",
-                    "file:///old/cache/node_modules/claude-smart",
+                    old_package.as_uri(),
                 ]
             }
         )
@@ -414,6 +417,42 @@ def test_opencode_config_patch_installs_local_file_spec_and_removes_bare_name(
     assert json.loads(config.read_text())["plugin"] == [
         "other-plugin",
         package_root.as_uri(),
+    ]
+
+
+def test_opencode_config_patch_preserves_unrelated_file_specs_named_claude_smart(
+    tmp_path: Path,
+) -> None:
+    missing_manifest = tmp_path / "vendor" / "claude-smart"
+    wrong_manifest = tmp_path / "other" / "claude-smart"
+    real_package = tmp_path / "real-package"
+    missing_manifest.mkdir(parents=True)
+    wrong_manifest.mkdir(parents=True)
+    real_package.mkdir()
+    (wrong_manifest / "package.json").write_text('{"name":"not-claude-smart"}\n')
+    (real_package / "package.json").write_text('{"name":"claude-smart"}\n')
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "plugin": [
+                    "other-plugin",
+                    missing_manifest.as_uri(),
+                    wrong_manifest.as_uri(),
+                    real_package.as_uri(),
+                    "claude-smart@0.2.46",
+                ]
+            }
+        )
+    )
+
+    changed, _ = cli._patch_opencode_plugin_config(config, install=False)
+
+    assert changed is True
+    assert json.loads(config.read_text())["plugin"] == [
+        "other-plugin",
+        missing_manifest.as_uri(),
+        wrong_manifest.as_uri(),
     ]
 
 
@@ -892,6 +931,7 @@ def test_node_opencode_install_from_npx_root_patches_config_to_local_file_packag
     node = shutil_which_node()
     if node is None:
         pytest.skip("node is not installed")
+    assert node is not None
     package_root = tmp_path / "_npx" / "abc" / "node_modules" / "claude-smart"
     _write_minimal_node_package_root(package_root)
     project = tmp_path / "project"
@@ -930,6 +970,7 @@ def test_node_opencode_install_stable_root_bootstrap_failure_leaves_config_uncha
     node = shutil_which_node()
     if node is None:
         pytest.skip("node is not installed")
+    assert node is not None
     package_root = tmp_path / "global" / "node_modules" / "claude-smart"
     bin_dir = package_root / "bin"
     bin_dir.mkdir(parents=True)
@@ -955,6 +996,39 @@ def test_node_opencode_install_stable_root_bootstrap_failure_leaves_config_uncha
     assert result.returncode != 0
     assert "could not prepare claude-smart OpenCode package" in result.stderr
     assert config.read_text() == original
+
+
+def test_opencode_install_copy_failure_preserves_existing_local_package(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    plugin_scripts = repo_root / "plugin" / "scripts"
+    plugin_scripts.mkdir(parents=True)
+    (repo_root / "package.json").write_text('{"name":"claude-smart"}\n')
+    (plugin_scripts / "smart-install.sh").write_text("#!/bin/sh\nexit 0\n")
+    local_package = tmp_path / "home" / ".claude-smart" / "opencode" / "claude-smart"
+    local_package.mkdir(parents=True)
+    marker = local_package / "marker.txt"
+    marker.write_text("keep\n")
+
+    def failing_copytree(src: Path, dst: Path, **_kwargs: object) -> Path:
+        assert src == repo_root
+        dst.mkdir(parents=True, exist_ok=True)
+        (dst / "partial.txt").write_text("partial\n")
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(cli, "_REPO_ROOT", repo_root)
+    monkeypatch.setattr(cli, "_PLUGIN_ROOT", repo_root / "plugin")
+    monkeypatch.setattr(cli, "_OPENCODE_LOCAL_PACKAGE_DIR", local_package)
+    monkeypatch.setattr(cli.shutil, "copytree", failing_copytree)
+
+    with pytest.raises(OSError, match="copy failed"):
+        cli._install_opencode_plugin_package()
+
+    assert marker.read_text() == "keep\n"
+    assert not (local_package / "partial.txt").exists()
+    assert not (local_package.parent / ".install.lock").exists()
+    assert list(local_package.parent.iterdir()) == [local_package]
 
 
 def test_opencode_install_patches_project_config_after_bootstrap(
@@ -1046,13 +1120,16 @@ def test_node_installer_patches_opencode_to_local_file_spec(tmp_path: Path) -> N
     config = tmp_path / "opencode.json"
     local_package = tmp_path / "local-package"
     local_package.mkdir()
+    old_package = tmp_path / "old-cache" / "node_modules" / "claude-smart"
+    old_package.mkdir(parents=True)
+    (old_package / "package.json").write_text('{"name":"claude-smart"}\n')
     config.write_text(
         json.dumps(
             {
                 "plugin": [
                     "other",
                     "claude-smart",
-                    "file:///old/cache/node_modules/claude-smart",
+                    old_package.as_uri(),
                 ]
             }
         )
@@ -1071,6 +1148,50 @@ def test_node_installer_patches_opencode_to_local_file_spec(tmp_path: Path) -> N
     assert json.loads(result.stdout)["plugin"] == [
         "other",
         local_package.as_uri(),
+    ]
+
+
+def test_node_installer_preserves_unrelated_file_specs_named_claude_smart(
+    tmp_path: Path,
+) -> None:
+    if shutil_which_node() is None:
+        pytest.skip("node is not installed")
+    missing_manifest = tmp_path / "vendor" / "claude-smart"
+    wrong_manifest = tmp_path / "other" / "claude-smart"
+    real_package = tmp_path / "real-package"
+    missing_manifest.mkdir(parents=True)
+    wrong_manifest.mkdir(parents=True)
+    real_package.mkdir()
+    (wrong_manifest / "package.json").write_text('{"name":"not-claude-smart"}\n')
+    (real_package / "package.json").write_text('{"name":"claude-smart"}\n')
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "plugin": [
+                    "other",
+                    missing_manifest.as_uri(),
+                    wrong_manifest.as_uri(),
+                    real_package.as_uri(),
+                    "claude-smart@0.2.46",
+                ]
+            }
+        )
+    )
+    script = (
+        f"const installer = require({json.dumps(str(REPO_ROOT / 'bin' / 'claude-smart.js'))});"
+        f"installer.patchOpenCodePluginConfig({json.dumps(str(config))}, {{install: false}});"
+        "process.stdout.write(require('fs').readFileSync(process.argv[1], 'utf8'));"
+    )
+
+    result = _run_node_script(script, str(config))
+    assert result is not None
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["plugin"] == [
+        "other",
+        missing_manifest.as_uri(),
+        wrong_manifest.as_uri(),
     ]
 
 
@@ -1110,6 +1231,62 @@ def test_node_installer_uninstalls_and_preserves_other_plugin_shapes(
     parsed = json.loads(result.stdout)
     assert parsed["plugin"] == ["other", ["tuple-plugin", {"enabled": True}]]
     assert parsed["theme"] == "system"
+
+
+def test_node_opencode_install_copy_failure_preserves_existing_local_package(
+    tmp_path: Path,
+) -> None:
+    node = shutil_which_node()
+    if node is None:
+        pytest.skip("node is not installed")
+    assert node is not None
+    package_root = tmp_path / "global" / "node_modules" / "claude-smart"
+    _write_minimal_node_package_root(package_root)
+    env = _isolated_installer_env(tmp_path)
+    local_package = (
+        Path(env["HOME"]) / ".claude-smart" / "opencode" / "claude-smart"
+    )
+    local_package.mkdir(parents=True)
+    (local_package / "marker.txt").write_text("keep\n")
+    script = (
+        "const fs = require('fs');"
+        "const path = require('path');"
+        "fs.cpSync = function(_src, dst) {"
+        "  fs.mkdirSync(dst, { recursive: true });"
+        "  fs.writeFileSync(path.join(dst, 'partial.txt'), 'partial\\n');"
+        "  throw new Error('copy failed');"
+        "};"
+        f"const installer = require({json.dumps(str(package_root / 'bin' / 'claude-smart.js'))});"
+        "try {"
+        "  installer.installOpenCodePluginPackage();"
+        "  process.stdout.write('unexpected success');"
+        "  process.exit(2);"
+        "} catch (err) {"
+        "  const target = path.join(process.env.HOME, '.claude-smart', 'opencode', 'claude-smart');"
+        "  const parent = path.dirname(target);"
+        "  process.stdout.write(JSON.stringify({"
+        "    message: err.message,"
+        "    marker: fs.existsSync(path.join(target, 'marker.txt')) ? fs.readFileSync(path.join(target, 'marker.txt'), 'utf8') : null,"
+        "    partialAtTarget: fs.existsSync(path.join(target, 'partial.txt')),"
+        "    entries: fs.readdirSync(parent).sort()"
+        "  }));"
+        "}"
+    )
+
+    result = subprocess.run(
+        [node, "-e", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(result.stdout)
+    assert parsed["message"] == "copy failed"
+    assert parsed["marker"] == "keep\n"
+    assert parsed["partialAtTarget"] is False
+    assert parsed["entries"] == ["claude-smart"]
 
 
 def test_node_installer_migrates_existing_plugins_field(tmp_path: Path) -> None:

--- a/tests/test_reflexio_lock_script.py
+++ b/tests/test_reflexio_lock_script.py
@@ -1,0 +1,53 @@
+"""Tests for Reflexio dependency lock validation script."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECK_REFLEXIO_LOCK = REPO_ROOT / "scripts" / "check-reflexio-lock.py"
+
+
+def test_check_reflexio_lock_pypi_source_does_not_require_tomllib(
+    tmp_path: Path,
+) -> None:
+    scripts = tmp_path / "scripts"
+    plugin = tmp_path / "plugin"
+    scripts.mkdir()
+    plugin.mkdir()
+    shutil.copy2(CHECK_REFLEXIO_LOCK, scripts / "check-reflexio-lock.py")
+    (scripts / "tomllib.py").write_text(
+        "raise ModuleNotFoundError('simulated Python 3.9')\n"
+    )
+    dependency = "reflexio-ai>=0.2.27"
+    (plugin / "pyproject.toml").write_text(
+        f'[project]\ndependencies = ["{dependency}"]\n'
+    )
+    (tmp_path / "reflexio.lock.json").write_text(
+        json.dumps(
+            {
+                "package": "reflexio-ai",
+                "repo": "https://github.com/ReflexioAI/reflexio.git",
+                "version": "0.2.27",
+                "commit": "a" * 40,
+                "dependency": dependency,
+                "source": "pypi",
+                "updated_at": "2026-06-30T00:00:00Z",
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(scripts / "check-reflexio-lock.py")],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"OK: {dependency} (pypi)" in result.stdout

--- a/tests/test_reflexio_lock_script.py
+++ b/tests/test_reflexio_lock_script.py
@@ -51,3 +51,51 @@ def test_check_reflexio_lock_pypi_source_does_not_require_tomllib(
 
     assert result.returncode == 0, result.stderr
     assert f"OK: {dependency} (pypi)" in result.stdout
+
+
+def test_check_reflexio_lock_vendor_source_does_not_require_tomllib(
+    tmp_path: Path,
+) -> None:
+    scripts = tmp_path / "scripts"
+    plugin = tmp_path / "plugin"
+    vendor = plugin / "vendor" / "reflexio"
+    scripts.mkdir()
+    plugin.mkdir()
+    vendor.mkdir(parents=True)
+    shutil.copy2(CHECK_REFLEXIO_LOCK, scripts / "check-reflexio-lock.py")
+    (scripts / "tomllib.py").write_text(
+        "raise ModuleNotFoundError('simulated Python 3.9')\n"
+    )
+    dependency = "reflexio-ai>=0.2.27"
+    (plugin / "pyproject.toml").write_text(
+        f'[project]\ndependencies = ["{dependency}"]\n'
+    )
+    (vendor / "pyproject.toml").write_text(
+        '[project]\nname = "reflexio-ai"\nversion = "0.2.27"\n'
+    )
+    (tmp_path / "reflexio.lock.json").write_text(
+        json.dumps(
+            {
+                "package": "reflexio-ai",
+                "repo": "https://github.com/ReflexioAI/reflexio.git",
+                "version": "0.2.27",
+                "commit": "a" * 40,
+                "dependency": dependency,
+                "source": "vendor",
+                "vendor_path": "plugin/vendor/reflexio",
+                "updated_at": "2026-06-30T00:00:00Z",
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(scripts / "check-reflexio-lock.py"), "--check-vendor"],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "OK: vendored Reflexio bundle present" in result.stdout
+    assert f"OK: {dependency} (vendor)" in result.stdout


### PR DESCRIPTION
## Summary

- Fix the fresh OpenCode install failure in published `0.2.46`: `claude-smart install --host opencode` can bootstrap one package, then OpenCode can later load a different resolver-managed package that was never bootstrapped.
- During OpenCode install, prepare a stable local claude-smart package, verify it, and register OpenCode with that `file://` package so the runtime OpenCode loads is the runtime the installer prepared.
- Keep Claude Code and Codex install behavior unchanged, with host E2E coverage and CI guardrails to catch regressions.

## Changes

- Copy the active package to `~/.claude-smart/opencode/claude-smart`, bootstrap it during OpenCode install, verify its `smart-install.sh` fingerprint, and register that local package in OpenCode config.
- Stage and verify OpenCode package copies under an install lock before replacing any existing local package.
- Remove only known claude-smart OpenCode specs from config while preserving unrelated `file://.../claude-smart` paths.
- Validate the standalone `plugin/uv.lock` and run the Python test suite in CI.
- Add happy-path host E2E coverage for Claude Code, Codex, and OpenCode, plus targeted OpenCode config/copy/rollback tests.

## Test Plan

- Local: `uv --project plugin run pytest tests -q` -> `580 passed, 9 warnings`
- Local: `uv --project plugin run pytest tests/test_install_scripts.py -q` -> `102 passed, 1 warning`
- Local: `node --check bin/claude-smart.js` -> pass
- Local: `npm run build:opencode` -> pass
- Local: `make check-locked-project-version && make check-standalone-lock` -> pass
- CI: integration run `28500035029` is green for `pytest suite`, standalone lockfile, dependency platforms on macOS/Windows, and host integration on Ubuntu/macOS with Node 20/22.

## Release Note

A new npm version is needed after merge; `0.2.46` is already published and broken for fresh OpenCode installs. Use the release flow to publish a new version, for example `make release-npm VERSION=0.2.47`.
