### PR TITLE
build: vendor reflexio working tree; split package vs release; drop uvx

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-smart",
-      "version": "0.2.46",
+      "version": "0.2.47",
       "source": "./plugin",
       "description": "Turns corrections into Preferences, Project-specific skills, and Shared skills — uses Claude Code, Codex, or OpenCode as the LLM backend (no external API key required)"
     }

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -166,7 +166,8 @@ Don't edit these by hand — use `make bump`.
 ### Prerequisites — one-time setup
 
 1. **npm**: `npm login` (writes a token to `~/.npmrc`). claude-smart is distributed via npm only — there is no PyPI publish of claude-smart itself.
-2. **git**: push access to `origin` for the tag push at the end of `make release`.
+2. **uv** + **Python 3.12**: on `PATH`. The release flow shells out to `uv` (e.g. `bump` regenerates the standalone `plugin/uv.lock` via `scripts/standalone-lock.sh`; `scripts/release-with-reflexio.sh` runs `uv sync`/`uv pip install` into the plugin `.venv`) and to `python3` (`scripts/vendor-reflexio.py`, `scripts/check-reflexio-lock.py`).
+3. **git**: push access to `origin` for the tag push at the end of `make release`.
 
 ### Path A: release claude-smart only
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ Internal notes for maintainers of `claude-smart`. End-user install instructions 
 | --- | --- |
 | `plugin/` | Claude Code plugin — hooks, slash commands, install script, and the Python package |
 | `plugin/src/claude_smart/` | Python package — hook handler, CLI, reflexio adapter |
-| `plugin/pyproject.toml` | Python manifest — shipped to PyPI via `uv build --project plugin` |
+| `plugin/pyproject.toml` | Python manifest for the plugin (deps + console scripts for the plugin venv); npm-only, not published to PyPI |
 | `tests/` | Pytest suite for the Python package (run via `uv run --project plugin pytest tests/ -q` from repo root) |
 | `bin/claude-smart.js` | Node wrapper so `npx claude-smart install` works |
 | `package.json` | npm manifest — ships `bin/`, marketplace metadata, `plugin/`, `README.md`, and `LICENSE` |
@@ -55,7 +55,7 @@ If you still want to use a cloud embedding provider (OpenAI, Gemini, etc.), omit
 ## Install dependency policy
 
 Vanilla install support means the user has installed the host (`claude` or
-`codex`) and the chosen installer runner (`npx` needs Node, `uvx` needs uv), but
+`codex`) and the installer runner (`npx`, which needs Node), but
 does not need global Python, uv, Node/npm for plugin runtime, npm packages, or
 embedding model files. The plugin bootstraps runtime dependencies into user
 state:
