### PR TITLE
fix: resolve issue #100 manual profile generation

### DIFF
--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -349,7 +349,7 @@ case "$CMD" in
       "$LOG_FILE" "$LOG_MAX_BYTES" -- \
       env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
       PYTHONPATH="$backend_pythonpath" \
-      "$backend_python" -m reflexio.cli services start --only backend --no-reload --workers "$workers"
+      "$backend_python" -m claude_smart.reflexio_backend services start --only backend --no-reload --workers "$workers"
     svc_pid=$!
     # Record the spawned pid, not a pgid sampled with ps. On POSIX,
     # setsid/python os.setsid make this pid the new process group leader;

--- a/plugin/src/claude_smart/reflexio_backend.py
+++ b/plugin/src/claude_smart/reflexio_backend.py
@@ -1,0 +1,56 @@
+"""claude-smart Reflexio backend launcher with local compatibility patches.
+
+The backend is still Reflexio's FastAPI server; this module only installs
+claude-smart-scoped shims before handing control to ``reflexio.cli``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _install_sqlite_storage_compat() -> None:
+    """Add storage methods expected by Reflexio services but absent in PyPI builds.
+
+    Reflexio 0.2.25-0.2.27 profile manual generation calls
+    ``SQLiteStorage.get_all_user_ids()`` when the API request omits ``user_id``.
+    The SQLite backend does not implement that method, so users with collected
+    interactions see an AttributeError and get zero generated profiles. The
+    method should enumerate users that have interactions, because manual profile
+    generation extracts profiles from interaction history.
+    """
+
+    try:
+        from reflexio.server.services.storage.sqlite_storage import SQLiteStorage  # type: ignore[import-not-found]
+    except Exception:  # noqa: BLE001 - backend startup should surface Reflexio errors later.
+        return
+
+    if hasattr(SQLiteStorage, "get_all_user_ids"):
+        return
+
+    def get_all_user_ids(self: Any) -> list[str]:
+        rows = self._fetchall(
+            """
+            SELECT user_id
+            FROM interactions
+            GROUP BY user_id
+            ORDER BY MIN(created_at), MIN(interaction_id)
+            """
+        )
+        return [row["user_id"] for row in rows]
+
+    setattr(SQLiteStorage, "get_all_user_ids", get_all_user_ids)
+
+
+def main() -> None:
+    """Install claude-smart compatibility patches, then run Reflexio's CLI."""
+
+    _install_sqlite_storage_compat()
+
+    from reflexio.cli.__main__ import main as reflexio_main  # type: ignore[import-not-found]
+
+    reflexio_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -377,11 +377,11 @@ def test_backend_service_forces_utf8_stdio_for_managed_backend() -> None:
     assert 'env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"' in service
 
 
-def test_backend_service_uses_prepared_venv_reflexio_cli() -> None:
+def test_backend_service_uses_prepared_venv_reflexio_backend_wrapper() -> None:
     service = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
     assert 'backend_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"' in service
-    assert '"$backend_python" -m reflexio.cli services start' in service
+    assert '"$backend_python" -m claude_smart.reflexio_backend services start' in service
     assert 'uv run --project "$PLUGIN_ROOT" --no-sync --quiet' not in service
     assert "ensure_vendored_reflexio_active" in service
     assert 'plugin_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"' in service

--- a/tests/test_reflexio_backend.py
+++ b/tests/test_reflexio_backend.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+
+def test_backend_compat_adds_all_user_ids_from_interactions(tmp_path):
+    from reflexio.server.services.storage.sqlite_storage import SQLiteStorage  # type: ignore[import-not-found]
+
+    from claude_smart.reflexio_backend import _install_sqlite_storage_compat
+
+    if hasattr(SQLiteStorage, "get_all_user_ids"):
+        delattr(SQLiteStorage, "get_all_user_ids")
+
+    _install_sqlite_storage_compat()
+
+    storage = SQLiteStorage(org_id="claude-smart-test", db_path=str(tmp_path / "db.sqlite"))
+    with storage._lock:
+        storage.conn.execute(
+            """
+            INSERT INTO interactions (user_id, content, request_id, created_at)
+            VALUES (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?)
+            """,
+            (
+                "project-a",
+                "first",
+                "req-1",
+                "2026-01-01T00:00:01Z",
+                "project-b",
+                "second",
+                "req-2",
+                "2026-01-01T00:00:02Z",
+                "project-a",
+                "third",
+                "req-3",
+                "2026-01-01T00:00:03Z",
+            ),
+        )
+        storage.conn.commit()
+
+    assert storage.get_all_user_ids() == ["project-a", "project-b"]


### PR DESCRIPTION
## Summary
- Launch the managed Reflexio backend through a claude-smart wrapper that installs local compatibility patches before handing off to Reflexio's CLI.
- Add the missing SQLiteStorage.get_all_user_ids compatibility method expected by Reflexio manual profile generation, enumerating users from collected interactions.
- Add regression coverage for the compatibility method and backend-service launcher command.

## Test Plan
- `uv run --project plugin pytest tests/test_reflexio_backend.py tests/test_install_scripts.py::test_backend_service_uses_prepared_venv_reflexio_backend_wrapper -q`
- `bash -n plugin/scripts/backend-service.sh`
- `uvx ruff check plugin/src/claude_smart/reflexio_backend.py tests/test_reflexio_backend.py tests/test_install_scripts.py`
- `PYTHONPATH=plugin/src uvx pyright plugin/src/claude_smart/reflexio_backend.py tests/test_reflexio_backend.py`
- `git diff --check`

Note: `uv run --project plugin pytest tests/test_install_scripts.py -q` was also attempted; it reached 101 passed and one existing environment-sensitive npm packaging failure (`test_npx_install_reads_managed_env`, `npm pack` exited 127 with no stderr) unrelated to this backend wrapper change.

Related Reflexio fix: ReflexioAI/reflexio#290 moves the manual generated-profile count fix into Reflexio's storage/profile-generation layer.

Fixes #100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend startup reliability by launching the service through a compatibility wrapper.
  * Added support for older storage setups so user ID lookups continue to work as expected.
  * Backend health checks and restart behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
