### PR TITLE
feat: surface applied learning value and trust

### DIFF
--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -177,12 +177,6 @@ def render_inline_with_registry(
     if not playbook_lines and not profile_lines:
         return "", []
     sections: list[str] = []
-    if playbook_lines:
-        sections.append("### Relevant project-specific skills")
-        sections.extend(playbook_lines)
-    if profile_lines:
-        sections.append("### Relevant project preferences")
-        sections.extend(profile_lines)
     instruction = _citation_instruction(
         os.environ.get("CLAUDE_SMART_CITATIONS", "on"),
         os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown"),
@@ -194,6 +188,12 @@ def render_inline_with_registry(
     )
     if exact_osc8_marker:
         sections.append(exact_osc8_marker)
+    if playbook_lines:
+        sections.append("### Relevant project-specific skills")
+        sections.extend(playbook_lines)
+    if profile_lines:
+        sections.append("### Relevant project preferences")
+        sections.extend(profile_lines)
     return "\n".join(sections) + "\n", playbook_entries + profile_entries
 
 

--- a/plugin/src/claude_smart/cs_cite.py
+++ b/plugin/src/claude_smart/cs_cite.py
@@ -64,23 +64,22 @@ _RAW_DASHBOARD_URL_RE = re.compile(
 )
 
 # The single "when to cite" decision, shared across every render path so the
-# bar can't drift between markdown / OSC8 / compact-Codex variants. The
-# counterfactual is the deciding test; relatedness alone is not enough.
+# bar can't drift between markdown / OSC8 / compact-Codex variants.
 WHEN_TO_CITE = (
-    "When to cite: add a marker only when a listed `[cs:…]` item materially "
-    "and meaningfully changed your response — it must be clearly related to "
-    "what you actually did, and your answer would be substantively different "
-    "if the item had not been shown. The counterfactual is the deciding test: "
-    "if your response would be essentially the same without the item, omit the "
-    "marker."
+    "When to cite: end your reply with the citation marker if any listed "
+    "`[cs:…]` rule informed your reasoning — your wording, your structure, "
+    "your decisions, or your next action. Skip only when the rule was clearly "
+    "unrelated to your reply or redundantly reinforced something you'd have "
+    "done anyway. When in doubt, cite — better to over-attribute than to hide "
+    "that learning shaped the response."
 )
 
 # One-line form of WHEN_TO_CITE for the compact Codex path, which renders the
 # whole context block as a single logical line.
 WHEN_TO_CITE_COMPACT = (
-    "Cite only if a listed memory materially and meaningfully changed your "
-    "response — counterfactual: the answer would be substantively different "
-    "without it; otherwise omit."
+    "Cite if a listed memory informed your reasoning (wording, structure, "
+    "decisions, or actions). Skip only when the memory was clearly unrelated "
+    "or redundantly reinforced what you'd do anyway. When in doubt, cite."
 )
 
 _COMPACT_INTRO = f"_{WHEN_TO_CITE}"

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -39,6 +39,9 @@ _PLAN_REJECTION_COMMENT_MARKER = "the user said:"
 
 _EXIT_PLAN_MODE_TOOL = "ExitPlanMode"
 
+CitationLogExtra = dict[str, int]
+StopResult = tuple[publish.PublishStatus, int, CitationLogExtra]
+
 
 def _read_transcript_entries(path: Path) -> list[dict[str, Any]]:
     """Parse the transcript JSONL once into a list of entries.
@@ -338,7 +341,27 @@ def _registry_entry_for_citation(
     return None
 
 
-def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
+def _citation_log_extra(
+    session_id: str, *, emitted_ids: list[str], cited_items: list[dict[str, Any]]
+) -> CitationLogExtra:
+    injected_total, injected_unique = state.injected_counts(session_id)
+    return {
+        "citation_emitted_items": len(emitted_ids),
+        "citation_resolved_items": len(cited_items),
+        "citation_injected_items": injected_total,
+        "citation_injected_unique_items": injected_unique,
+    }
+
+
+def _with_citation_log_extra(
+    result: tuple[publish.PublishStatus, int] | None, extra: CitationLogExtra
+) -> StopResult | None:
+    if result is None:
+        return None
+    return result[0], result[1], extra
+
+
+def handle(payload: dict[str, Any]) -> StopResult | None:
     """Drain the buffered assistant turn to reflexio.
 
     Args:
@@ -396,6 +419,9 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
         assistant_text = cs_cite.strip_marker_lines(assistant_text)
     text_cited_ids = cs_cite.parse_text_citations(assistant_text)
     cited_items = _resolve_cited_items(session_id, text_cited_ids)
+    citation_extra = _citation_log_extra(
+        session_id, emitted_ids=text_cited_ids, cited_items=cited_items
+    )
     plan_decisions = _scan_transcript_for_plan_decisions(entries)
 
     now = int(time.time())
@@ -432,10 +458,13 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
     state.append(session_id, record)
     if env_config.env_truthy(env_config.CLAUDE_SMART_READ_ONLY_ENV):
         state.mark_all_published(session_id)
-        return ("nothing", 0)
-    return publish.publish_unpublished(
-        session_id=session_id,
-        project_id=project_id,
-        force_extraction=False,
-        skip_aggregation=False,
+        return _with_citation_log_extra(("nothing", 0), citation_extra)
+    return _with_citation_log_extra(
+        publish.publish_unpublished(
+            session_id=session_id,
+            project_id=project_id,
+            force_extraction=False,
+            skip_aggregation=False,
+        ),
+        citation_extra,
     )

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -344,12 +344,12 @@ def _registry_entry_for_citation(
 def _citation_log_extra(
     session_id: str, *, emitted_ids: list[str], cited_items: list[dict[str, Any]]
 ) -> CitationLogExtra:
-    injected_total, injected_unique = state.injected_counts(session_id)
+    injected_total, injected_unique = state.session_injected_counts(session_id)
     return {
-        "citation_emitted_items": len(emitted_ids),
-        "citation_resolved_items": len(cited_items),
-        "citation_injected_items": injected_total,
-        "citation_injected_unique_items": injected_unique,
+        "citation_turn_emitted_items": len(emitted_ids),
+        "citation_turn_resolved_items": len(cited_items),
+        "citation_session_injected_items": injected_total,
+        "citation_session_injected_unique_items": injected_unique,
     }
 
 
@@ -368,12 +368,11 @@ def handle(payload: dict[str, Any]) -> StopResult | None:
         payload (dict[str, Any]): Claude Code hook payload.
 
     Returns:
-        tuple[PublishStatus, int] | None: The ``(status, count)`` tuple
-            from ``publish.publish_unpublished`` so the dispatcher can
-            include it in the forensic hook log. ``None`` is returned
-            only when the handler short-circuits before publishing (no
-            ``session_id`` in the payload, or Codex internal-prompt
-            detection skipped the fire).
+        StopResult | None: The ``(status, count, citation_metrics)`` tuple
+            so the dispatcher can include publish status and local citation
+            metrics in the forensic hook log. ``None`` is returned only when
+            the handler short-circuits before publishing (no ``session_id`` in
+            the payload, or Codex internal-prompt detection skipped the fire).
     """
     session_id = payload.get("session_id")
     if not session_id:

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -31,7 +31,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # Stop and SessionEnd return ``(PublishStatus, int)`` so the dispatcher can
-# log the publish outcome; the other handlers return ``None`` (or nothing).
+# log the publish outcome; handlers may include a third ``extra`` dict for
+# structured metrics. The other handlers return ``None`` (or nothing).
 # Use ``Any`` here rather than two specialised typedefs — the dispatcher
 # narrows at the call site via ``isinstance(result, tuple)``.
 def _load_handlers() -> dict[str, Callable[[dict[str, Any]], Any]]:
@@ -156,12 +157,17 @@ def main(argv: list[str] | None = None) -> int:
     handler_status = "ok"
     publish_status: str | None = None
     publish_count: int | None = None
+    log_extra: dict[str, Any] | None = None
     handler_stdout = StringIO()
     try:
         with redirect_stdout(handler_stdout):
             result = handler(payload)
         if isinstance(result, tuple) and len(result) == 2:
             publish_status, publish_count = result
+        elif isinstance(result, tuple) and len(result) == 3:
+            publish_status, publish_count, maybe_extra = result
+            if isinstance(maybe_extra, dict):
+                log_extra = maybe_extra
     except Exception as exc:  # noqa: BLE001 — hooks must never crash the session.
         _LOGGER.exception("hook handler %s raised: %s", event, exc)
         handler_status = f"raised:{type(exc).__name__}: {exc}"
@@ -184,6 +190,7 @@ def main(argv: list[str] | None = None) -> int:
         handler_status=handler_status,
         publish_status=publish_status,
         publish_count=publish_count,
+        extra=log_extra,
     )
     return 0
 

--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -131,6 +131,30 @@ def read_injected(session_id: str) -> dict[str, dict[str, Any]]:
     return registry
 
 
+def injected_counts(session_id: str) -> tuple[int, int]:
+    """Return ``(total_exposures, unique_items)`` for injected citation entries."""
+    path = injected_path(session_id)
+    if not path.exists():
+        return 0, 0
+    total = 0
+    unique: set[str] = set()
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                _LOGGER.warning("Skipping malformed injected line in %s: %s", path, exc)
+                continue
+            item_id = entry.get("id")
+            if isinstance(item_id, str) and item_id:
+                total += 1
+                unique.add(item_id)
+    return total, len(unique)
+
+
 def append(session_id: str, record: dict[str, Any]) -> None:
     """Append one JSON record to the session buffer. Creates the dir if needed.
 

--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -131,8 +131,8 @@ def read_injected(session_id: str) -> dict[str, dict[str, Any]]:
     return registry
 
 
-def injected_counts(session_id: str) -> tuple[int, int]:
-    """Return ``(total_exposures, unique_items)`` for injected citation entries."""
+def session_injected_counts(session_id: str) -> tuple[int, int]:
+    """Return session-wide ``(total_exposures, unique_items)`` for citations."""
     path = injected_path(session_id)
     if not path.exists():
         return 0, 0

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -239,7 +239,7 @@ def test_codex_citation_instruction_uses_text_marker_not_tool_call() -> None:
 
     instruction = cs_cite.CITATION_INSTRUCTION
 
-    assert "materially and meaningfully changed your response" in instruction
+    assert "informed your reasoning" in instruction
     assert "✨ claude-smart rule applied:" in instruction
     assert "tool call" not in instruction
 

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -192,6 +192,20 @@ def test_render_inline_with_registry_uses_inline_headers() -> None:
     assert len(registry) == 2
 
 
+def test_render_inline_with_registry_puts_citation_instruction_before_memory() -> None:
+    md, _ = context_format.render_inline_with_registry(
+        project_id="demo",
+        user_playbooks=[{"content": "use pathlib"}],
+        agent_playbooks=[],
+        profiles=[{"content": "prefers concise answers"}],
+    )
+
+    assert 0 <= md.find("When to cite:") < md.find(
+        "### Relevant project-specific skills"
+    )
+    assert md.find("When to cite:") < md.find("### Relevant project preferences")
+
+
 def test_render_inline_with_registry_auto_mode_injects_compact_instruction(
     monkeypatch,
 ) -> None:
@@ -294,6 +308,21 @@ def test_render_inline_compact_with_registry_is_one_logical_line(
     assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
 
 
+def test_render_inline_compact_keeps_memory_summary_before_citation_gate(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("CLAUDE_SMART_CITATION_LINK_STYLE", raising=False)
+    md, _ = context_format.render_inline_compact_with_registry(
+        project_id="demo",
+        user_playbooks=[{"content": "Run uv sync after pyproject edits."}],
+        agent_playbooks=[],
+        profiles=[{"content": "prefers concise answers"}],
+    )
+
+    assert md.startswith("claude-smart: using relevant memory.")
+    assert 0 < md.find("Cite if a listed memory informed your reasoning")
+
+
 def test_render_inline_compact_with_registry_can_emit_osc8_when_requested(
     monkeypatch,
 ) -> None:
@@ -331,7 +360,7 @@ def test_render_inline_with_registry_marker_only_is_enabled_alias(
         profiles=[],
     )
     assert cs_cite.CITATION_INSTRUCTION in md
-    assert "materially and meaningfully changed your response" in md
+    assert "informed your reasoning" in md
     assert "citation block is up to two lines" not in md
 
 

--- a/tests/test_cs_cite.py
+++ b/tests/test_cs_cite.py
@@ -201,9 +201,9 @@ def test_citation_instruction_on_returns_compact_string() -> None:
     text = cs_cite.citation_instruction("on")
     assert text == cs_cite.CITATION_INSTRUCTION
     assert "When to cite:" in text
-    assert "materially and meaningfully changed your response" in text
+    assert "informed your reasoning" in text
     assert "citation block is up to two lines" not in text
-    assert "counterfactual" in text.lower()
+    assert "When in doubt, cite" in text
     assert "✨ claude-smart rule applied:" in text
     assert "⚡Reflexio" in text
     assert cs_cite.REFLEXIO_REPO_URL in text
@@ -225,7 +225,7 @@ def test_citation_instruction_osc8_uses_terminal_hyperlink_examples() -> None:
     assert "✨ claude-smart rules applied:" not in text
     assert " | \x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in text
     assert "visible ` | ` separator" in text
-    assert "materially and meaningfully changed your response" in text
+    assert "informed your reasoning" in text
     assert "markdown links" in text
     assert "⚡Reflexio" in text
     assert cs_cite.REFLEXIO_REPO_URL in text

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -815,7 +815,16 @@ def test_stop_read_only_marks_buffer_without_publishing(
         {"session_id": "s_read_only", "transcript_path": str(transcript)}
     )
 
-    assert result == ("nothing", 0)
+    assert result == (
+        "nothing",
+        0,
+        {
+            "citation_emitted_items": 0,
+            "citation_resolved_items": 0,
+            "citation_injected_items": 0,
+            "citation_injected_unique_items": 0,
+        },
+    )
     records = state.read_all("s_read_only")
     assert records[-1]["published_up_to"] == len(records) - 1
     _, unpublished = state.unpublished_slice(records)
@@ -1187,6 +1196,76 @@ def test_stop_records_text_marker_ids_as_cited_items(
             "real_id": "uuid-anyio",
         },
     ]
+
+
+def test_stop_returns_structured_citation_metrics(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    state.append_injected(
+        "s1",
+        [
+            {
+                "id": "s1-42",
+                "kind": "playbook",
+                "title": "use pathlib",
+                "content": "use pathlib",
+                "real_id": "42",
+                "ts": 0,
+            },
+            {
+                "id": "s1-42",
+                "kind": "playbook",
+                "title": "use pathlib",
+                "content": "use pathlib",
+                "real_id": "42",
+                "ts": 1,
+            },
+            {
+                "id": "p1-uuid",
+                "kind": "profile",
+                "title": "prefers anyio",
+                "content": "prefers anyio",
+                "real_id": "uuid-anyio",
+                "ts": 2,
+            },
+        ],
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {"type": "user", "message": {"content": "do the thing"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "Done.\n\n"
+                                "✨ 2 claude-smart learnings applied [cs:s1-42,s9-dead]"
+                            ),
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
+    )
+
+    result = stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
+
+    assert result == (
+        "nothing",
+        0,
+        {
+            "citation_emitted_items": 2,
+            "citation_resolved_items": 1,
+            "citation_injected_items": 3,
+            "citation_injected_unique_items": 2,
+        },
+    )
 
 
 def test_stop_preserves_cited_item_source_kind(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -819,10 +819,10 @@ def test_stop_read_only_marks_buffer_without_publishing(
         "nothing",
         0,
         {
-            "citation_emitted_items": 0,
-            "citation_resolved_items": 0,
-            "citation_injected_items": 0,
-            "citation_injected_unique_items": 0,
+            "citation_turn_emitted_items": 0,
+            "citation_turn_resolved_items": 0,
+            "citation_session_injected_items": 0,
+            "citation_session_injected_unique_items": 0,
         },
     )
     records = state.read_all("s_read_only")
@@ -1198,7 +1198,7 @@ def test_stop_records_text_marker_ids_as_cited_items(
     ]
 
 
-def test_stop_returns_structured_citation_metrics(
+def test_stop_returns_structured_citation_metrics_with_explicit_scopes(
     session_dir, tmp_path, monkeypatch
 ) -> None:
     state.append_injected(
@@ -1260,10 +1260,10 @@ def test_stop_returns_structured_citation_metrics(
         "nothing",
         0,
         {
-            "citation_emitted_items": 2,
-            "citation_resolved_items": 1,
-            "citation_injected_items": 3,
-            "citation_injected_unique_items": 2,
+            "citation_turn_emitted_items": 2,
+            "citation_turn_resolved_items": 1,
+            "citation_session_injected_items": 3,
+            "citation_session_injected_unique_items": 2,
         },
     )
 

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -245,6 +245,31 @@ def test_dispatcher_logs_nothing_publish_status(
     assert rec["publish_count"] == 0
 
 
+def test_dispatcher_logs_handler_extra_fields(
+    hook_log_path, stdin_payload, monkeypatch
+) -> None:
+    def stop_with_extra(_payload: dict[str, Any]) -> tuple[str, int, dict[str, int]]:
+        return (
+            "nothing",
+            0,
+            {
+                "citation_emitted_items": 2,
+                "citation_resolved_items": 1,
+                "citation_injected_items": 6,
+                "citation_injected_unique_items": 3,
+            },
+        )
+
+    monkeypatch.setattr(hook, "_load_handlers", lambda: {"stop": stop_with_extra})
+    stdin_payload({"session_id": "s-citations", "cwd": "/tmp"})
+    hook.main(["claude-code", "stop"])
+    rec = _read_lines(hook_log_path)[0]
+    assert rec["citation_emitted_items"] == 2
+    assert rec["citation_resolved_items"] == 1
+    assert rec["citation_injected_items"] == 6
+    assert rec["citation_injected_unique_items"] == 3
+
+
 def test_dispatcher_emits_continue_on_handler_success(
     hook_log_path, stdin_payload, monkeypatch, capsys
 ) -> None:

--- a/tests/test_hook_log.py
+++ b/tests/test_hook_log.py
@@ -253,10 +253,10 @@ def test_dispatcher_logs_handler_extra_fields(
             "nothing",
             0,
             {
-                "citation_emitted_items": 2,
-                "citation_resolved_items": 1,
-                "citation_injected_items": 6,
-                "citation_injected_unique_items": 3,
+                "citation_turn_emitted_items": 2,
+                "citation_turn_resolved_items": 1,
+                "citation_session_injected_items": 6,
+                "citation_session_injected_unique_items": 3,
             },
         )
 
@@ -264,10 +264,10 @@ def test_dispatcher_logs_handler_extra_fields(
     stdin_payload({"session_id": "s-citations", "cwd": "/tmp"})
     hook.main(["claude-code", "stop"])
     rec = _read_lines(hook_log_path)[0]
-    assert rec["citation_emitted_items"] == 2
-    assert rec["citation_resolved_items"] == 1
-    assert rec["citation_injected_items"] == 6
-    assert rec["citation_injected_unique_items"] == 3
+    assert rec["citation_turn_emitted_items"] == 2
+    assert rec["citation_turn_resolved_items"] == 1
+    assert rec["citation_session_injected_items"] == 6
+    assert rec["citation_session_injected_unique_items"] == 3
 
 
 def test_dispatcher_emits_continue_on_handler_success(

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -282,7 +282,16 @@ def test_opencode_learning_loop_buffers_injects_tools_and_publishes(
     )
 
     records = state.read_all("s-loop")
-    assert result == ("ok", 3)
+    assert result == (
+        "ok",
+        3,
+        {
+            "citation_emitted_items": 0,
+            "citation_resolved_items": 0,
+            "citation_injected_items": 0,
+            "citation_injected_unique_items": 0,
+        },
+    )
     assert injected == [
         {
             "session_id": "s-loop",

--- a/tests/test_opencode_support.py
+++ b/tests/test_opencode_support.py
@@ -286,10 +286,10 @@ def test_opencode_learning_loop_buffers_injects_tools_and_publishes(
         "ok",
         3,
         {
-            "citation_emitted_items": 0,
-            "citation_resolved_items": 0,
-            "citation_injected_items": 0,
-            "citation_injected_unique_items": 0,
+            "citation_turn_emitted_items": 0,
+            "citation_turn_resolved_items": 0,
+            "citation_session_injected_items": 0,
+            "citation_session_injected_unique_items": 0,
         },
     )
     assert injected == [


### PR DESCRIPTION
## Summary
- Surfaces when remembered guidance shaped the assistant's reply, so users can see the value of the learning loop instead of inferring it from behavior alone.
- Reframes citation guidance from a strict counterfactual gate to an informed-reasoning standard with a deliberate "when in doubt, cite" bias.
- Builds product trust through visible causality: the answer shows which learned rule influenced wording, structure, decisions, or follow-up action.
- Keeps the compact Codex experience readable by leaving the memory summary first while preserving the exact citation marker instructions.
- Adds local structured citation metrics that stay on the user's machine, are not sent to maintainers, and use explicit turn/session scopes to avoid misleading comparisons.

## Changes
- Citation prompts: shared `WHEN_TO_CITE` and compact wording now ask assistants to cite when a `[cs:...]` item informed reasoning, while still skipping unrelated or redundant memory.
- Context rendering: the model-facing inline renderer places citation guidance before retrieved skills and preferences, making attribution instructions easier for the model to see.
- Compact Codex rendering: preserves memory-first compact output so user-visible context remains scannable instead of front-loading citation mechanics.
- Stop-hook metrics: records turn-scoped emitted/resolved citation counts and session-scoped injected/unique-injected citation counts in the structured local hook log.
- Exposure counting: adds `state.session_injected_counts()` so session metrics use total sidecar exposures plus unique item counts rather than only the de-duplicated registry.
- Tests: updates citation wording coverage and adds regressions for renderer order, compact shape, dispatcher extra fields, scoped Stop metrics, and opencode CLI loop expectations.

## Why This Matters
- Users can tell that learned guidance is active because the assistant names the applied rule when it matters.
- The product feels more trustworthy because attribution is connected to a visible answer, not hidden behind logs or implicit personalization.
- The new metrics preserve the local-first trust model: they are written to the user's local hook log for their own inspection and are not transmitted to project maintainers.
- Explicit metric scopes make later local analysis safer: emitted/resolved fields describe the current Stop event, while injected fields describe the session-to-date exposure registry.

## Test Plan
- Red/green verification for the Claude review finding: first updated the metric tests to require explicit turn/session scopes and confirmed the focused Stop metric test failed against the old keys; then updated production code and reran the focused tests.
- `uv run --project plugin pytest tests/test_events.py::test_stop_returns_structured_citation_metrics_with_explicit_scopes tests/test_events.py::test_stop_read_only_marks_buffer_without_publishing tests/test_hook_log.py::test_dispatcher_logs_handler_extra_fields tests/test_opencode_support.py::test_opencode_learning_loop_buffers_injects_tools_and_publishes -q` — 4 passed
- `uv run --project plugin pytest tests/test_context_format.py tests/test_cs_cite.py tests/test_events.py tests/test_hook_log.py tests/test_codex_support.py tests/test_opencode_support.py -q` — 282 passed
- `uvx ruff check plugin/src/claude_smart/cs_cite.py plugin/src/claude_smart/context_format.py plugin/src/claude_smart/events/stop.py plugin/src/claude_smart/hook.py plugin/src/claude_smart/state.py tests/test_context_format.py tests/test_hook_log.py tests/test_events.py tests/test_cs_cite.py tests/test_codex_support.py tests/test_opencode_support.py` — all checks passed
- `uvx pyright plugin/src/claude_smart/cs_cite.py plugin/src/claude_smart/context_format.py plugin/src/claude_smart/events/stop.py plugin/src/claude_smart/hook.py plugin/src/claude_smart/state.py` — 0 errors
- `git diff --check`
- `uv run --project plugin pytest tests/ -q` — 584 passed, 8 warnings from the existing Python 3.14 multiprocessing fork deprecation in `test_append_concurrent_writes_do_not_corrupt_jsonl`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured citation metrics to event handling, including session-level counts and per-turn citation tracking.
  * Logging now captures extra structured metrics returned by handlers.

* **Bug Fixes**
  * Updated citation guidance text and markdown ordering so citation instructions appear earlier and more consistently.
  * Revised citation prompts to use clearer “informed your reasoning” language with a stronger “when in doubt, cite” default.

* **Tests**
  * Expanded coverage for citation wording, markdown ordering, and structured event output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->