### PR TITLE
fix: resolve issue #96 embedding startup retry

### DIFF
--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -71,7 +71,8 @@ if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
     # resolves opencode from CLAUDE_SMART_OPENCODE_PATH or PATH; don't require
     # Git Bash's PATH to match the installer shell's PATH here.
     claude_smart_prepend_node_bins
-    export CLAUDE_SMART_CLI_PATH="$(claude_smart_opencode_compat_path "$PLUGIN_ROOT")"
+    CLAUDE_SMART_CLI_PATH="$(claude_smart_opencode_compat_path "$PLUGIN_ROOT")"
+    export CLAUDE_SMART_CLI_PATH
   elif [ "${CLAUDE_SMART_HOST:-claude-code}" = "codex" ]; then
     # Reflexio's provider still calls CLAUDE_SMART_CLI_PATH with Claude CLI
     # flags. Use a small compatibility executable that translates that narrow
@@ -139,7 +140,30 @@ kill_group() {
 # you'll get collision regardless of what we do here.
 backend_healthy() {
   command -v curl >/dev/null 2>&1 || return 1
-  curl -sf -o /dev/null "http://127.0.0.1:$PORT/health" 2>/dev/null
+  curl -sf --connect-timeout 1 --max-time 1 -o /dev/null "http://127.0.0.1:$PORT/health" 2>/dev/null
+}
+
+embedding_healthy() {
+  [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
+  command -v curl >/dev/null 2>&1 || return 1
+  curl -sf --connect-timeout 1 --max-time 1 -o /dev/null "http://127.0.0.1:$EMBEDDING_PORT/health" 2>/dev/null
+}
+
+wait_for_health() {
+  probe_fn="$1"
+  attempts="$2"
+  interval="$3"
+  while [ "$attempts" -gt 0 ]; do
+    "$probe_fn" && return 0
+    attempts=$((attempts - 1))
+    sleep "$interval"
+  done
+  "$probe_fn"
+}
+
+log_embedding_degraded() {
+  claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+    "[claude-smart] backend: Embedding service did not become healthy on port $EMBEDDING_PORT; semantic retrieval remains unavailable until the local embedding daemon recovers"
 }
 
 # True only if the recorded PID is alive AND /health responds. A stale
@@ -275,12 +299,14 @@ case "$CMD" in
     if [ "${CLAUDE_SMART_BACKEND_AUTOSTART:-1}" = "0" ]; then
       emit_ok; exit 0
     fi
-    if is_our_backend_running; then emit_ok; exit 0; fi
+    if is_our_backend_running; then
+      embedding_healthy || log_embedding_degraded
+      emit_ok; exit 0
+    fi
     if port_occupied; then
-      # Something answered the TCP probe but /health didn't — don't
-      # start a second uvicorn on top of it. Surface the holder so the
-      # user knows which process to quit (common case: editor/dev tool
-      # squatting 8071) instead of silently failing.
+      # is_our_backend_running already ruled out a healthy Reflexio backend.
+      # Anything still holding the port would make uvicorn fail to bind, so
+      # surface the holder instead of silently starting into a collision.
       holder="$(port_holder "$PORT" 2>/dev/null || true)"
       msg="[claude-smart] backend: port $PORT held by another process${holder:+ ($holder)}; skipping start"
       claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "$msg"
@@ -350,27 +376,27 @@ case "$CMD" in
     # Claude Code sessions or wanting zero-downtime recycling.
     workers="${CLAUDE_SMART_BACKEND_WORKERS:-1}"
     backend_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"
+    # Record the spawned pid, not a pgid sampled with ps. On POSIX,
+    # setsid/python os.setsid make this pid the new process group leader;
+    # sampling immediately can race and capture the caller's pgid instead.
+    # On Windows, claude_smart_kill_tree translates the MSYS pid to WINPID.
     claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
       "$LOG_FILE" "$LOG_MAX_BYTES" -- \
       env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
       PYTHONPATH="$backend_pythonpath" \
       "$backend_python" -m reflexio.cli services start --only backend --no-reload --workers "$workers"
     svc_pid=$!
-    # Record the spawned pid, not a pgid sampled with ps. On POSIX,
-    # setsid/python os.setsid make this pid the new process group leader;
-    # sampling immediately can race and capture the caller's pgid instead.
-    # On Windows, claude_smart_kill_tree translates the MSYS pid to WINPID.
     echo "$svc_pid" > "$PID_FILE"
 
-    # Give uvicorn up to ~10s to answer /health. The very first boot
-    # after a fresh checkout may be slower (LiteLLM import, chromadb
-    # warmup) — dashboard auto-start does the same thing. We always
-    # return ok; the backend catches up in background if it needs to.
-    for _ in 1 2 3 4 5 6 7 8 9 10; do
-      backend_healthy && break
-      sleep 1
-    done
-    if ! backend_healthy; then
+    # Give uvicorn about 20s to answer /health. The first boot after a fresh
+    # checkout may be slower; if it catches up later, the next hook observes it.
+    if wait_for_health backend_healthy 10 1; then
+      # The Node installer waits 45s for this script. Each curl probe is also
+      # bounded so a wedged listener cannot outlive the caller's timeout budget.
+      if ! wait_for_health embedding_healthy 5 3; then
+        log_embedding_degraded
+      fi
+    else
       pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
       if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
         reason=$(tail -n 120 "$LOG_FILE" 2>/dev/null | grep -E "No LLM provider available|No generation-capable LLM provider available|CLI not found|skipping provider registration|Application startup failed" | tail -n 1 | sed 's/^[[:space:]]*//')
@@ -396,8 +422,12 @@ case "$CMD" in
   status)
     if claude_smart_reflexio_url_is_remote; then
       echo "remote configured at $REFLEXIO_URL"
-    elif is_our_backend_running; then
-      echo "running on http://localhost:$PORT"
+    elif backend_healthy; then
+      if embedding_healthy; then
+        echo "running on http://localhost:$PORT"
+      else
+        echo "running on http://localhost:$PORT (embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
+      fi
     else
       echo "not running"
     fi

--- a/tests/test_cli_clear_all.py
+++ b/tests/test_cli_clear_all.py
@@ -137,6 +137,16 @@ def test_service_status_returns_probe_failed_when_bash_missing(
     assert cli._service_status(script, wait_ready_s=0.0) == "probe_failed"
 
 
+def test_degraded_backend_status_is_treated_as_running() -> None:
+    status = (
+        "running on http://localhost:8071 "
+        "(embedding degraded on http://127.0.0.1:8072)"
+    )
+
+    assert cli._is_running_status(status)
+    assert not cli._is_confirmed_stopped_status(status)
+
+
 def test_clear_all_aborts_when_initial_backend_status_probe_fails(
     clear_all_harness, capsys
 ) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shlex
 import shutil
 import stat
@@ -2030,6 +2031,160 @@ def test_backend_service_configures_shared_embedding_daemon() -> None:
     assert 'EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"' in backend
     assert "REFLEXIO_EMBEDDING_PROVIDER:-local_service" in backend
     assert "REFLEXIO_EMBEDDING_SERVICE_URL" in backend
+
+
+def test_backend_service_reports_local_embedding_degradation_without_cache_repair(
+    tmp_path: Path,
+) -> None:
+    """claude-smart reports degraded vectors; Reflexio owns MiniLM cache repair."""
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+
+    assert "embedding_healthy()" in backend
+    assert 'http://127.0.0.1:$EMBEDDING_PORT/health' in backend
+    assert "--connect-timeout 1 --max-time 1" in backend
+    assert "wait_for_health()" in backend
+    assert "wait_for_health backend_healthy 10 1" in backend
+    assert "wait_for_health embedding_healthy 5 3" in backend
+    assert "spawn_backend()" not in backend
+    assert "Embedding service did not become healthy" in backend
+    assert "semantic retrieval remains unavailable" in backend
+    assert "clear_minilm_cache" not in backend
+    assert "clearing MiniLM cache" not in backend
+    assert "restarting local services" not in backend
+    assert "backend_healthy && embedding_healthy" not in backend
+    start_match = re.search(r"(?ms)^  start\)\n(?P<body>.*?)(?=^  stop\)\n)", backend)
+    assert start_match, "backend-service.sh start case not found"
+    start_case = start_match.group("body")
+    assert "full_stop" not in start_case
+    assert "backend_started" not in start_case
+    assert "if wait_for_health backend_healthy 10 1; then" in start_case
+    assert "if ! wait_for_health embedding_healthy 5 3; then" in start_case
+    assert (
+        "running on http://localhost:$PORT "
+        "(embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
+    ) in backend
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "curl",
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$HOME/curl.log"\n'
+        'case " $* " in\n'
+        '  *" http://127.0.0.1:8071/health "*) exit 0 ;;\n'
+        '  *" http://127.0.0.1:8072/health "*) exit 22 ;;\n'
+        "esac\n"
+        "exit 22\n",
+    )
+    _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+    env = _isolated_env(tmp_path)
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "CLAUDE_SMART_HOST": "codex",
+            "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+            "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "1",
+        }
+    )
+
+    status = subprocess.run(
+        ["bash", str(REPO_ROOT / "plugin" / "scripts" / "backend-service.sh"), "status"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    assert status.returncode == 0, status.stderr
+    assert status.stdout.strip() == (
+        "running on http://localhost:8071 "
+        "(embedding degraded on http://127.0.0.1:8072)"
+    )
+
+    start = subprocess.run(
+        ["bash", str(REPO_ROOT / "plugin" / "scripts" / "backend-service.sh"), "start"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=25,
+    )
+    assert start.returncode == 0, start.stderr
+    assert start.stdout.strip() == '{"continue":true}'
+    backend_log = (tmp_path / ".claude-smart" / "backend.log").read_text()
+    assert "Embedding service did not become healthy" in backend_log
+    assert "semantic retrieval remains unavailable" in backend_log
+    assert "clearing MiniLM cache" not in backend_log
+    assert "restarting local services" not in backend_log
+
+    cold_home = tmp_path / "cold-start"
+    cold_plugin_root = _seed_fake_claude_cache(cold_home)
+    fake_python = (
+        cold_plugin_root
+        / ".venv"
+        / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    )
+    fake_python.parent.mkdir(parents=True)
+    _write_executable(
+        fake_python,
+        "#!/bin/sh\n"
+        'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+        'if [ "$1" = "-m" ]; then\n'
+        '  printf "spawned backend\\n" >> "$HOME/python.log"\n'
+        "fi\n"
+        "exit 0\n",
+    )
+    cold_bin_dir = cold_home / "bin"
+    cold_bin_dir.mkdir()
+    _write_executable(
+        cold_bin_dir / "uv",
+        "#!/bin/sh\n"
+        'printf "uv %s\\n" "$*" >> "$HOME/uv.log"\n'
+        "exit 0\n",
+    )
+    _write_executable(cold_bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        cold_bin_dir / "curl",
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$HOME/curl.log"\n'
+        'case " $* " in\n'
+        '  *" http://127.0.0.1:8071/health "*)\n'
+        '    count=$(cat "$HOME/backend-health-count" 2>/dev/null || echo 0)\n'
+        '    count=$((count + 1))\n'
+        '    printf "%s\\n" "$count" > "$HOME/backend-health-count"\n'
+        '    [ "$count" -ge 3 ] && exit 0\n'
+        "    exit 22\n"
+        "    ;;\n"
+        '  *" http://127.0.0.1:8072/health "*) exit 22 ;;\n'
+        "esac\n"
+        "exit 22\n",
+    )
+    cold_env = _isolated_env(cold_home)
+    cold_env.update(
+        {
+            "PATH": f"{cold_bin_dir}{os.pathsep}{cold_env['PATH']}",
+            "CLAUDE_SMART_HOST": "codex",
+            "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+            "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "1",
+        }
+    )
+
+    cold_start = subprocess.run(
+        ["bash", str(cold_plugin_root / "scripts" / "backend-service.sh"), "start"],
+        env=cold_env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=25,
+    )
+    assert cold_start.returncode == 0, cold_start.stderr
+    assert cold_start.stdout.strip() == '{"continue":true}'
+    assert "spawned backend" in (cold_home / "python.log").read_text()
+    cold_backend_log = (cold_home / ".claude-smart" / "backend.log").read_text()
+    assert "Embedding service did not become healthy" in cold_backend_log
+    assert "semantic retrieval remains unavailable" in cold_backend_log
+    assert "clearing MiniLM cache" not in cold_backend_log
+    assert "restarting local services" not in cold_backend_log
 
 
 def test_backend_service_full_stop_reaps_embedding_port() -> None:


### PR DESCRIPTION
## Summary
- Detects when the managed Reflexio backend is healthy but the local embedding daemon on 8072 is degraded.
- Reports that state explicitly in `backend-service.sh status` instead of treating the backend as stopped.
- Stops claude-smart from clearing MiniLM/Chroma caches or restarting local services for embedding-only failures; Reflexio owns embedding cache recovery.
- Bounds backend and embedding health probes, and only waits for embedding readiness after backend health is confirmed, so startup cannot hang past caller timeout budgets when health endpoints are slow or wedged.

## Fixed behavior
- Fresh startup waits briefly for the local embedding daemon when local embeddings are enabled and the backend is ready, then continues with a degraded log if embeddings are still unavailable.
- Existing healthy backends remain running even if embedding health is degraded.
- Status now distinguishes:
  - `running on http://localhost:$PORT`
  - `running on http://localhost:$PORT (embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)`
  - `not running`

## Test Plan
- `bash -n plugin/scripts/backend-service.sh && git diff --check`
- `PYTHONPATH="$PWD/plugin/src" UV_PYTHON=3.12 uv run --python 3.12 --with pytest pytest tests/test_install_scripts.py -q`
- `PYTHONPATH="$PWD/plugin/src" UV_PYTHON=3.12 uv run --python 3.12 --with pytest pytest tests/test_cli_restart.py tests/test_cli_clear_all.py -q`
- `PYTHONPATH="$PWD/plugin/src" UV_PYTHON=3.12 uv run --python 3.12 --with pytest --with ruff ruff check tests/test_install_scripts.py tests/test_cli_clear_all.py`

Fixes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup orchestration by independently probing backend health and local embedding service health with bounded readiness checks.
  * Reduced incorrect “already running” skips by keeping the occupied-port path gated on existing backend ownership/health.
  * When embeddings are unhealthy but backend is healthy, the service continues running, logs embedding degradation, and surfaces it in `status` (no cache repair or embedding restarts).
* **Tests**
  * Added coverage for degraded embedding behavior in both warm and cold-start scenarios.
  * Updated CLI status detection so a “degraded” backend is treated as running (not confirmed-stopped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->