@@ -144,7 +144,7 @@ dynamic-param types, consult `plugin/dashboard/node_modules/next/dist/docs/`.
 ## Versioning
 
 `claude-smart` uses [semver](https://semver.org/). Release metadata must stay
-in lockstep — if it drifts, the npm wrapper, PyPI wheel, plugin metadata, and
+in lockstep — if it drifts, the npm wrapper, plugin metadata, vendor bundle, and
 marketplace entry can claim different versions, and users see confusing
 mismatches in `claude plugin list` vs. `npm view claude-smart version`.
 
@@ -165,13 +165,8 @@ Don't edit these by hand — use `make bump`.
 
 ### Prerequisites — one-time setup
 
-1. **npm**: `npm login` (writes a token to `~/.npmrc`).
-2. **PyPI**: create a project-scoped token at <https://pypi.org/manage/account/token/> and export it:
-   ```bash
-   export UV_PUBLISH_TOKEN=pypi-AgEN...
-   ```
-   Persist it in your shell rc if you release frequently.
-3. **git**: push access to `origin` for the tag push at the end of `make release`.
+1. **npm**: `npm login` (writes a token to `~/.npmrc`). claude-smart is distributed via npm only — there is no PyPI publish of claude-smart itself.
+2. **git**: push access to `origin` for the tag push at the end of `make release`.
 
 ### Path A: release claude-smart only
 
@@ -187,9 +182,8 @@ git pull --ff-only
 # 2. Dry-run to confirm what will ship.
 make publish-dry
 #   → npm: tarball includes bin/, .agents/plugins/marketplace.json, plugin/, LICENSE, README.md, package.json
-#   → PyPI: dist/ contains a wheel + sdist
 
-# 3. Bump, commit, tag, publish npm + PyPI, then push commit + tag.
+# 3. Bump, commit, tag, publish to npm, then push commit + tag.
 make release VERSION=<new-claude-smart-version>
 ```
 
@@ -238,34 +232,53 @@ claude-smart release commit and tag.
 
 ### What make release does
 
-For claude-smart, `make release` runs these steps in order and aborts on the
-first failure:
+`make release` is an alias for `make release-npm` — claude-smart is published to
+npm only. It runs these steps in order (Make evaluates the prerequisites
+left-to-right) and aborts on the first failure:
 
 1. `check-version` — regex-validates `VERSION` as semver.
-2. `check-clean` — refuses to run with a dirty working tree.
-3. `bump` — rewrites release metadata.
-4. `git add` + `git commit -m "Release v$VERSION"`.
-5. `git tag -a v$VERSION`.
-6. `publish-npm` → `npm publish --access public`.
-7. `publish-pypi` → `rm -rf dist/ && uv build && uv publish`.
-8. `git push --follow-tags`.
+2. `check-clean` — refuses to run with a dirty `claude-smart` working tree. Runs
+   **before** `vendor-release`, so the tree must be clean before vendoring
+   refreshes `reflexio.lock.json`.
+3. `check-npm-auth` — `NPM_TOKEN` is set or `npm whoami` succeeds.
+4. `vendor-release` — `python3 scripts/vendor-reflexio.py --require-clean --write`
+   self-vendors the reflexio working tree (which must equal committed HEAD,
+   enforced by `--require-clean`) and refreshes `reflexio.lock.json`, so a stale
+   vendor bundle can never block the release.
+5. `check-reflexio-lock` — `plugin/pyproject.toml`'s `reflexio-ai` pin matches
+   the lock.
+6. `check-reflexio-pin` — the vendored reflexio version exists on PyPI.
+7. `check-vendor-reflexio` — the vendor bundle is present and its version matches
+   the lock.
+8. `bump` — rewrites release metadata (and regenerates the standalone `plugin/uv.lock`).
+9. `check-locked-project-version` — `plugin/uv.lock`'s claude-smart version matches
+   `plugin/pyproject.toml`.
+10. `git add` (`VERSION_FILES` + `LOCK_FILES`, which includes the refreshed
+    `reflexio.lock.json`) + `git commit -m "Release v$VERSION"`.
+11. `git tag -a v$VERSION`.
+12. `publish-npm` → `npm run build:opencode` + `npm publish --access public`.
+13. `git push --follow-tags`.
 
-### Vendor-mode exception: unpublished Reflexio update
+### Vendor mode: unpublished Reflexio update
 
-Use vendor mode only when claude-smart needs Reflexio changes that should not or
-cannot be published to PyPI first. This is npm-only because the generated vendor
-bundle is included in the npm tarball, not the PyPI wheel.
+claude-smart is distributed via npm only, so `make release-npm` (aliased as
+`make release`) is always the release command. Use vendor mode when claude-smart
+needs Reflexio changes that should not or cannot be published to PyPI first: the
+generated Reflexio bundle is shipped inside the npm tarball rather than pulled
+from PyPI as a dependency.
 
 ```bash
 bash scripts/release-with-reflexio.sh
 make release-npm VERSION=<new-claude-smart-version>
 ```
 
-The helper exports the committed Reflexio `HEAD` into `plugin/vendor/reflexio`,
+The helper copies the committed Reflexio `HEAD` into `plugin/vendor/reflexio`,
 updates and commits `reflexio.lock.json`, and leaves the generated vendor bundle
-in the working tree. Keep `plugin/vendor/reflexio` in place until npm publish
-completes. `make release` intentionally refuses to publish PyPI while
-`reflexio.lock.json` says `source=vendor`.
+in the working tree. `make release-npm` then self-vendors again via its
+`vendor-release` step (`scripts/vendor-reflexio.py --require-clean --write`),
+which refuses a dirty Reflexio tree so the vendored bundle always equals the
+committed Reflexio `HEAD` — a stale bundle can never block a release. Keep
+`plugin/vendor/reflexio` in place until npm publish completes.
 
 Because publish happens **before** the push, a registry failure (e.g. auth expired) leaves the commit and tag local — you can fix the cause and re-run `make publish && git push --follow-tags` without re-bumping.
 
@@ -278,14 +291,10 @@ make bump VERSION=0.1.1
 git diff                                          # inspect
 git commit -am "Release v0.1.1"
 git tag -a v0.1.1 -m "Release v0.1.1"
-make publish                                      # both registries
+make publish                                      # npm publish (== publish-npm)
 git push --follow-tags
 
-# Only one registry (e.g. if the other published successfully and you're retrying).
-make publish-npm
-make publish-pypi
-
-# Vendor-mode Reflexio release (npm only).
+# Full vendor-and-release in one step (npm only).
 make release-npm VERSION=0.1.1
 
 # Preview without uploading anything.
@@ -299,7 +308,7 @@ make publish-dry
 Once published, end users update to the latest version with either:
 
 ```bash
-npx claude-smart update     # or: uvx claude-smart update
+npx claude-smart update
 ```
 
 Both wrap `claude plugin update claude-smart@reflexioai`. Users restart Claude Code to apply. Codex users rerun `npx claude-smart install --host codex`, then restart Codex after `/plugins` has upgraded the installed plugin.
@@ -322,9 +331,6 @@ Before running `make release`:
 
 **`npm publish` fails with `403 Forbidden`.**
 Usually means the version already exists. Check `npm view claude-smart versions`. npm does not allow re-uploading the same version — bump and re-release.
-
-**`uv publish` fails with `400 File already exists`.**
-Same as above for PyPI. Bump and re-release.
 
 **`uv build` produces a wheel that fails to install with `No matching distribution found for reflexio-ai`.**
 The committed `plugin/pyproject.toml` must resolve `reflexio-ai` from PyPI. If this release only needs Reflexio through the npm plugin artifact, use vendor mode instead of raising the PyPI dependency to an unpublished Reflexio version:
@@ -360,7 +366,7 @@ git commit -m "Sync Reflexio release metadata"
 **`make release` committed and tagged but `npm publish` failed after.**
 `publish` runs before `git push --follow-tags`, so nothing was pushed. Fix the cause (auth, network, registry), then:
 ```bash
-make publish           # retry both, or publish-npm / publish-pypi individually
+make publish           # re-runs npm publish
 git push --follow-tags
 ```
 If you need to *unwind* the local commit and tag:
@@ -377,12 +383,18 @@ rm -f package.json.bak pyproject.toml.bak .claude-plugin/*.bak
 
 ## Developing locally
 
-There is one local test path: build the npm tarball from this checkout and install it. The tarball bundles the plugin (and, in vendor mode, a Reflexio source snapshot), so installing it exercises your local plugin code end-to-end on both hosts.
+There is one local test path: build the npm tarball from this checkout and install it. The tarball bundles the plugin plus a Reflexio source snapshot, so installing it exercises your local plugin code end-to-end on both hosts.
 
 ```bash
 make package
 # → prints the absolute path of the resulting claude-smart-<version>.tgz
 ```
+
+`make package` vendors the **local Reflexio working tree** for testing:
+`python3 scripts/vendor-reflexio.py --bundle-only --write` then `npm pack`.
+Uncommitted Reflexio edits **are** included, it does not require a PyPI-published
+Reflexio version, and it does not touch `reflexio.lock.json` (`--bundle-only`
+regenerates only the bundle).
 
 Install the tarball globally and run the host installer:
 
@@ -422,7 +434,7 @@ Do **not** use `claude-smart update` for this loop — it wraps `claude plugin u
 
 For Reflexio backend changes, edit `open_source/reflexio/` and either:
 - Publish `reflexio-ai` to PyPI and use [Path B](#path-b-release-claude-smart-with-a-published-reflexio-update), or
-- Use [vendor mode](#vendor-mode-exception-unpublished-reflexio-update) — `make package` then bundles the local Reflexio source into `plugin/vendor/reflexio` so the tarball install picks it up.
+- Use [vendor mode](#vendor-mode-unpublished-reflexio-update) — `make package` bundles the local Reflexio working tree into `plugin/vendor/reflexio` so the tarball install picks it up (uncommitted edits included).
 
 What's picked up after each reinstall + host restart:
 

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,25 @@
 #
 # Usage:
 #   make bump VERSION=0.1.1          Update version in all release manifests
-#   make release VERSION=0.1.1       Bump, commit, tag v0.1.1, publish, push
-#   make release-npm VERSION=0.1.1   Bump, commit, tag, publish npm only
-#   make publish                     Publish current version to npm + PyPI
+#   make release VERSION=0.1.1       Alias for release-npm (claude-smart ships via npm only)
+#   make release-npm VERSION=0.1.1   Re-vendor reflexio, bump, commit, tag, publish npm, push
+#   make publish                     Publish current version to npm
 #   make publish-npm                 npm publish only
-#   make publish-pypi                uv build + uv publish only
 #   make publish-dry                 Show what would ship without uploading
-#   make package                     Build the npm tarball locally without publishing
+#   make package                     Build the npm tarball locally (vendors local reflexio working tree)
+#
+# claude-smart is distributed exclusively via npm; it is no longer published to
+# PyPI (uvx install is unsupported). The reflexio-ai dependency still resolves
+# from PyPI, and a release always vendors the current reflexio submodule.
 #
 # Requires:
 #   - npm (logged in, or NPM_TOKEN set)
-#   - uv (UV_PUBLISH_TOKEN set for PyPI uploads)
+#   - uv (for standalone lockfile resolution + the plugin venv)
 #   - git (for the release flow)
 
-.PHONY: help bump release release-npm publish publish-npm publish-pypi publish-dry package \
+.PHONY: help bump release release-npm publish publish-npm publish-dry package vendor-release \
         check-version check-clean check-npm-auth check-reflexio-pin check-reflexio-lock \
-        check-vendor-reflexio check-pypi-compatible-reflexio \
+        check-vendor-reflexio \
         check-locked-project-version check-standalone-lock relock unskip-worktree
 
 VERSION_FILES := package.json plugin/pyproject.toml \
@@ -59,8 +62,9 @@ check-reflexio-lock: ## Verify plugin/pyproject.toml matches reflexio.lock.json
 check-vendor-reflexio: ## Verify generated Reflexio vendor bundle exists when the lock requires it
 	@python3 scripts/check-reflexio-lock.py --check-vendor
 
-check-pypi-compatible-reflexio: ## Refuse PyPI publish when this release relies on a generated vendor bundle
-	@python3 -c 'import json, pathlib, sys; p=pathlib.Path("reflexio.lock.json"); data=json.loads(p.read_text()) if p.exists() else {}; sys.exit("error: reflexio.lock.json uses source=vendor; publish npm only with `make release-npm VERSION=...`, or run `REFLEXIO_RELEASE_SOURCE=pypi bash scripts/release-with-reflexio.sh` first" if data.get("source") == "vendor" else 0)'
+vendor-release: unskip-worktree ## Re-vendor the current (clean) reflexio submodule + refresh reflexio.lock.json
+	@echo "→ vendoring reflexio submodule (must be clean) into plugin/vendor/reflexio"
+	@python3 scripts/vendor-reflexio.py --require-clean --write
 
 check-npm-auth: ## Verify npm auth via NPM_TOKEN or `npm whoami`; fail if neither is available
 	@if [ -n "$$NPM_TOKEN" ]; then \
@@ -120,23 +124,14 @@ publish-npm: check-vendor-reflexio check-locked-project-version check-standalone
 	npm run build:opencode
 	npm publish --access public
 
-publish-pypi: check-pypi-compatible-reflexio unskip-worktree ## Build and publish the current version to PyPI
-	@echo "→ uv build + uv publish"
-	rm -rf plugin/dist/
-	uv build --project plugin --out-dir plugin/dist
-	uv publish --project plugin plugin/dist/*
-
 publish-dry: unskip-worktree check-vendor-reflexio check-locked-project-version check-standalone-lock ## Show what would be published without uploading
 	@echo "→ npm publish --dry-run"
 	@npm run build:opencode
 	@npm publish --dry-run
-	@echo ""
-	@echo "→ uv build (dry: inspect plugin/dist/ manually)"
-	rm -rf plugin/dist/
-	uv build --project plugin
-	@ls -la plugin/dist/
 
-package: check-vendor-reflexio check-locked-project-version check-standalone-lock ## Build the npm tarball locally without publishing
+package: check-locked-project-version check-standalone-lock ## Build the npm tarball locally (vendors the local reflexio working tree)
+	@echo "→ vendoring local reflexio working tree (uncommitted edits included) into plugin/vendor/reflexio"
+	@python3 scripts/vendor-reflexio.py --bundle-only --write
 	@echo "→ npm pack"
 	@npm run build:opencode
 	@tarball=$$(npm pack 2>/dev/null | tail -1); \
@@ -152,19 +147,12 @@ package: check-vendor-reflexio check-locked-project-version check-standalone-loc
 	  echo "  npx --package=$$abs -- claude-smart install --host codex"; \
 	  echo "  npx --package=$$abs -- claude-smart install --host opencode"
 
-publish: check-pypi-compatible-reflexio publish-npm publish-pypi ## Publish to both npm and PyPI
+publish: publish-npm ## Publish the current version to npm (claude-smart is npm-only)
 
-release: check-version check-clean check-npm-auth check-reflexio-lock check-reflexio-pin check-pypi-compatible-reflexio bump check-locked-project-version ## Bump + commit + tag + publish + push
-	@echo "→ committing release v$(VERSION)"
-	git add $(VERSION_FILES) $(LOCK_FILES)
-	git commit -m "Release v$(VERSION)"
-	git tag -a v$(VERSION) -m "Release v$(VERSION)"
-	@$(MAKE) publish
-	@echo "→ pushing commit + tag"
-	git push --follow-tags
-	@echo "✓ released v$(VERSION)"
+release: ## Alias for release-npm — claude-smart is distributed via npm only
+	@$(MAKE) release-npm VERSION=$(VERSION)
 
-release-npm: check-version check-clean check-npm-auth check-reflexio-lock check-reflexio-pin check-vendor-reflexio bump check-locked-project-version ## Bump + commit + tag + publish npm only
+release-npm: check-version check-clean check-npm-auth vendor-release check-reflexio-lock check-reflexio-pin check-vendor-reflexio bump check-locked-project-version ## Re-vendor + bump + commit + tag + publish npm
 	@echo "→ committing npm release v$(VERSION)"
 	git add $(VERSION_FILES) $(LOCK_FILES)
 	git commit -m "Release v$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
   </a>
   <a href="plugin/pyproject.toml">
-    <img src="https://img.shields.io/badge/version-0.2.46-green.svg" alt="Version">
+    <img src="https://img.shields.io/badge/version-0.2.47-green.svg" alt="Version">
   </a>
   <a href="plugin/pyproject.toml">
     <img src="https://img.shields.io/badge/python-%3E%3D3.12-brightgreen.svg" alt="Python">

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@
 ### Claude Code
 
 ```bash
-npx claude-smart install     # or: uvx claude-smart install
+npx claude-smart install
 ```
 
 Then restart Claude Code.
 
-Requires Node.js (for `npx`) or uv (for `uvx`) to already exist.
+Requires Node.js (for `npx`) to already exist.
 
 Alternatively, install via Claude Code's plugin marketplace:
 
@@ -78,7 +78,7 @@ claude plugin install claude-smart@reflexioai
 To uninstall:
 
 ```bash
-npx claude-smart uninstall     # or: uvx claude-smart uninstall
+npx claude-smart uninstall
 ```
 
 Or, if installed via the plugin marketplace:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-smart",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-smart",
-      "version": "0.2.46",
+      "version": "0.2.47",
       "license": "Apache-2.0",
       "bin": {
         "claude-smart": "bin/claude-smart.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
   "author": {
     "name": "Yi Lu"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-smart",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Self-improving coding assistant plugin — learns from corrections across sessions via reflexio",
   "author": {
     "name": "Yi Lu"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,7 +2,7 @@
 
 Self-improving [Claude Code](https://claude.com/claude-code), Codex, and OpenCode plugin — turns corrections and successful workflows into durable Preferences, Project-specific skills, and Shared skills that future sessions follow, via [reflexio](https://github.com/ReflexioAI/reflexio).
 
-This directory is the published Python package (`claude-smart` on PyPI) and the Claude Code/Codex/OpenCode plugin payload shipped through the marketplace and npm. For the project overview, install instructions, benchmarks, and feature walkthrough, see the [top-level README](https://github.com/ReflexioAI/claude-smart#readme).
+This directory is the Claude Code/Codex/OpenCode plugin payload shipped through the marketplace and the `claude-smart` npm package. For the project overview, install instructions, benchmarks, and feature walkthrough, see the [top-level README](https://github.com/ReflexioAI/claude-smart#readme).
 
 ## Install
 
@@ -15,8 +15,7 @@ claude plugin install claude-smart@reflexioai
 
 The Setup hook bootstraps `uv`, Python 3.12, and a private Node.js/npm runtime
 under `~/.claude-smart/` when they are missing. If Node.js is already installed,
-`npx claude-smart install` is equivalent; if uv is already installed,
-`uvx claude-smart install` is equivalent.
+`npx claude-smart install` is equivalent.
 
 Add `--read-only` to either install command to skip hooks that publish
 interactions for learning.
@@ -56,10 +55,10 @@ Preferences, Project-specific skills, and Shared skills as Claude Code and Codex
 claude plugin uninstall claude-smart@reflexioai
 ```
 
-Or, if Node.js or uv is already installed:
+Or, if Node.js is already installed:
 
 ```bash
-npx claude-smart uninstall   # or: uvx claude-smart uninstall
+npx claude-smart uninstall
 ```
 
 ### Codex

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -38,9 +38,13 @@ dependencies = [
     "sqlite-vec>=0.1.6",
 ]
 
+# claude-smart is distributed via npm only (see bin/claude-smart.js); it is not
+# published to PyPI, so there is no `claude-smart` console script / uvx entry
+# point. These two scripts are resolved by the runtime from the plugin venv
+# (session_start.py locates claude-smart-optimizer-assistant; the hook is invoked
+# via `python -m claude_smart.hook`), so they stay.
 [project.scripts]
 claude-smart-hook = "claude_smart.hook:main"
-claude-smart = "claude_smart.cli:main"
 claude-smart-optimizer-assistant = "claude_smart.optimizer_assistant:main"
 
 [build-system]

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-smart"
-version = "0.2.46"
+version = "0.2.47"
 description = "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills"
 keywords = [
     "claude",

--- a/plugin/uv.lock
+++ b/plugin/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "claude-smart"
-version = "0.2.46"
+version = "0.2.47"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },

--- a/reflexio.lock.json
+++ b/reflexio.lock.json
@@ -2,9 +2,9 @@
   "package": "reflexio-ai",
   "repo": "https://github.com/ReflexioAI/reflexio.git",
   "version": "0.2.27",
-  "commit": "ad028f0951afba8811c40dbfe0971f2bd570c196",
+  "commit": "21d1167f9cb28881857969779b33be3a57abf40a",
   "dependency": "reflexio-ai>=0.2.27",
   "source": "vendor",
   "vendor_path": "plugin/vendor/reflexio",
-  "updated_at": "2026-06-30T21:43:02Z"
+  "updated_at": "2026-07-01T08:29:54Z"
 }

--- a/scripts/release-with-reflexio.sh
+++ b/scripts/release-with-reflexio.sh
@@ -78,6 +78,7 @@ case "$REFLEXIO_RELEASE_SOURCE" in
     ensure_commit_inputs_clean "${COMMIT_FILES[@]}"
     "$PYTHON_BIN" scripts/vendor-reflexio.py \
       --reflexio-path "$REFLEXIO_PATH" \
+      --require-clean \
       --write
     uv sync --project plugin --locked
     PLUGIN_PYTHON="$REPO_ROOT/plugin/.venv/bin/python"

--- a/scripts/vendor-reflexio.py
+++ b/scripts/vendor-reflexio.py
@@ -131,6 +131,49 @@ VENDOR_IGNORE = shutil.ignore_patterns(
 REQUIRED_VENDOR_PATHS = ("pyproject.toml", "reflexio")
 
 
+def safe_vendor_src(reflexio_path: Path, root: Path, rel: str) -> Path:
+    """Resolve an include entry to a path guaranteed to sit inside the checkout.
+
+    The include list is metadata-driven (Reflexio's own pyproject sdist config
+    plus defaults), so guard against a malformed or hostile entry escaping the
+    checkout via an absolute path, ``..`` traversal, or a symlinked top-level
+    entry before it is copied into the published npm payload.
+
+    Args:
+        reflexio_path (Path): Root of the Reflexio checkout.
+        root (Path): ``reflexio_path`` resolved (passed in to avoid re-resolving).
+        rel (str): Include entry relative to the checkout root.
+
+    Returns:
+        Path: ``reflexio_path / rel``, validated to stay within the checkout.
+
+    Raises:
+        SystemExit: If the entry is absolute, contains ``..``, or resolves outside.
+    """
+    rel_path = Path(rel)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        fail(f"vendored include path must stay inside the Reflexio checkout: {rel!r}")
+    src = reflexio_path / rel_path
+    resolved = src.resolve()
+    if resolved != root and root not in resolved.parents:
+        fail(f"vendored include path escapes the Reflexio checkout: {rel!r}")
+    return src
+
+
+def ignore_vendor_entries(src_dir: str, names: list[str]) -> set[str]:
+    """copytree ignore filter: drop the usual junk plus any symlink.
+
+    Dropping symlinks (rather than following them) keeps a link inside the
+    Reflexio tree from dereferencing an out-of-checkout target into the vendored
+    bundle. This matches the old ``git archive`` behaviour of never copying
+    external file contents into the release payload.
+    """
+    ignored = set(VENDOR_IGNORE(src_dir, names))
+    src_path = Path(src_dir)
+    ignored.update(name for name in names if (src_path / name).is_symlink())
+    return ignored
+
+
 def copy_worktree(reflexio_path: Path, vendor_dest: Path, files: list[str]) -> None:
     """Copy the current Reflexio working tree into the vendor destination.
 
@@ -147,6 +190,7 @@ def copy_worktree(reflexio_path: Path, vendor_dest: Path, files: list[str]) -> N
     Raises:
         SystemExit: If a required package path (pyproject.toml, reflexio) is missing.
     """
+    root = reflexio_path.resolve()
     for required in REQUIRED_VENDOR_PATHS:
         if not (reflexio_path / required).exists():
             fail(f"Reflexio checkout is missing required path: {required}")
@@ -154,12 +198,14 @@ def copy_worktree(reflexio_path: Path, vendor_dest: Path, files: list[str]) -> N
         shutil.rmtree(vendor_dest)
     vendor_dest.mkdir(parents=True)
     for rel in files:
-        src = reflexio_path / rel
+        src = safe_vendor_src(reflexio_path, root, rel)
         if not src.exists():
             continue
         dest = vendor_dest / rel
         if src.is_dir():
-            shutil.copytree(src, dest, ignore=VENDOR_IGNORE)
+            # ignore_symlinks drops any symlink so the metadata-driven include
+            # list cannot dereference a link into the published npm payload.
+            shutil.copytree(src, dest, ignore=ignore_vendor_entries)
         else:
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dest)

--- a/scripts/vendor-reflexio.py
+++ b/scripts/vendor-reflexio.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
-"""Vendor a Reflexio checkout into the npm release payload.
+"""Vendor the current Reflexio checkout into the npm release payload.
 
 This keeps claude-smart and Reflexio as independent repositories during normal
 development, while allowing a claude-smart npm release to carry an exact
 Reflexio source snapshot without requiring user machines to clone GitHub.
+
+Both `make package` (local testing) and `make release-npm` vendor the Reflexio
+submodule **as it is right now** — the working tree, so uncommitted edits are
+captured too. `make release-npm` passes ``--require-clean`` so the vendored tree
+equals the committed HEAD (reproducible, traceable via the recorded commit),
+while `make package` allows a dirty tree and passes ``--bundle-only`` so it never
+rewrites the tracked reflexio.lock.json.
 """
 
 from __future__ import annotations
@@ -13,11 +20,10 @@ import json
 import shutil
 import subprocess
 import sys
-import tarfile
-import tempfile
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import NoReturn
 
 PACKAGE_NAME = "reflexio-ai"
 REPO_URL = "https://github.com/ReflexioAI/reflexio.git"
@@ -25,7 +31,7 @@ VENDOR_PATH = Path("plugin/vendor/reflexio")
 DEFAULT_INCLUDE = ["pyproject.toml", "README.md", "LICENSE", ".env.example", "reflexio"]
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     print(f"error: {message}", file=sys.stderr)
     raise SystemExit(1)
 
@@ -111,34 +117,52 @@ def current_dependency(repo_root: Path) -> str:
     return dependency
 
 
-def export_reflexio(
-    reflexio_path: Path,
-    commit: str,
-    vendor_dest: Path,
-    files: list[str],
-) -> None:
-    with tempfile.TemporaryDirectory(prefix="claude-smart-reflexio-") as tmp:
-        archive = Path(tmp) / "reflexio.tar"
-        try:
-            with archive.open("wb") as handle:
-                subprocess.run(
-                    ["git", "-C", str(reflexio_path), "archive", "--format=tar", commit, *files],
-                    check=True,
-                    stdout=handle,
-                    stderr=subprocess.PIPE,
-                    text=False,
-                )
-        except subprocess.CalledProcessError as exc:
-            detail = (exc.stderr or b"").decode(errors="replace").strip()
-            fail(f"git archive failed: {detail or f'exit {exc.returncode}'}")
-        if vendor_dest.exists():
-            shutil.rmtree(vendor_dest)
-        vendor_dest.mkdir(parents=True)
-        with tarfile.open(archive) as tar:
-            if sys.version_info >= (3, 12):
-                tar.extractall(vendor_dest, filter="data")
-            else:
-                tar.extractall(vendor_dest)
+VENDOR_IGNORE = shutil.ignore_patterns(
+    ".git",
+    ".venv",
+    "__pycache__",
+    "*.pyc",
+    "*.pyo",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "*.egg-info",
+)
+REQUIRED_VENDOR_PATHS = ("pyproject.toml", "reflexio")
+
+
+def copy_worktree(reflexio_path: Path, vendor_dest: Path, files: list[str]) -> None:
+    """Copy the current Reflexio working tree into the vendor destination.
+
+    Unlike a ``git archive`` of HEAD, this captures uncommitted edits too, so
+    ``make package`` can vendor local Reflexio changes for testing. Callers that
+    need reproducibility (release) pass ``--require-clean`` so the working tree
+    equals the committed HEAD.
+
+    Args:
+        reflexio_path (Path): Root of the Reflexio checkout to copy from.
+        vendor_dest (Path): Destination directory (wiped and recreated).
+        files (list[str]): Top-level paths to include, relative to reflexio_path.
+
+    Raises:
+        SystemExit: If a required package path (pyproject.toml, reflexio) is missing.
+    """
+    for required in REQUIRED_VENDOR_PATHS:
+        if not (reflexio_path / required).exists():
+            fail(f"Reflexio checkout is missing required path: {required}")
+    if vendor_dest.exists():
+        shutil.rmtree(vendor_dest)
+    vendor_dest.mkdir(parents=True)
+    for rel in files:
+        src = reflexio_path / rel
+        if not src.exists():
+            continue
+        dest = vendor_dest / rel
+        if src.is_dir():
+            shutil.copytree(src, dest, ignore=VENDOR_IGNORE)
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
 
 
 def existing_updated_at(lock_file: Path, payload: dict[str, str]) -> str | None:
@@ -195,9 +219,17 @@ def parse_args() -> argparse.Namespace:
         help="Path to Reflexio checkout (default: ../reflexio relative to claude-smart)",
     )
     parser.add_argument(
-        "--allow-dirty",
+        "--require-clean",
         action="store_true",
-        help="Allow uncommitted Reflexio changes. The committed HEAD is still what gets vendored.",
+        help=(
+            "Fail if the Reflexio checkout has uncommitted changes. Used by release so the "
+            "vendored working tree equals the committed HEAD. Omit for `make package`."
+        ),
+    )
+    parser.add_argument(
+        "--bundle-only",
+        action="store_true",
+        help="Regenerate only the vendor bundle; do not write reflexio.lock.json (local testing).",
     )
     parser.add_argument(
         "--require-origin-main",
@@ -221,13 +253,12 @@ def main() -> int:
         fail(f"Reflexio path does not exist: {reflexio_path}")
 
     package, version = read_project_metadata(reflexio_path)
-    if not args.allow_dirty:
-        dirty = run_git(reflexio_path, "status", "--porcelain")
-        if dirty:
-            fail(
-                f"Reflexio checkout has uncommitted changes at {reflexio_path}. "
-                "Commit/stash them or pass --allow-dirty."
-            )
+    dirty = run_git(reflexio_path, "status", "--porcelain")
+    if args.require_clean and dirty:
+        fail(
+            f"Reflexio checkout has uncommitted changes at {reflexio_path}. "
+            "Commit/stash them or drop --require-clean (only `make package` allows a dirty tree)."
+        )
     commit = run_git(reflexio_path, "rev-parse", "HEAD")
     if args.require_origin_main:
         run_git(reflexio_path, "fetch", "origin", "main", capture=False)
@@ -243,7 +274,15 @@ def main() -> int:
     include_paths = package_include_paths(reflexio_path)
     vendor_dest = repo_root / VENDOR_PATH
     lock_file = repo_root / "reflexio.lock.json"
-    lock_changed = write_lock(lock_file, version, commit, dependency, write=args.write)
+    if not args.bundle_only and dirty:
+        print(
+            "warning: Reflexio checkout is dirty; reflexio.lock.json will record HEAD "
+            f"({commit[:12]}), which may not match the vendored working tree.",
+            file=sys.stderr,
+        )
+    lock_changed = (
+        None if args.bundle_only else write_lock(lock_file, version, commit, dependency, write=args.write)
+    )
 
     print(f"Reflexio path: {reflexio_path}")
     print(f"Reflexio package: {package}")
@@ -256,13 +295,19 @@ def main() -> int:
         print(f"  {include_path}")
 
     if args.write:
-        export_reflexio(reflexio_path, commit, vendor_dest, include_paths)
+        copy_worktree(reflexio_path, vendor_dest, include_paths)
         print(f"Updated: {VENDOR_PATH}")
-        print(f"{'Updated' if lock_changed else 'Unchanged'}: reflexio.lock.json")
+        if args.bundle_only:
+            print("Skipped: reflexio.lock.json (--bundle-only)")
+        else:
+            print(f"{'Updated' if lock_changed else 'Unchanged'}: reflexio.lock.json")
     else:
         print("Dry run only; no files changed.")
         print(f"Would update: {VENDOR_PATH}")
-        print(f"Would update: {'reflexio.lock.json' if lock_changed else 'no lock change'}")
+        if args.bundle_only:
+            print("Would skip: reflexio.lock.json (--bundle-only)")
+        else:
+            print(f"Would update: {'reflexio.lock.json' if lock_changed else 'no lock change'}")
     return 0
 
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1333,7 +1333,12 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     gitignore = (REPO_ROOT / ".gitignore").read_text()
 
     assert "plugin/vendor/reflexio" in vendor_script
-    assert 'git", "-C", str(reflexio_path), "archive"' in vendor_script
+    # Vendoring copies the current reflexio working tree (captures uncommitted
+    # edits for `make package`); release passes --require-clean so the tree == HEAD.
+    assert "def copy_worktree(" in vendor_script
+    assert "shutil.copytree(src, dest, ignore=VENDOR_IGNORE)" in vendor_script
+    assert "--require-clean" in vendor_script
+    assert "--bundle-only" in vendor_script
     assert '"source": "vendor"' in vendor_script
     assert '"vendor_path": str(VENDOR_PATH)' in vendor_script
     assert "package_include_paths" in vendor_script
@@ -1805,11 +1810,13 @@ def test_vendor_release_is_npm_only() -> None:
     developer = (REPO_ROOT / "DEVELOPER.md").read_text()
 
     assert "release-npm:" in makefile
-    assert "check-pypi-compatible-reflexio:" in makefile
-    assert "source=vendor" in makefile
-    assert "make release-npm VERSION=..." in makefile
+    # claude-smart is npm-only: its own PyPI wheel publish (uvx) was removed.
+    assert "publish-pypi" not in makefile
+    assert "check-pypi-compatible-reflexio" not in makefile
+    # release-npm self-vendors the current (clean) reflexio submodule before publishing.
+    assert "vendor-release:" in makefile
+    assert "python3 scripts/vendor-reflexio.py --require-clean --write" in makefile
     assert "make release-npm VERSION=<new-claude-smart-version>" in developer
-    assert "intentionally refuses to publish PyPI" in developer
 
 
 def test_backend_service_configures_shared_embedding_daemon() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1336,7 +1336,12 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     # Vendoring copies the current reflexio working tree (captures uncommitted
     # edits for `make package`); release passes --require-clean so the tree == HEAD.
     assert "def copy_worktree(" in vendor_script
-    assert "shutil.copytree(src, dest, ignore=VENDOR_IGNORE)" in vendor_script
+    assert "shutil.copytree(src, dest, ignore=ignore_vendor_entries)" in vendor_script
+    # Include paths are validated to stay inside the checkout and symlinks are
+    # dropped, so a metadata-driven include cannot escape into the npm payload.
+    assert "def safe_vendor_src(" in vendor_script
+    assert "escapes the Reflexio checkout" in vendor_script
+    assert "is_symlink()" in vendor_script
     assert "--require-clean" in vendor_script
     assert "--bundle-only" in vendor_script
     assert '"source": "vendor"' in vendor_script

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -173,10 +173,7 @@ def test_package_target_checks_standalone_lock_freshness() -> None:
 
     assert "check-standalone-lock:" in makefile
     assert "bash scripts/standalone-lock.sh --check" in makefile
-    assert (
-        "package: check-vendor-reflexio check-locked-project-version "
-        "check-standalone-lock"
-    ) in makefile
+    assert "package: check-locked-project-version check-standalone-lock" in makefile
 
 
 def test_opencode_bridge_does_not_call_pre_tool() -> None:


### PR DESCRIPTION
## Summary

- Unblocks `make release-npm` (was failing on a stale vendor bundle: `0.2.26` on disk vs `0.2.27` in the lock) and makes that failure class impossible going forward.
- Splits the two reflexio-vendoring intents cleanly: **release** vendors the current reflexio submodule with guards; **`make package`** vendors the local reflexio **working tree** (uncommitted edits included) for local testing.
- Drops claude-smart's own PyPI / `uvx` install path — npm is now the sole distribution channel. (The `reflexio-ai` *dependency* still resolves from PyPI; only claude-smart's own wheel/uvx entry goes away.)

## Changes

**Vendoring (`scripts/vendor-reflexio.py`)**
- Copies the reflexio submodule **working tree** instead of `git archive HEAD`, so both commands vendor "whatever is in the submodule right now."
- New `--require-clean` (release: refuse a dirty tree so the vendored tree == committed HEAD) and `--bundle-only` (package: regenerate only the bundle, don't write `reflexio.lock.json`). Removed `--allow-dirty`.

**Makefile**
- `make package` now actively vendors the local working tree (`--bundle-only --write`) then `npm pack` — local reflexio edits are testable without publishing or committing.
- `make release-npm` self-vendors via a new `vendor-release` step (`--require-clean --write`) before its guards, so a stale bundle can never block a release.
- Removed claude-smart's PyPI publish: deleted `publish-pypi` and `check-pypi-compatible-reflexio`, dropped the PyPI half of `publish`/`publish-dry`. `make publish` == `publish-npm`; `make release` is an alias of `make release-npm`.

**uvx removal**
- Removed the `claude-smart = "claude_smart.cli:main"` console-script entry (`plugin/pyproject.toml`); kept `claude-smart-hook` / `claude-smart-optimizer-assistant` (runtime-resolved).
- Stripped `uvx` install/uninstall/update instructions and the claude-smart-PyPI-publish narrative from `README.md`, `plugin/README.md`, `DEVELOPER.md`. Corrected the "What make release does" step list to match the Makefile's actual prerequisite order.

**Provenance**
- Refreshed `plugin/vendor/reflexio/` + `reflexio.lock.json` to reflexio `0.2.27` (commit `21d1167`).

## Test Plan

- `uv run pytest tests/test_install_scripts.py tests/test_reflexio_lock_script.py` → **104 passed** (includes the npm-only Makefile assertions, DEVELOPER.md release-doc checks, and a tarball-build test).
- Functional checks:
  - `vendor-reflexio.py --require-clean` **refuses** a dirty reflexio tree.
  - `vendor-reflexio.py --bundle-only --write` copies the working tree (an untracked marker showed up in the bundle) and leaves `reflexio.lock.json` unchanged.
  - `make package` builds the tarball; `tar tzf` confirms it ships `plugin/vendor/reflexio/{pyproject.toml,reflexio/__init__.py}`.
  - `check-vendor-reflexio` + `check-reflexio-lock` pass after the re-vendor; `reflexio-ai 0.2.27` is on PyPI, so `make release-npm VERSION=0.2.47` is ready.
- `pyright scripts/vendor-reflexio.py` clean. (Remaining ruff `S603/S607/S101` are pre-existing default-ruleset noise — no `[tool.ruff]` config — and this change reduced the subprocess ones 4→2.)

> Note: two claude-smart learned rules still describe the old `git archive HEAD` behavior ("uncommitted reflexio changes are NOT picked up by make package"); those are now stale and worth updating separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated install/uninstall and Claude Code quick-start to use npm-only commands (`npx claude-smart install` / `npx claude-smart uninstall`), removing `uvx` alternatives and clarifying Node.js requirements.
  * Refreshed plugin documentation wording for the npm-distributed payload.
* **Release & Publishing**
  * Streamlined releases to npm-only; `make release` now follows the npm publish flow and PyPI publishing paths are removed.
  * Updated release failure/retry guidance for npm publish outcomes.
* **Packaging**
  * Updated the Reflexio vendoring/bundling process used for npm releases, including bundle regeneration and lock refresh during release.
* **Tests**
  * Updated tests to match the npm-only publishing and revised vendoring/bundling flow.
* **Chores**
  * Bumped version to **0.2.47** across project/marketplace manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->