### PR TITLE
fix: render dashboard transcript links

### DIFF
--- a/plugin/dashboard/app/sessions/[sessionId]/page.tsx
+++ b/plugin/dashboard/app/sessions/[sessionId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useState } from "react";
+import { type ReactNode, use, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
@@ -22,6 +22,9 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { formatTimestamp, truncateId } from "@/lib/format";
 import type { CitedItem, SessionDetail } from "@/lib/types";
+
+const MARKDOWN_LINK_PATTERN =
+  /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+|\/[^\s)]*)\)/g;
 
 export default function InteractionDetailPage({
   params,
@@ -204,7 +207,7 @@ export default function InteractionDetailPage({
                     </div>
                   </header>
                   <pre className="whitespace-pre-wrap break-words text-sm font-sans leading-relaxed">
-                    {turn.content}
+                    <MarkdownLinkedText text={turn.content} />
                   </pre>
                   {turn.user_action_description && (
                     <p className="text-xs text-muted-foreground mt-2 italic">
@@ -226,6 +229,37 @@ export default function InteractionDetailPage({
       </div>
     </div>
   );
+}
+
+function MarkdownLinkedText({ text }: { text: string }) {
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+
+  for (const match of text.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const matchIndex = match.index ?? 0;
+    const [raw, label, href] = match;
+    if (matchIndex > cursor) {
+      parts.push(text.slice(cursor, matchIndex));
+    }
+    parts.push(
+      <a
+        key={`${matchIndex}-${href}`}
+        href={href}
+        target={href.startsWith("/") ? undefined : "_blank"}
+        rel={href.startsWith("/") ? undefined : "noopener noreferrer"}
+        className="font-medium text-primary underline decoration-primary/35 underline-offset-2 hover:decoration-primary"
+      >
+        {label}
+      </a>,
+    );
+    cursor = matchIndex + raw.length;
+  }
+
+  if (parts.length === 0) return text;
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+  return <>{parts}</>;
 }
 
 function CitedItemsRow({ items }: { items: CitedItem[] }) {


### PR DESCRIPTION
## Summary
- Fixes claude-smart dashboard session transcripts so citation markers render as usable links instead of literal Markdown.
- Keeps transcript content as plain text and only converts safe Markdown links for `http`, `https`, and root-relative URLs.

## Changes
- Added a lightweight `MarkdownLinkedText` renderer for session turn content.
- Styled rendered links consistently with the dashboard while preserving existing whitespace and line wrapping.

## Test Plan
- `uv run python -c "import reflexio"`
- `npm run lint`
- `npm run build`
- Browser smoke test with a temporary session containing the reported marker string; verified the two rule citations and `⚡Reflexio` rendered as separate links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session transcripts now support clickable Markdown-style links in message content.
  * Links are automatically formatted for external websites or in-app paths, improving navigation and safety.

* **Bug Fixes**
  * Transcript text is now rendered more consistently instead of appearing as plain raw markup when links are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->