### PR TITLE
fix: resolve issue #107 IDE entrypoints

### DIFF
--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -144,7 +144,7 @@ claude_smart_is_internal_invocation_env() {
     return 0
   fi
   case "${CLAUDE_CODE_ENTRYPOINT:-}" in
-    ""|"cli"|"claude-desktop") return 1 ;;
+    ""|"cli"|"claude-desktop"|"claude-vscode"|"claude-jetbrains") return 1 ;;
     *) return 0 ;;
   esac
 }

--- a/plugin/src/claude_smart/internal_call.py
+++ b/plugin/src/claude_smart/internal_call.py
@@ -20,7 +20,8 @@ Two distinct sources of unwanted hook fires:
 
 Detection signals, OR'd:
   - ``CLAUDE_CODE_ENTRYPOINT`` is anything other than an interactive entrypoint
-    (``"cli"`` or Claude Desktop's ``"claude-desktop"``). Headless
+    (``"cli"``, Claude Desktop's ``"claude-desktop"``, or Claude Code IDE
+    entrypoints such as ``"claude-vscode"``/``"claude-jetbrains"``). Headless
     ``claude -p`` sets ``sdk-cli`` (and the SDKs may set other values). This
     catches case (2) for any third-party tool, not just claude-mem.
   - Env var ``CLAUDE_SMART_INTERNAL=1``, set by reflexio's provider
@@ -46,7 +47,9 @@ from typing import Any
 from claude_smart import runtime
 
 _ENTRYPOINT_VAR = "CLAUDE_CODE_ENTRYPOINT"
-_INTERACTIVE_ENTRYPOINTS = frozenset({"cli", "claude-desktop"})
+_INTERACTIVE_ENTRYPOINTS = frozenset(
+    {"cli", "claude-desktop", "claude-vscode", "claude-jetbrains"}
+)
 _CODEX_TITLE_PROMPT_PREFIX = (
     "You are a helpful assistant. You will be presented with a user prompt, "
     "and your job is to provide a short title for a task"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1276,7 +1276,7 @@ def test_service_start_scripts_guard_internal_invocations() -> None:
 
     assert "claude_smart_is_internal_invocation_env()" in lib
     assert "CLAUDE_CODE_ENTRYPOINT" in lib
-    assert '"cli"|"claude-desktop"' in lib
+    assert '"cli"|"claude-desktop"|"claude-vscode"|"claude-jetbrains"' in lib
     assert "if claude_smart_is_internal_invocation_env; then" in hook_entry
     assert "if claude_smart_is_internal_invocation_env; then" in backend
     assert "if claude_smart_is_internal_invocation_env; then" in dashboard

--- a/tests/test_internal_call.py
+++ b/tests/test_internal_call.py
@@ -110,11 +110,12 @@ def test_returns_false_for_interactive_entrypoint(
     assert is_internal_invocation({}) is False
 
 
-def test_returns_false_for_desktop_entrypoint(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("entrypoint", ["claude-desktop", "claude-vscode", "claude-jetbrains"])
+def test_returns_false_for_interactive_entrypoints(
+    monkeypatch: pytest.MonkeyPatch, entrypoint: str
 ) -> None:
     monkeypatch.delenv("CLAUDE_SMART_INTERNAL", raising=False)
-    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "claude-desktop")
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", entrypoint)
     assert is_internal_invocation({}) is False
 
 


### PR DESCRIPTION
## Summary
- Treat Claude Code IDE entrypoints (`claude-vscode` and `claude-jetbrains`) as interactive invocations instead of internal/headless invocations.
- Keep `CLAUDE_SMART_INTERNAL=1` and unknown entrypoints guarded for Reflexio/headless subprocesses.
- Add regressions for the Python internal-call guard and shell service-start guard.

## Test Plan
- `uv run --project plugin pytest tests/test_internal_call.py tests/test_install_scripts.py::test_service_start_scripts_guard_internal_invocations -q`
- `uvx ruff check plugin/src/claude_smart/internal_call.py tests/test_internal_call.py tests/test_install_scripts.py`
- `bash -n plugin/scripts/_lib.sh`
- `git diff --check`

Fixes #107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of interactive app launches so desktop and IDE-based entrypoints are handled consistently.
  * Reduced cases where background hooks or internal checks could trigger incorrectly during normal use.
  * Expanded coverage to ensure these entrypoints behave the same across supported launch methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->