### PR TITLE
fix: bound publish_interaction so a hung Windows backend can't freeze the SessionStart hook

### DIFF
--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import inspect
 import logging
 import os
+import threading
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -27,6 +28,13 @@ _DEFAULT_URL = "http://localhost:8071/"
 # unhealthy POST would freeze the user's prompt. 5s matches the precedent
 # in ``ids.py`` for short-lived hook HTTP calls.
 _HTTP_TIMEOUT_SECONDS = 5
+# Wall-clock cap for a single publish_interaction call. wait_for_response=False
+# already makes this fire-and-forget semantically, but on Windows a wedged
+# backend's write path can hang the HTTP round-trip itself (see
+# ReflexioAI/claude-smart#109 / ReflexioAI/reflexio), which would freeze the
+# SessionStart hook. Bounding the call keeps the hook responsive; a dropped
+# publish is retried next turn from the unpublished buffer.
+_PUBLISH_WALL_TIMEOUT_SECONDS = 8
 _SEARCH_MODE_HYBRID = "hybrid"  # reflexio.models.config_schema.SearchMode.HYBRID
 _UNIFIED_ENTITY_TYPES = ("profiles", "user_playbooks", "agent_playbooks")
 _AGENT_PLAYBOOK_APPROVAL_STATUSES = ("pending", "approved")
@@ -119,8 +127,23 @@ class Adapter:
                 _LOGGER.debug(
                     "publish_interaction client does not support override_learning_stall"
                 )
-            client.publish_interaction(**kwargs)
-            return True
+            result: dict[str, Any] = {"ok": False}
+
+            def _do_publish() -> None:
+                client.publish_interaction(**kwargs)
+                result["ok"] = True
+
+            worker = threading.Thread(target=_do_publish, daemon=True)
+            worker.start()
+            worker.join(_PUBLISH_WALL_TIMEOUT_SECONDS)
+            if worker.is_alive():
+                _LOGGER.warning(
+                    "publish_interaction exceeded %ss wall-clock; treating as "
+                    "dropped (buffer retries next turn)",
+                    _PUBLISH_WALL_TIMEOUT_SECONDS,
+                )
+                return False
+            return result["ok"]
         except Exception as exc:  # noqa: BLE001
             _LOGGER.warning("publish_interaction failed: %s", exc)
             return False

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -127,11 +127,15 @@ class Adapter:
                 _LOGGER.debug(
                     "publish_interaction client does not support override_learning_stall"
                 )
-            result: dict[str, Any] = {"ok": False}
+            result: dict[str, Any] = {"ok": False, "error": None}
 
             def _do_publish() -> None:
-                client.publish_interaction(**kwargs)
-                result["ok"] = True
+                try:
+                    client.publish_interaction(**kwargs)
+                except Exception as exc:  # noqa: BLE001
+                    result["error"] = exc
+                else:
+                    result["ok"] = True
 
             worker = threading.Thread(target=_do_publish, daemon=True)
             worker.start()
@@ -142,6 +146,9 @@ class Adapter:
                     "dropped (buffer retries next turn)",
                     _PUBLISH_WALL_TIMEOUT_SECONDS,
                 )
+                return False
+            if result["error"] is not None:
+                _LOGGER.warning("publish_interaction failed: %s", result["error"])
                 return False
             return result["ok"]
         except Exception as exc:  # noqa: BLE001

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -809,3 +809,30 @@ def test_mark_stall_notified_calls_through(monkeypatch):
     monkeypatch.setattr(adapter, "_get_client", lambda: stub)
     adapter.mark_stall_notified()
     assert stub.notified_called is True
+
+
+def test_publish_returns_false_when_client_hangs(monkeypatch):
+    """A wedged backend must not hang the hook: publish returns within the cap."""
+    import threading
+    import time
+
+    from claude_smart import reflexio_adapter
+
+    class HangingClient:
+        def publish_interaction(self, **_kwargs):
+            time.sleep(30)  # simulate the Windows write-path hang
+
+    adapter = reflexio_adapter.Adapter(url="http://x", api_key="")
+    monkeypatch.setattr(adapter, "_get_client", lambda: HangingClient())
+    monkeypatch.setattr(reflexio_adapter, "_PUBLISH_WALL_TIMEOUT_SECONDS", 1)
+
+    start = time.monotonic()
+    ok = adapter.publish(
+        session_id="s",
+        project_id="p",
+        interactions=[{"role": "user", "content": "hi"}],
+    )
+    elapsed = time.monotonic() - start
+    assert ok is False
+    assert elapsed < 5  # bounded, not the 30s hang
+    assert threading.active_count() >= 1  # no crash


### PR DESCRIPTION
Containment for #109 (root cause tracked in ReflexioAI/reflexio: https://github.com/ReflexioAI/reflexio/issues/295). Runs the publish under an 8s wall-clock cap; on timeout returns False and the unpublished buffer retries next turn. Refs #109.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `publish` now enforces a short wall-clock timeout for send operations, so the app won’t hang if delivery stalls.
  * If publishing doesn’t complete within the timeout, the attempt is treated as failed to allow buffering/retries instead of blocking.
* **Tests**
  * Added a regression test to verify fail-fast behavior when the underlying publish call hangs and completes within a bounded time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->