### PR TITLE
chore: vendor Reflexio Sonnet 5 defaults

### DIFF
--- a/reflexio.lock.json
+++ b/reflexio.lock.json
@@ -2,8 +2,9 @@
   "package": "reflexio-ai",
   "repo": "https://github.com/ReflexioAI/reflexio.git",
   "version": "0.2.27",
-  "commit": "732e041dab9937d7065f1aba844564f048e3cedd",
+  "commit": "ad028f0951afba8811c40dbfe0971f2bd570c196",
   "dependency": "reflexio-ai>=0.2.27",
-  "source": "pypi",
-  "updated_at": "2026-06-30T06:26:39Z"
+  "source": "vendor",
+  "vendor_path": "plugin/vendor/reflexio",
+  "updated_at": "2026-06-30T21:43:02Z"
 }


### PR DESCRIPTION
## Summary
- Vendors the Reflexio commit that updates default Claude Sonnet usage to `claude-sonnet-5`.
- Switches claude-smart release metadata to vendor mode so npm packaging installs that exact Reflexio snapshot.
- Verifies the package path end to end, including tarball build and isolated Codex install from the artifact.

## Changes
- Release metadata
  - Updates `reflexio.lock.json` to `source=vendor` and pins Reflexio commit `ad028f0951afba8811c40dbfe0971f2bd570c196`.
- Packaging
  - Regenerates the local vendor bundle for packaging verification. The generated `plugin/vendor/reflexio` directory remains gitignored, as expected by the vendor-mode release flow.

## Related PRs
- Reflexio default update: https://github.com/ReflexioAI/reflexio/pull/260

## Test Plan
- `uv run --project plugin pytest --rootdir . -o addopts= tests -q` (`550 passed`)
- `make package`
- Tarball inspection confirmed packaged vendored Reflexio contains `claude-sonnet-5` defaults.
- Isolated npm install from `claude-smart-0.2.46.tgz` completed `claude-smart install --host codex --yes`, built the dashboard, installed bundled Reflexio, and the installed venv reported:
  - `claude_code.default_cli_model= claude-sonnet-5`
  - `anthropic.generation= claude-sonnet-5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Reflexio AI dependency metadata to a newer revision.
  * Switched the dependency source to a vendored version and refreshed its timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->