### PR TITLE
Harden backend and dashboard startup races

### DIFF
--- a/plugin/dashboard/app/api/reflexio/[...path]/route.ts
+++ b/plugin/dashboard/app/api/reflexio/[...path]/route.ts
@@ -4,7 +4,9 @@ import { readConfig } from "@/lib/config-file";
 
 export const dynamic = "force-dynamic";
 
-const DEFAULT_URL = "http://localhost:8071";
+function defaultUrl(): string {
+  return `http://localhost:${process.env.BACKEND_PORT || "8071"}`;
+}
 
 async function reflexioConfig(): Promise<{ base: string; apiKey: string }> {
   const config = await readConfig();
@@ -13,7 +15,7 @@ async function reflexioConfig(): Promise<{ base: string; apiKey: string }> {
   const fromConfig = originOnly(config.REFLEXIO_URL ?? "");
   const configuredBase = fromEnv ?? fromConfig;
   return {
-    base: configuredBase ?? DEFAULT_URL,
+    base: configuredBase ?? defaultUrl(),
     apiKey: configuredBase ? apiKey : "",
   };
 }

--- a/plugin/dashboard/lib/config-file.ts
+++ b/plugin/dashboard/lib/config-file.ts
@@ -27,6 +27,10 @@ const BOOL_KEYS = new Set([
   "CLAUDE_SMART_READ_ONLY",
 ]);
 
+function defaultReflexioUrl(): string {
+  return `http://localhost:${process.env.BACKEND_PORT || "8071"}/`;
+}
+
 function envPath(): string {
   return path.join(os.homedir(), ".reflexio", ".env");
 }
@@ -49,7 +53,7 @@ function parseLine(line: string): { key: string; value: string } | null {
 
 export async function readConfig(): Promise<ClaudeSmartConfig> {
   const defaults: ClaudeSmartConfig = {
-    REFLEXIO_URL: "http://localhost:8071/",
+    REFLEXIO_URL: defaultReflexioUrl(),
     REFLEXIO_API_KEY: "",
     CLAUDE_SMART_USE_LOCAL_CLI: false,
     CLAUDE_SMART_USE_LOCAL_EMBEDDING: false,

--- a/plugin/scripts/_lib.sh
+++ b/plugin/scripts/_lib.sh
@@ -143,6 +143,17 @@ claude_smart_reflexio_url_is_remote() {
   return 0
 }
 
+claude_smart_derive_reflexio_url_from_backend_port() {
+  local port default_url
+  port="${BACKEND_PORT:-8071}"
+  default_url="http://localhost:$port/"
+  case "${REFLEXIO_URL:-}" in
+    ""|"http://localhost:8071"|"http://localhost:8071/"|"http://127.0.0.1:8071"|"http://127.0.0.1:8071/")
+      export REFLEXIO_URL="$default_url"
+      ;;
+  esac
+}
+
 claude_smart_is_internal_invocation_env() {
   if [ "${CLAUDE_SMART_INTERNAL:-}" = "1" ]; then
     return 0
@@ -701,6 +712,191 @@ claude_smart_kill_tree() {
     sleep 0.2
   done
   kill -KILL -- "-$pid" 2>/dev/null || true
+}
+
+claude_smart_now_epoch() {
+  date +%s 2>/dev/null || {
+    _CS_PY=$(claude_smart_resolve_python 2>/dev/null || true)
+    [ -n "$_CS_PY" ] || return 1
+    "$_CS_PY" - <<'PY'
+import time
+
+print(int(time.time()))
+PY
+  }
+}
+
+claude_smart_path_mtime_epoch() {
+  path="$1"
+  mtime=""
+  [ -e "$path" ] || return 1
+  mtime="$(stat -f %m "$path" 2>/dev/null || true)"
+  case "$mtime" in
+    ''|*[!0-9]*) ;;
+    *) printf '%s\n' "$mtime"; return 0 ;;
+  esac
+  mtime="$(stat -c %Y "$path" 2>/dev/null || true)"
+  case "$mtime" in
+    ''|*[!0-9]*) ;;
+    *) printf '%s\n' "$mtime"; return 0 ;;
+  esac
+  _CS_PY=$(claude_smart_resolve_python 2>/dev/null || true)
+  [ -n "$_CS_PY" ] || return 1
+  "$_CS_PY" - "$path" <<'PY'
+import os
+import sys
+
+print(int(os.path.getmtime(sys.argv[1])))
+PY
+}
+
+claude_smart_service_lock_stale_seconds() {
+  value="${CLAUDE_SMART_SERVICE_LOCK_STALE_SECONDS:-60}"
+  case "$value" in
+    ''|*[!0-9]*) printf '%s\n' "60" ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+}
+
+claude_smart_service_lock() {
+  name="$1"
+  lock_dir="$HOME/.claude-smart/$name.start.lock"
+  pid_file="$lock_dir/pid"
+  mkdir -p "$HOME/.claude-smart"
+  for _ in 1 2 3; do
+    if mkdir "$lock_dir" 2>/dev/null; then
+      printf '%s\n' "$$" > "$pid_file"
+      return 0
+    fi
+
+    lock_pid="$(cat "$pid_file" 2>/dev/null || true)"
+    now="$(claude_smart_now_epoch 2>/dev/null || printf '%s\n' "0")"
+    mtime="$(claude_smart_path_mtime_epoch "$lock_dir" 2>/dev/null || printf '%s\n' "$now")"
+    age=$((now - mtime))
+    stale_after="$(claude_smart_service_lock_stale_seconds)"
+
+    if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
+      return 1
+    fi
+    if [ -z "$lock_pid" ] && [ "$age" -lt "$stale_after" ]; then
+      return 1
+    fi
+    if [ -n "$lock_pid" ] || [ "$age" -ge "$stale_after" ]; then
+      stale_dir="$lock_dir.stale.$$"
+      if mv "$lock_dir" "$stale_dir" 2>/dev/null; then
+        rm -rf "$stale_dir"
+        continue
+      fi
+    fi
+    return 1
+  done
+  return 1
+}
+
+claude_smart_service_unlock() {
+  name="$1"
+  lock_dir="$HOME/.claude-smart/$name.start.lock"
+  pid_file="$lock_dir/pid"
+  [ -d "$lock_dir" ] || return 0
+  lock_pid="$(cat "$pid_file" 2>/dev/null || true)"
+  [ "$lock_pid" = "$$" ] || return 0
+  rm -rf "$lock_dir"
+}
+
+claude_smart_powershell_bin() {
+  for cand in powershell.exe powershell pwsh.exe pwsh; do
+    if command -v "$cand" >/dev/null 2>&1; then
+      command -v "$cand"
+      return 0
+    fi
+  done
+  return 1
+}
+
+claude_smart_port_listener_pids() {
+  port="$1"
+  if claude_smart_is_windows; then
+    ps_bin="$(claude_smart_powershell_bin 2>/dev/null || true)"
+    if [ -n "$ps_bin" ]; then
+      PORT="$port" "$ps_bin" -NoProfile -ExecutionPolicy Bypass -Command \
+        '$ErrorActionPreference="SilentlyContinue"; Get-NetTCPConnection -LocalPort $env:PORT -State Listen | Select-Object -ExpandProperty OwningProcess' \
+        2>/dev/null | tr -d '\r' | awk 'NF && !seen[$1]++ {print $1}'
+      return 0
+    fi
+    if command -v netstat >/dev/null 2>&1; then
+      netstat -ano 2>/dev/null | awk -v port=":$port" '
+        $1 ~ /^TCP/ && $2 ~ port "$" && $4 == "LISTENING" && !seen[$5]++ {print $5}
+      '
+      return 0
+    fi
+  fi
+  command -v lsof >/dev/null 2>&1 || return 0
+  lsof -tiTCP:"$port" -sTCP:LISTEN -P -n 2>/dev/null | awk 'NF && !seen[$1]++ {print $1}'
+}
+
+claude_smart_pid_command() {
+  pid="$1"
+  if claude_smart_is_windows; then
+    ps_bin="$(claude_smart_powershell_bin 2>/dev/null || true)"
+    if [ -n "$ps_bin" ]; then
+      PID="$pid" "$ps_bin" -NoProfile -ExecutionPolicy Bypass -Command \
+        '$ErrorActionPreference="SilentlyContinue"; $p=Get-CimInstance Win32_Process -Filter "ProcessId=$env:PID"; if ($p) { $p.CommandLine }' \
+        2>/dev/null | tr -d '\r'
+      return 0
+    fi
+    if command -v tasklist >/dev/null 2>&1; then
+      tasklist //FI "PID eq $pid" //FO CSV //NH 2>/dev/null \
+        | awk -F, 'NR==1 {gsub(/^"|"$/, "", $1); print $1}'
+      return 0
+    fi
+  fi
+  command -v ps >/dev/null 2>&1 || return 0
+  ps -ww -p "$pid" -o command= 2>/dev/null || true
+}
+
+claude_smart_pid_parent() {
+  pid="$1"
+  if claude_smart_is_windows; then
+    ps_bin="$(claude_smart_powershell_bin 2>/dev/null || true)"
+    if [ -n "$ps_bin" ]; then
+      PID="$pid" "$ps_bin" -NoProfile -ExecutionPolicy Bypass -Command \
+        '$ErrorActionPreference="SilentlyContinue"; $p=Get-CimInstance Win32_Process -Filter "ProcessId=$env:PID"; if ($p) { $p.ParentProcessId }' \
+        2>/dev/null | tr -d '\r'
+      return 0
+    fi
+  fi
+  command -v ps >/dev/null 2>&1 || return 0
+  ps -p "$pid" -o ppid= 2>/dev/null | awk 'NF {print $1; exit}' || true
+}
+
+claude_smart_port_holder() {
+  port="$1"
+  pid="$(claude_smart_port_listener_pids "$port" | head -n1)"
+  [ -n "$pid" ] || return 0
+  cmdline="$(claude_smart_pid_command "$pid" | head -n1)"
+  [ -n "$cmdline" ] || cmdline="unknown"
+  printf '%s (pid %s)\n' "$cmdline" "$pid"
+}
+
+claude_smart_reap_port_listeners_matching() {
+  port="$1"
+  shift || true
+  [ "$#" -gt 0 ] || return 1
+  killed=1
+  pids="$(claude_smart_port_listener_pids "$port" || true)"
+  [ -n "$pids" ] || return 1
+  for pid in $pids; do
+    cmdline="$(claude_smart_pid_command "$pid" | tr '\n' ' ' || true)"
+    [ -n "$cmdline" ] || continue
+    for pattern in "$@"; do
+      if [[ "$cmdline" == $pattern ]]; then
+        claude_smart_kill_tree "$pid"
+        killed=0
+        break
+      fi
+    done
+  done
+  return "$killed"
 }
 
 # Return 0 (true) if $1 names a pid file whose pid is currently alive.

--- a/plugin/scripts/backend-python-runner.py
+++ b/plugin/scripts/backend-python-runner.py
@@ -9,6 +9,17 @@ import sys
 
 
 def main() -> int:
+    """Mirror claude-smart metadata into env and delegate to Reflexio CLI.
+
+    Args:
+        None: Reads process argv. Arguments before ``--`` are
+            ``--claude-smart-*`` metadata kept visible in the process command
+            line; arguments after ``--`` become ``reflexio.cli`` arguments.
+
+    Returns:
+        int: Exit status. Returns ``2`` when required argument separators or
+            Reflexio CLI arguments are missing.
+    """
     try:
         separator = sys.argv.index("--")
     except ValueError:

--- a/plugin/scripts/backend-python-runner.py
+++ b/plugin/scripts/backend-python-runner.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Run Reflexio CLI with claude-smart metadata visible in process argv."""
+
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+
+
+def main() -> int:
+    try:
+        separator = sys.argv.index("--")
+    except ValueError:
+        return 2
+
+    metadata_args = sys.argv[1:separator]
+    reflexio_args = sys.argv[separator + 1 :]
+    if not reflexio_args:
+        return 2
+
+    for arg in metadata_args:
+        if not arg.startswith("--claude-smart-") or "=" not in arg:
+            continue
+        key, value = arg[2:].split("=", 1)
+        env_key = key.replace("-", "_").upper()
+        os.environ.setdefault(env_key, value)
+
+    sys.argv = ["reflexio.cli", *reflexio_args]
+    runpy.run_module("reflexio.cli", run_name="__main__")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -92,6 +92,11 @@ plugin_version_from_root() {
   printf '%s\n' "${version:-unknown}"
 }
 
+plugin_root_has_version_manifest() {
+  root="$1"
+  [ -f "$root/.codex-plugin/plugin.json" ] || [ -f "$root/package.json" ] || [ -f "$root/pyproject.toml" ]
+}
+
 PLUGIN_VERSION="$(plugin_version_from_root "$PLUGIN_ROOT_CANONICAL")"
 
 if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
@@ -293,8 +298,16 @@ pid_vendor_root() {
         printf '%s/vendor/reflexio\n' "${token#--claude-smart-plugin-root=}"
         return 0
         ;;
+    esac
+    value="${token#*=}"
+    case "$value" in
+      *";"*) value="${value%%;*}" ;;
+      [A-Za-z]:\\*) ;;
+      *) value="${value%%:*}" ;;
+    esac
+    case "$value" in
       */vendor/reflexio|*\\vendor\\reflexio)
-        printf '%s\n' "$token"
+        printf '%s\n' "$value"
         return 0
         ;;
     esac
@@ -322,8 +335,21 @@ pid_plugin_root() {
     esac
   done
   vendor="$(pid_vendor_root "$1" 2>/dev/null || true)"
-  [ -n "$vendor" ] || return 1
-  plugin_root_from_vendor_root "$vendor"
+  if [ -n "$vendor" ]; then
+    plugin_root_from_vendor_root "$vendor" && return 0
+  fi
+  for token in $text; do
+    case "$token" in
+      cwd=*)
+        root="${token#cwd=}"
+        if plugin_root_has_version_manifest "$root"; then
+          printf '%s\n' "$root"
+          return 0
+        fi
+        ;;
+    esac
+  done
+  return 1
 }
 
 pid_plugin_version() {
@@ -523,7 +549,7 @@ stop_backend_listener_if_owned() {
   [ -n "$pids" ] || return 1
   ours=""
   for pid in $pids; do
-    if is_claude_smart_backend_pid "$pid" && { pid_uses_current_vendor_root "$pid" || backend_pid_strictly_older_than_plugin "$pid" || backend_pid_is_own_recorded "$pid"; }; then
+    if is_claude_smart_backend_pid "$pid" && { pid_uses_current_vendor_root "$pid" || backend_pid_strictly_older_than_plugin "$pid"; }; then
       ours="$ours $pid"
     fi
   done
@@ -739,6 +765,10 @@ case "$CMD" in
     case "$listener_class" in
       claude_smart)
         if backend_current_or_compatible; then
+          if ! backend_owned_by_current_vendor; then
+            claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+              "[claude-smart] backend: accepted compatible claude-smart backend on port $PORT from another plugin root; not restarting"
+          fi
           embedding_current_or_compatible || log_embedding_degraded
           emit_ok; exit 0
         fi
@@ -855,37 +885,24 @@ case "$CMD" in
     # setsid/python os.setsid make this pid the new process group leader;
     # sampling immediately can race and capture the caller's pgid instead.
     # On Windows, claude_smart_kill_tree translates the MSYS pid to WINPID.
+    set -- services start --only backend --no-reload --workers "$workers"
     if reflexio_services_start_supports_skip "$backend_python"; then
-      claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
-        "$LOG_FILE" "$LOG_MAX_BYTES" -- \
-        env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
-        PYTHONPATH="$backend_pythonpath" \
-        CLAUDE_SMART_BACKEND=1 \
-        CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL" \
-        CLAUDE_SMART_VERSION="$PLUGIN_VERSION" \
-        CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON" \
-        "$backend_python" "$HERE/backend-python-runner.py" \
-        --claude-smart-backend=1 \
-        "--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL" \
-        "--claude-smart-version=$PLUGIN_VERSION" \
-        "--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON" \
-        -- services start --skip-if-running --only backend --no-reload --workers "$workers"
-    else
-      claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
-        "$LOG_FILE" "$LOG_MAX_BYTES" -- \
-        env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
-        PYTHONPATH="$backend_pythonpath" \
-        CLAUDE_SMART_BACKEND=1 \
-        CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL" \
-        CLAUDE_SMART_VERSION="$PLUGIN_VERSION" \
-        CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON" \
-        "$backend_python" "$HERE/backend-python-runner.py" \
-        --claude-smart-backend=1 \
-        "--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL" \
-        "--claude-smart-version=$PLUGIN_VERSION" \
-        "--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON" \
-        -- services start --only backend --no-reload --workers "$workers"
+      set -- services start --skip-if-running --only backend --no-reload --workers "$workers"
     fi
+    claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
+      "$LOG_FILE" "$LOG_MAX_BYTES" -- \
+      env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
+      PYTHONPATH="$backend_pythonpath" \
+      CLAUDE_SMART_BACKEND=1 \
+      CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL" \
+      CLAUDE_SMART_VERSION="$PLUGIN_VERSION" \
+      CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON" \
+      "$backend_python" "$HERE/backend-python-runner.py" \
+      --claude-smart-backend=1 \
+      "--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL" \
+      "--claude-smart-version=$PLUGIN_VERSION" \
+      "--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON" \
+      -- "$@"
     svc_pid=$!
     echo "$svc_pid" > "$PID_FILE"
 

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -628,13 +628,6 @@ port_holder() {
   claude_smart_port_holder "$1"
 }
 
-reflexio_services_start_supports_skip() {
-  python_bin="$1"
-  [ -x "$python_bin" ] || return 1
-  "$python_bin" -m reflexio.cli services start --help 2>/dev/null \
-    | grep -q -- "--skip-if-running"
-}
-
 recorded_backend_pid() {
   [ -f "$PID_FILE" ] || return 1
   pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
@@ -930,9 +923,6 @@ case "$CMD" in
     # sampling immediately can race and capture the caller's pgid instead.
     # On Windows, claude_smart_kill_tree translates the MSYS pid to WINPID.
     set -- services start --only backend --no-reload --workers "$workers"
-    if reflexio_services_start_supports_skip "$backend_python"; then
-      set -- services start --skip-if-running --only backend --no-reload --workers "$workers"
-    fi
     claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
       "$LOG_FILE" "$LOG_MAX_BYTES" -- \
       env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -267,7 +267,7 @@ looks_like_claude_smart_backend_pid() {
   text="$(pid_details "$pid")"
   [ -n "$text" ] || return 1
   case "$text" in
-    *--claude-smart-backend=1*|*--claude-smart-reflexio-vendor-root=*|*--claude-smart-plugin-root=*|*CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=*|*CLAUDE_SMART_USE_LOCAL_CLI=1*|*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*|*".claude-smart/.env"*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"local-agent-mode-sessions"*|*"$PLUGIN_ROOT_CANONICAL"*|*"$HOME/.reflexio/plugin-root"*)
+    *--claude-smart-backend=1*|*--claude-smart-reflexio-vendor-root=*|*--claude-smart-plugin-root=*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"$PLUGIN_ROOT_CANONICAL"*)
       return 0
       ;;
   esac
@@ -291,23 +291,6 @@ pid_vendor_root() {
         ;;
       --claude-smart-plugin-root=*)
         printf '%s/vendor/reflexio\n' "${token#--claude-smart-plugin-root=}"
-        return 0
-        ;;
-      CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=*)
-        printf '%s\n' "${token#CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=}"
-        return 0
-        ;;
-      PYTHONPATH=*)
-        pythonpath_value="${token#PYTHONPATH=}"
-        if claude_smart_is_windows; then
-          printf '%s\n' "$pythonpath_value" \
-            | tr ';' '\n' \
-            | awk '/\/vendor\/reflexio$|\\vendor\\reflexio$/ {print; exit}'
-        else
-          printf '%s\n' "$pythonpath_value" \
-            | tr ':' '\n' \
-            | awk '/\/vendor\/reflexio$|\\vendor\\reflexio$/ {print; exit}'
-        fi
         return 0
         ;;
       */vendor/reflexio|*\\vendor\\reflexio)
@@ -363,7 +346,7 @@ pid_uses_current_vendor_root() {
   text="$(pid_details "$pid")"
   [ -n "$text" ] || return 1
   case "$text" in
-    *"--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO"*|*"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"PYTHONPATH=$VENDORED_REFLEXIO"*|*"PYTHONPATH=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"$VENDORED_REFLEXIO"*|*"$VENDORED_REFLEXIO_FOR_PYTHON"*)
+    *"--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"$VENDORED_REFLEXIO"*|*"$VENDORED_REFLEXIO_FOR_PYTHON"*)
       return 0
       ;;
   esac
@@ -625,6 +608,26 @@ backend_pid_is_own_recorded() {
   [ -n "$recorded" ] && [ "$pid" = "$recorded" ]
 }
 
+pid_cwd_matches_current_plugin_root() {
+  pid="$1"
+  command -v lsof >/dev/null 2>&1 || return 1
+  cwd="$(
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null \
+      | sed -n 's/^n//p' \
+      | head -n 1
+  )"
+  [ -n "$cwd" ] || return 1
+  cwd_canonical="$(cd "$cwd" 2>/dev/null && pwd -P || printf '%s\n' "$cwd")"
+  [ "$cwd_canonical" = "$PLUGIN_ROOT_CANONICAL" ]
+}
+
+backend_pid_is_legacy_same_root_shared() {
+  pid="$1"
+  shared="$(shared_backend_pid 2>/dev/null || true)"
+  [ -n "$shared" ] && [ "$pid" = "$shared" ] || return 1
+  pid_cwd_matches_current_plugin_root "$pid"
+}
+
 backend_start_grace_seconds() {
   value="${CLAUDE_SMART_BACKEND_START_GRACE_SECONDS:-60}"
   case "$value" in
@@ -646,7 +649,10 @@ kill_pid_if_directionally_owned() {
   [ -n "$pid" ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   is_claude_smart_backend_pid "$pid" || return 1
-  if pid_uses_current_vendor_root "$pid" || backend_pid_strictly_older_than_plugin "$pid" || backend_pid_is_own_recorded "$pid"; then
+  if pid_uses_current_vendor_root "$pid" \
+    || backend_pid_strictly_older_than_plugin "$pid" \
+    || backend_pid_is_own_recorded "$pid" \
+    || backend_pid_is_legacy_same_root_shared "$pid"; then
     kill_group "$pid"
     return 0
   fi

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -272,16 +272,43 @@ looks_like_claude_smart_backend_pid() {
   text="$(pid_details "$pid")"
   [ -n "$text" ] || return 1
   case "$text" in
-    *--claude-smart-backend=1*|*--claude-smart-reflexio-vendor-root=*|*--claude-smart-plugin-root=*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"$PLUGIN_ROOT_CANONICAL"*)
+    *--claude-smart-backend=1*|*--claude-smart-reflexio-vendor-root=*|*--claude-smart-plugin-root=*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*)
       return 0
       ;;
   esac
+  for token in $text; do
+    value="$(pid_token_path_entry "$token")"
+    path_is_or_under_root "$PLUGIN_ROOT_CANONICAL" "$value" && return 0
+  done
   return 1
 }
 
 is_claude_smart_backend_pid() {
   pid="$1"
   backend_pid_command_matches "$pid" && looks_like_claude_smart_backend_pid "$pid"
+}
+
+path_is_or_under_root() {
+  root="$1"
+  value="$2"
+  [ -n "$root" ] && [ -n "$value" ] || return 1
+  case "$value" in
+    "$root"|"$root"/*|"$root"\\*) return 0 ;;
+  esac
+  return 1
+}
+
+pid_token_path_entry() {
+  token="$1"
+  value="${token#*=}"
+  # PYTHONPATH can hold multiple roots; split path-list suffixes without
+  # treating a Windows drive prefix like C:\... as a separator.
+  case "$value" in
+    *";"*) value="${value%%;*}" ;;
+    [A-Za-z]:\\*) ;;
+    *) value="${value%%:*}" ;;
+  esac
+  printf '%s\n' "$value"
 }
 
 pid_vendor_root() {
@@ -299,16 +326,14 @@ pid_vendor_root() {
         return 0
         ;;
     esac
-    value="${token#*=}"
-    case "$value" in
-      *";"*) value="${value%%;*}" ;;
-      [A-Za-z]:\\*) ;;
-      *) value="${value%%:*}" ;;
-    esac
+    value="$(pid_token_path_entry "$token")"
     case "$value" in
       */vendor/reflexio|*\\vendor\\reflexio)
-        printf '%s\n' "$value"
-        return 0
+        root="$(plugin_root_from_vendor_root "$value" 2>/dev/null || true)"
+        if [ -n "$root" ] && plugin_root_has_version_manifest "$root"; then
+          printf '%s\n' "$value"
+          return 0
+        fi
         ;;
     esac
   done
@@ -371,11 +396,24 @@ pid_uses_current_vendor_root() {
   pid="$1"
   text="$(pid_details "$pid")"
   [ -n "$text" ] || return 1
-  case "$text" in
-    *"--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"$VENDORED_REFLEXIO"*|*"$VENDORED_REFLEXIO_FOR_PYTHON"*)
-      return 0
-      ;;
-  esac
+  for token in $text; do
+    case "$token" in
+      --claude-smart-plugin-root=*)
+        value="${token#--claude-smart-plugin-root=}"
+        path_is_or_under_root "$PLUGIN_ROOT_CANONICAL" "$value" && return 0
+        ;;
+      --claude-smart-reflexio-vendor-root=*)
+        value="${token#--claude-smart-reflexio-vendor-root=}"
+        path_is_or_under_root "$VENDORED_REFLEXIO" "$value" && return 0
+        path_is_or_under_root "$VENDORED_REFLEXIO_FOR_PYTHON" "$value" && return 0
+        ;;
+      *)
+        value="$(pid_token_path_entry "$token")"
+        path_is_or_under_root "$VENDORED_REFLEXIO" "$value" && return 0
+        path_is_or_under_root "$VENDORED_REFLEXIO_FOR_PYTHON" "$value" && return 0
+        ;;
+    esac
+  done
   return 1
 }
 
@@ -688,13 +726,19 @@ kill_pid_if_directionally_owned() {
 kill_recorded_backend() {
   pid="$(recorded_backend_pid 2>/dev/null || true)"
   if [ -n "$pid" ]; then
-    kill_pid_if_directionally_owned "$pid" || true
+    if ! kill_pid_if_directionally_owned "$pid"; then
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+        "[claude-smart] backend: recorded pid $pid is not owned by this plugin; removing stale root-specific pid file"
+    fi
     rm -f "$PID_FILE"
   fi
   shared_pid="$(shared_backend_pid 2>/dev/null || true)"
   if [ -n "$shared_pid" ]; then
     if kill_pid_if_directionally_owned "$shared_pid"; then
       rm -f "$SHARED_PID_FILE"
+    else
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+        "[claude-smart] backend: shared pid $shared_pid is not owned by this plugin; leaving shared pid file"
     fi
   fi
   return 0

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -27,7 +27,7 @@ fi
 claude_smart_prepend_astral_bins
 claude_smart_source_reflexio_env
 
-PORT=8071
+PORT="${BACKEND_PORT:-8071}"
 EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"
 # Pass through to `reflexio services start/stop` so the spawned backend
 # binds to PORT instead of reflexio's library default (8081).
@@ -71,6 +71,29 @@ if claude_smart_is_windows; then
 fi
 export CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON"
 
+plugin_version_from_root() {
+  root="$1"
+  version="$(
+    sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$root/.codex-plugin/plugin.json" 2>/dev/null | head -n1
+  )"
+  if [ -z "$version" ]; then
+    version="$(
+      sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        "$root/package.json" 2>/dev/null | head -n1
+    )"
+  fi
+  if [ -z "$version" ]; then
+    version="$(
+      sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+        "$root/pyproject.toml" 2>/dev/null | head -n1
+    )"
+  fi
+  printf '%s\n' "${version:-unknown}"
+}
+
+PLUGIN_VERSION="$(plugin_version_from_root "$PLUGIN_ROOT_CANONICAL")"
+
 if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
   if [ "${CLAUDE_SMART_HOST:-claude-code}" = "opencode" ]; then
     # Preserve Reflexio's Claude CLI provider contract while routing
@@ -95,7 +118,12 @@ if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
 fi
 
 STATE_DIR="$HOME/.claude-smart"
-PID_FILE="$STATE_DIR/backend.pid"
+backend_pid_key="$(
+  printf '%s' "$PLUGIN_ROOT_CANONICAL" | cksum 2>/dev/null | awk '{print $1}' || true
+)"
+backend_pid_key="${backend_pid_key:-default}"
+PID_FILE="$STATE_DIR/backend.$backend_pid_key.pid"
+SHARED_PID_FILE="$STATE_DIR/backend.pid"
 LOG_FILE="$STATE_DIR/backend.log"
 LOG_MAX_BYTES="$(claude_smart_log_max_bytes)"
 mkdir -p "$STATE_DIR"
@@ -175,21 +203,63 @@ port_occupied() {
   (echo >"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null
 }
 
-port_listener_pids() {
-  command -v lsof >/dev/null 2>&1 || return 0
-  lsof -t -i ":$1" -sTCP:LISTEN 2>/dev/null || true
-}
-
 pid_details() {
   pid="$1"
-  {
-    ps eww -p "$pid" -o command= 2>/dev/null \
-      || ps -p "$pid" -o command= 2>/dev/null \
-      || true
-    if command -v lsof >/dev/null 2>&1; then
-      lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n/cwd=/p' || true
-    fi
-  } | tr '\n' ' '
+  seen=" "
+  depth=0
+  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$depth" -lt 6 ]; do
+    case "$seen" in *" $pid "*) break ;; esac
+    seen="$seen$pid "
+    {
+      printf 'pid=%s ' "$pid"
+      claude_smart_pid_command "$pid" 2>/dev/null || true
+      if command -v lsof >/dev/null 2>&1; then
+        lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n/cwd=/p' || true
+      fi
+    }
+    parent="$(claude_smart_pid_parent "$pid" 2>/dev/null || true)"
+    [ -n "$parent" ] && [ "$parent" != "$pid" ] || break
+    pid="$parent"
+    depth=$((depth + 1))
+  done | tr '\n' ' '
+}
+
+marked_backend_ancestor_pid() {
+  pid="$1"
+  seen=" "
+  depth=0
+  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$depth" -lt 6 ]; do
+    case "$seen" in *" $pid "*) break ;; esac
+    seen="$seen$pid "
+    cmdline="$(claude_smart_pid_command "$pid" | tr '\n' ' ' || true)"
+    case "$cmdline" in
+      *backend-python-runner.py*--claude-smart-backend=1*)
+        printf '%s\n' "$pid"
+        return 0
+        ;;
+    esac
+    parent="$(claude_smart_pid_parent "$pid" 2>/dev/null || true)"
+    [ -n "$parent" ] && [ "$parent" != "$pid" ] || break
+    pid="$parent"
+    depth=$((depth + 1))
+  done
+  return 1
+}
+
+stop_backend_pids() {
+  pids="$1"
+  [ -n "$pids" ] || return 0
+  targets=""
+  for pid in $pids; do
+    target="$(marked_backend_ancestor_pid "$pid" 2>/dev/null || true)"
+    for candidate in ${target:-} "$pid"; do
+      [ -n "$candidate" ] || continue
+      case " $targets " in *" $candidate "*) ;; *) targets="$targets $candidate" ;; esac
+    done
+  done
+  for target in $targets; do
+    kill_group "$target"
+  done
 }
 
 looks_like_claude_smart_backend_pid() {
@@ -197,11 +267,95 @@ looks_like_claude_smart_backend_pid() {
   text="$(pid_details "$pid")"
   [ -n "$text" ] || return 1
   case "$text" in
-    *CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=*|*CLAUDE_SMART_USE_LOCAL_CLI=1*|*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*|*".claude-smart/.env"*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"local-agent-mode-sessions"*|*"$PLUGIN_ROOT_CANONICAL"*|*"$HOME/.reflexio/plugin-root"*)
+    *--claude-smart-backend=1*|*--claude-smart-reflexio-vendor-root=*|*--claude-smart-plugin-root=*|*CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=*|*CLAUDE_SMART_USE_LOCAL_CLI=1*|*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*|*".claude-smart/.env"*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"local-agent-mode-sessions"*|*"$PLUGIN_ROOT_CANONICAL"*|*"$HOME/.reflexio/plugin-root"*)
       return 0
       ;;
   esac
   return 1
+}
+
+is_claude_smart_backend_pid() {
+  pid="$1"
+  backend_pid_command_matches "$pid" && looks_like_claude_smart_backend_pid "$pid"
+}
+
+pid_vendor_root() {
+  pid="$1"
+  text="$(pid_details "$pid")"
+  [ -n "$text" ] || return 1
+  for token in $text; do
+    case "$token" in
+      --claude-smart-reflexio-vendor-root=*)
+        printf '%s\n' "${token#--claude-smart-reflexio-vendor-root=}"
+        return 0
+        ;;
+      --claude-smart-plugin-root=*)
+        printf '%s/vendor/reflexio\n' "${token#--claude-smart-plugin-root=}"
+        return 0
+        ;;
+      CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=*)
+        printf '%s\n' "${token#CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=}"
+        return 0
+        ;;
+      PYTHONPATH=*)
+        pythonpath_value="${token#PYTHONPATH=}"
+        if claude_smart_is_windows; then
+          printf '%s\n' "$pythonpath_value" \
+            | tr ';' '\n' \
+            | awk '/\/vendor\/reflexio$|\\vendor\\reflexio$/ {print; exit}'
+        else
+          printf '%s\n' "$pythonpath_value" \
+            | tr ':' '\n' \
+            | awk '/\/vendor\/reflexio$|\\vendor\\reflexio$/ {print; exit}'
+        fi
+        return 0
+        ;;
+      */vendor/reflexio|*\\vendor\\reflexio)
+        printf '%s\n' "$token"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+plugin_root_from_vendor_root() {
+  vendor="$1"
+  case "$vendor" in
+    */vendor/reflexio) printf '%s\n' "${vendor%/vendor/reflexio}"; return 0 ;;
+    *\\vendor\\reflexio) printf '%s\n' "${vendor%\\vendor\\reflexio}"; return 0 ;;
+  esac
+  return 1
+}
+
+pid_plugin_root() {
+  text="$(pid_details "$1")"
+  for token in $text; do
+    case "$token" in
+      --claude-smart-plugin-root=*)
+        printf '%s\n' "${token#--claude-smart-plugin-root=}"
+        return 0
+        ;;
+    esac
+  done
+  vendor="$(pid_vendor_root "$1" 2>/dev/null || true)"
+  [ -n "$vendor" ] || return 1
+  plugin_root_from_vendor_root "$vendor"
+}
+
+pid_plugin_version() {
+  text="$(pid_details "$1")"
+  for token in $text; do
+    case "$token" in
+      --claude-smart-version=*)
+        printf '%s\n' "${token#--claude-smart-version=}"
+        return 0
+        ;;
+    esac
+  done
+  root="$(pid_plugin_root "$1" 2>/dev/null || true)"
+  [ -n "$root" ] || { printf '%s\n' "unknown"; return 0; }
+  plugin_version_from_root "$root"
 }
 
 pid_uses_current_vendor_root() {
@@ -209,18 +363,78 @@ pid_uses_current_vendor_root() {
   text="$(pid_details "$pid")"
   [ -n "$text" ] || return 1
   case "$text" in
-    *"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO"*|*"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"PYTHONPATH=$VENDORED_REFLEXIO"*|*"PYTHONPATH=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"$VENDORED_REFLEXIO"*|*"$VENDORED_REFLEXIO_FOR_PYTHON"*)
+    *"--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO"*|*"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO"*|*"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"PYTHONPATH=$VENDORED_REFLEXIO"*|*"PYTHONPATH=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"$VENDORED_REFLEXIO"*|*"$VENDORED_REFLEXIO_FOR_PYTHON"*)
       return 0
       ;;
   esac
   return 1
 }
 
+backend_version_core_parts() {
+  version="$1"
+  printf '%s\n' "$version" \
+    | sed -n 's/^\([0-9][0-9]*\)\.\([0-9][0-9]*\)\.\([0-9][0-9]*\)$/\1 \2 \3/p'
+}
+
+backend_version_older_than() {
+  actual_version_input="$1"
+  target_version_input="$2"
+  actual_core="$(backend_version_core_parts "$actual_version_input")"
+  target_core="$(backend_version_core_parts "$target_version_input")"
+  [ -n "$actual_core" ] && [ -n "$target_core" ] || return 1
+
+  set -- $actual_core
+  actual_major="$1"; actual_minor="$2"; actual_patch="$3"
+  set -- $target_core
+  target_major="$1"; target_minor="$2"; target_patch="$3"
+
+  [ "$actual_major" -lt "$target_major" ] && return 0
+  [ "$actual_major" -gt "$target_major" ] && return 1
+  [ "$actual_minor" -lt "$target_minor" ] && return 0
+  [ "$actual_minor" -gt "$target_minor" ] && return 1
+  [ "$actual_patch" -lt "$target_patch" ] && return 0
+  return 1
+}
+
+backend_pid_current_or_compatible() {
+  pid="$1"
+  pid_uses_current_vendor_root "$pid" && return 0
+  [ "$PLUGIN_VERSION" = "unknown" ] && return 0
+  running_version="$(pid_plugin_version "$pid")"
+  [ "$running_version" = "unknown" ] && return 0
+  ! backend_version_older_than "$running_version" "$PLUGIN_VERSION"
+}
+
+backend_pid_strictly_older_than_plugin() {
+  pid="$1"
+  [ "$PLUGIN_VERSION" != "unknown" ] || return 1
+  pid_uses_current_vendor_root "$pid" && return 1
+  running_version="$(pid_plugin_version "$pid")"
+  [ "$running_version" != "unknown" ] || return 1
+  backend_version_older_than "$running_version" "$PLUGIN_VERSION"
+}
+
+backend_listener_pids() {
+  claude_smart_port_listener_pids "$PORT"
+}
+
+classify_backend_listener() {
+  pids="$(backend_listener_pids || true)"
+  [ -n "$pids" ] || { printf '%s\n' "free"; return 0; }
+  for pid in $pids; do
+    if is_claude_smart_backend_pid "$pid"; then
+      printf '%s\n' "claude_smart"
+      return 0
+    fi
+  done
+  printf '%s\n' "foreign"
+}
+
 backend_owned_by_current_vendor() {
   backend_healthy || return 1
-  pids="$(port_listener_pids "$PORT")"
+  pids="$(backend_listener_pids)"
   for pid in $pids; do
-    if looks_like_claude_smart_backend_pid "$pid" && pid_uses_current_vendor_root "$pid"; then
+    if is_claude_smart_backend_pid "$pid" && pid_uses_current_vendor_root "$pid"; then
       return 0
     fi
   done
@@ -228,9 +442,20 @@ backend_owned_by_current_vendor() {
 }
 
 backend_owned_by_stale_claude_smart() {
-  pids="$(port_listener_pids "$PORT")"
+  pids="$(backend_listener_pids)"
   for pid in $pids; do
-    if looks_like_claude_smart_backend_pid "$pid" && ! pid_uses_current_vendor_root "$pid"; then
+    if is_claude_smart_backend_pid "$pid" && backend_pid_strictly_older_than_plugin "$pid"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+backend_current_or_compatible() {
+  backend_healthy || return 1
+  pids="$(backend_listener_pids)"
+  for pid in $pids; do
+    if is_claude_smart_backend_pid "$pid" && backend_pid_current_or_compatible "$pid"; then
       return 0
     fi
   done
@@ -239,9 +464,20 @@ backend_owned_by_stale_claude_smart() {
 
 embedding_owned_by_current_vendor() {
   [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
-  pids="$(port_listener_pids "$EMBEDDING_PORT")"
+  pids="$(claude_smart_port_listener_pids "$EMBEDDING_PORT")"
   for pid in $pids; do
-    if looks_like_claude_smart_backend_pid "$pid" && pid_uses_current_vendor_root "$pid"; then
+    if is_claude_smart_backend_pid "$pid" && pid_uses_current_vendor_root "$pid"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+embedding_current_or_compatible() {
+  [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
+  pids="$(claude_smart_port_listener_pids "$EMBEDDING_PORT")"
+  for pid in $pids; do
+    if is_claude_smart_backend_pid "$pid" && backend_pid_current_or_compatible "$pid"; then
       return 0
     fi
   done
@@ -284,82 +520,152 @@ PY
 is_our_backend_running() {
   if [ -f "$PID_FILE" ]; then
     pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && backend_pid_command_matches "$pid"; then
       if command -v curl >/dev/null 2>&1; then
-        backend_healthy && pid_uses_current_vendor_root "$pid" && return 0
+        backend_healthy && backend_pid_current_or_compatible "$pid" && return 0
       else
-        pid_uses_current_vendor_root "$pid" && return 0
+        backend_pid_current_or_compatible "$pid" && return 0
       fi
     fi
   fi
   # Recover from a missing PID file only when the listener proves it belongs
-  # to the current vendored Reflexio package. A generic healthy service is not
-  # enough.
-  backend_owned_by_current_vendor && return 0
+  # to a compatible claude-smart package. A generic healthy service is not
+  # enough, and a known older claude-smart package is restarted later.
+  backend_current_or_compatible && return 0
   return 1
 }
 
-stop_port_pids() {
-  pids="$1"
-  [ -n "$pids" ] || return 0
-  # shellcheck disable=SC2086
-  kill -TERM $pids 2>/dev/null || true
-  sleep 1
-  remaining=""
-  for pid in $pids; do
-    kill -0 "$pid" 2>/dev/null && remaining="$remaining $pid"
-  done
-  [ -z "$remaining" ] && return 0
-  # shellcheck disable=SC2086
-  kill -KILL $remaining 2>/dev/null || true
-}
-
 stop_backend_listener_if_owned() {
-  pids="$(port_listener_pids "$PORT")"
+  pids="$(backend_listener_pids)"
   [ -n "$pids" ] || return 1
   ours=""
   for pid in $pids; do
-    if looks_like_claude_smart_backend_pid "$pid"; then
+    if is_claude_smart_backend_pid "$pid" && { pid_uses_current_vendor_root "$pid" || backend_pid_strictly_older_than_plugin "$pid" || backend_pid_is_own_recorded "$pid"; }; then
       ours="$ours $pid"
     fi
   done
   [ -n "$ours" ] || return 1
-  stop_port_pids "$ours"
+  stop_backend_pids "$ours"
 }
 
 stop_stale_backend_listener_if_owned() {
   backend_owned_by_stale_claude_smart || return 1
   stale=""
-  for pid in $(port_listener_pids "$PORT"); do
-    if looks_like_claude_smart_backend_pid "$pid" && ! pid_uses_current_vendor_root "$pid"; then
+  for pid in $(backend_listener_pids); do
+    if is_claude_smart_backend_pid "$pid" && backend_pid_strictly_older_than_plugin "$pid"; then
       stale="$stale $pid"
     fi
   done
   [ -n "$stale" ] || return 1
-  stop_port_pids "$stale"
+  stop_backend_pids "$stale"
 }
 
 stop_stale_embedding_listener_if_owned() {
   [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
-  pids="$(port_listener_pids "$EMBEDDING_PORT")"
+  pids="$(claude_smart_port_listener_pids "$EMBEDDING_PORT")"
   [ -n "$pids" ] || return 0
   ours=""
   for pid in $pids; do
-    if looks_like_claude_smart_backend_pid "$pid" && ! pid_uses_current_vendor_root "$pid"; then
+    if is_claude_smart_backend_pid "$pid" && backend_pid_strictly_older_than_plugin "$pid"; then
       ours="$ours $pid"
     fi
   done
   [ -n "$ours" ] || return 0
-  stop_port_pids "$ours"
+  stop_backend_pids "$ours"
 }
 
 # Describe what (if anything) is currently listening on $1. Returns
-# "<command> (pid <pid>)" or empty if the port is free or lsof is
-# unavailable. Used to make port-conflict log lines diagnosable.
+# "<command> (pid <pid>)" or empty if the port is free or no platform probe is
+# available. Used to make port-conflict log lines diagnosable.
 port_holder() {
-  command -v lsof >/dev/null 2>&1 || return 0
-  lsof -i:"$1" -sTCP:LISTEN -P -n 2>/dev/null \
-    | awk 'NR==2 {print $1" (pid "$2")"; exit}'
+  claude_smart_port_holder "$1"
+}
+
+reflexio_services_start_supports_skip() {
+  python_bin="$1"
+  [ -x "$python_bin" ] || return 1
+  "$python_bin" -m reflexio.cli services start --help 2>/dev/null \
+    | grep -q -- "--skip-if-running"
+}
+
+recorded_backend_pid() {
+  [ -f "$PID_FILE" ] || return 1
+  pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
+  [ -n "$pid" ] || return 1
+  printf '%s\n' "$pid"
+}
+
+shared_backend_pid() {
+  [ -f "$SHARED_PID_FILE" ] || return 1
+  pid=$(cat "$SHARED_PID_FILE" 2>/dev/null || echo "")
+  [ -n "$pid" ] || return 1
+  printf '%s\n' "$pid"
+}
+
+backend_pid_command_matches() {
+  pid="$1"
+  cmdline="$(claude_smart_pid_command "$pid" | tr '\n' ' ' || true)"
+  [ -n "$cmdline" ] || return 1
+  case "$cmdline" in
+    *backend-python-runner.py*--claude-smart-backend=1*services*start*|*reflexio.cli*services*start*|*reflexio.server*|*uvicorn*reflexio*|*reflexio*uvicorn*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+recorded_backend_pid_alive() {
+  pid="$(recorded_backend_pid 2>/dev/null || true)"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  backend_pid_command_matches "$pid"
+}
+
+backend_pid_is_own_recorded() {
+  pid="$1"
+  recorded="$(recorded_backend_pid 2>/dev/null || true)"
+  [ -n "$recorded" ] && [ "$pid" = "$recorded" ]
+}
+
+backend_start_grace_seconds() {
+  value="${CLAUDE_SMART_BACKEND_START_GRACE_SECONDS:-60}"
+  case "$value" in
+    ''|*[!0-9]*) printf '%s\n' "60" ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+}
+
+recorded_backend_pid_in_startup_grace() {
+  recorded_backend_pid_alive || return 1
+  now="$(claude_smart_now_epoch 2>/dev/null || printf '%s\n' "0")"
+  mtime="$(claude_smart_path_mtime_epoch "$PID_FILE" 2>/dev/null || printf '%s\n' "$now")"
+  age=$((now - mtime))
+  [ "$age" -lt "$(backend_start_grace_seconds)" ]
+}
+
+kill_pid_if_directionally_owned() {
+  pid="$1"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  is_claude_smart_backend_pid "$pid" || return 1
+  if pid_uses_current_vendor_root "$pid" || backend_pid_strictly_older_than_plugin "$pid" || backend_pid_is_own_recorded "$pid"; then
+    kill_group "$pid"
+    return 0
+  fi
+  return 1
+}
+
+kill_recorded_backend() {
+  pid="$(recorded_backend_pid 2>/dev/null || true)"
+  if [ -n "$pid" ]; then
+    kill_pid_if_directionally_owned "$pid" || true
+    rm -f "$PID_FILE"
+  fi
+  shared_pid="$(shared_backend_pid 2>/dev/null || true)"
+  if [ -n "$shared_pid" ]; then
+    if kill_pid_if_directionally_owned "$shared_pid"; then
+      rm -f "$SHARED_PID_FILE"
+    fi
+  fi
+  return 0
 }
 
 ensure_vendored_reflexio_active() {
@@ -395,10 +701,7 @@ PY
 # claude-smart-owned backend/embedding listeners. Foreign services on the same
 # ports are left alone.
 full_stop() {
-  if [ -f "$PID_FILE" ]; then
-    kill_group "$(cat "$PID_FILE" 2>/dev/null)"
-    rm -f "$PID_FILE"
-  fi
+  kill_recorded_backend
   stop_backend_listener_if_owned || true
   if [ -n "${EMBEDDING_PORT:-}" ] && [ "$EMBEDDING_PORT" != "$PORT" ]; then
     stop_stale_embedding_listener_if_owned || true
@@ -419,13 +722,48 @@ case "$CMD" in
     if [ "${CLAUDE_SMART_BACKEND_AUTOSTART:-1}" = "0" ]; then
       emit_ok; exit 0
     fi
-    if is_our_backend_running; then
-      embedding_owned_by_current_vendor || log_embedding_degraded
+    if ! claude_smart_service_lock "backend"; then
+      if wait_for_health backend_current_or_compatible 3 1; then
+        embedding_current_or_compatible || log_embedding_degraded
+      fi
       emit_ok; exit 0
+    fi
+    trap 'claude_smart_service_unlock "backend"' EXIT
+    listener_class="$(classify_backend_listener)"
+    case "$listener_class" in
+      claude_smart)
+        if backend_current_or_compatible; then
+          embedding_current_or_compatible || log_embedding_degraded
+          emit_ok; exit 0
+        fi
+        ;;
+      foreign)
+        holder="$(port_holder "$PORT" 2>/dev/null || true)"
+        msg="[claude-smart] backend: port $PORT held by another process${holder:+ ($holder)}; skipping start"
+        claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "$msg"
+        echo "$msg" >&2
+        echo "Free port $PORT (or stop the process above) and run /claude-smart:restart again." >&2
+        emit_ok; exit 0
+        ;;
+    esac
+    if is_our_backend_running; then
+      embedding_current_or_compatible || log_embedding_degraded
+      emit_ok; exit 0
+    fi
+    if recorded_backend_pid_in_startup_grace; then
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+        "[claude-smart] backend: recorded backend process is still running but not healthy yet; skipping duplicate start"
+      emit_ok; exit 0
+    fi
+    if recorded_backend_pid_alive; then
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+        "[claude-smart] backend: recorded backend process exceeded startup grace without health; restarting"
+      kill_recorded_backend
+      sleep 1
     fi
     if stop_stale_backend_listener_if_owned; then
       claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
-        "[claude-smart] backend: replaced claude-smart backend on port $PORT that was not using bundled Reflexio at $VENDORED_REFLEXIO"
+        "[claude-smart] backend: existing claude-smart backend is older than plugin $PLUGIN_VERSION; restarting local services"
     fi
     stop_stale_embedding_listener_if_owned || true
     if port_occupied; then
@@ -511,17 +849,43 @@ case "$CMD" in
     # setsid/python os.setsid make this pid the new process group leader;
     # sampling immediately can race and capture the caller's pgid instead.
     # On Windows, claude_smart_kill_tree translates the MSYS pid to WINPID.
-    claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
-      "$LOG_FILE" "$LOG_MAX_BYTES" -- \
-      env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
-      PYTHONPATH="$backend_pythonpath" \
-      "$backend_python" -m reflexio.cli services start --only backend --no-reload --workers "$workers"
+    if reflexio_services_start_supports_skip "$backend_python"; then
+      claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
+        "$LOG_FILE" "$LOG_MAX_BYTES" -- \
+        env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
+        PYTHONPATH="$backend_pythonpath" \
+        CLAUDE_SMART_BACKEND=1 \
+        CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL" \
+        CLAUDE_SMART_VERSION="$PLUGIN_VERSION" \
+        CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON" \
+        "$backend_python" "$HERE/backend-python-runner.py" \
+        --claude-smart-backend=1 \
+        "--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL" \
+        "--claude-smart-version=$PLUGIN_VERSION" \
+        "--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON" \
+        -- services start --skip-if-running --only backend --no-reload --workers "$workers"
+    else
+      claude_smart_spawn_detached bash "$HERE/backend-log-runner.sh" \
+        "$LOG_FILE" "$LOG_MAX_BYTES" -- \
+        env PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}" \
+        PYTHONPATH="$backend_pythonpath" \
+        CLAUDE_SMART_BACKEND=1 \
+        CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL" \
+        CLAUDE_SMART_VERSION="$PLUGIN_VERSION" \
+        CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON" \
+        "$backend_python" "$HERE/backend-python-runner.py" \
+        --claude-smart-backend=1 \
+        "--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL" \
+        "--claude-smart-version=$PLUGIN_VERSION" \
+        "--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON" \
+        -- services start --only backend --no-reload --workers "$workers"
+    fi
     svc_pid=$!
     echo "$svc_pid" > "$PID_FILE"
 
     # Give uvicorn about 20s to answer /health. The first boot after a fresh
     # checkout may be slower; if it catches up later, the next hook observes it.
-    if wait_for_health backend_healthy 10 1; then
+    if wait_for_health backend_owned_by_current_vendor 10 1; then
       # The Node installer waits 45s for this script. Each curl probe is also
       # bounded so a wedged listener cannot outlive the caller's timeout budget.
       if ! wait_for_health embedding_owned_by_current_vendor 5 3; then
@@ -559,8 +923,14 @@ case "$CMD" in
       else
         echo "running on http://localhost:$PORT (bundled Reflexio at $VENDORED_REFLEXIO; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
       fi
+    elif backend_current_or_compatible; then
+      if embedding_current_or_compatible; then
+        echo "running on http://localhost:$PORT (compatible claude-smart backend)"
+      else
+        echo "running on http://localhost:$PORT (compatible claude-smart backend; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
+      fi
     elif backend_owned_by_stale_claude_smart; then
-      echo "stale claude-smart backend on http://localhost:$PORT (not using bundled Reflexio at $VENDORED_REFLEXIO)"
+      echo "stale claude-smart backend on http://localhost:$PORT (older than plugin $PLUGIN_VERSION)"
     elif backend_healthy; then
       echo "foreign or ambiguous backend on http://localhost:$PORT (not managed by claude-smart)"
     else

--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -3,16 +3,30 @@
 
 const { spawn, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
-const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
 
 const HOME = os.homedir();
 const STATE_DIR = path.join(HOME, ".claude-smart");
 const REFLEXIO_DIR = path.join(HOME, ".reflexio");
-const DEFAULT_BACKEND_PORT = 8071;
-const DASHBOARD_PORT = 3001;
+const SERVICE_SCRIPT_TIMEOUT_MS = parsePositiveInteger(
+  process.env.CLAUDE_SMART_SERVICE_SCRIPT_TIMEOUT_MS,
+  45_000,
+);
+const DEFAULT_BACKEND_PORT = parsePort(process.env.BACKEND_PORT, 8071);
+const DEFAULT_EMBEDDING_PORT = parsePort(process.env.EMBEDDING_PORT, 8072);
+const DASHBOARD_PORT = parsePort(process.env.DASHBOARD_PORT, parsePort(process.env.PORT, 3001));
 const LOG_MAX_BYTES = 10000000;
+
+function parsePort(value, fallback) {
+  const port = Number(value);
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : fallback;
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 function emitOk() {
   process.stdout.write('{"continue":true}\n');
@@ -206,20 +220,8 @@ function uvPath() {
   return commandPath(process.platform === "win32" ? ["uv.exe", "uv"] : ["uv"]);
 }
 
-function npmPath() {
-  return commandPath(process.platform === "win32" ? ["npm.cmd", "npm.exe", "npm"] : ["npm"]);
-}
-
 function bashPath() {
   return commandPath(process.platform === "win32" ? ["bash.exe", "bash"] : ["bash"]);
-}
-
-function stateFile(name) {
-  return path.join(STATE_DIR, name);
-}
-
-function backendUrlFile() {
-  return stateFile("backend-url");
 }
 
 function unquoteEnvValue(value) {
@@ -282,44 +284,7 @@ function codexCompatPath(root) {
 
 function readBackendUrl() {
   if (process.env.REFLEXIO_URL) return process.env.REFLEXIO_URL;
-  try {
-    const value = fs.readFileSync(backendUrlFile(), "utf8").trim();
-    if (value) return value;
-  } catch {
-    // Fall through to default.
-  }
   return `http://localhost:${DEFAULT_BACKEND_PORT}/`;
-}
-
-function healthOk(port, pathname, markerHeader) {
-  return new Promise((resolve) => {
-    const req = http.request(
-      {
-        host: "127.0.0.1",
-        port,
-        path: pathname,
-        method: "GET",
-        timeout: 1200,
-      },
-      (res) => {
-        const ok = res.statusCode && res.statusCode >= 200 && res.statusCode < 400;
-        const markerOk = markerHeader ? Boolean(res.headers[markerHeader]) : true;
-        res.resume();
-        resolve(Boolean(ok && markerOk));
-      },
-    );
-    req.on("timeout", () => req.destroy());
-    req.on("error", () => resolve(false));
-    req.end();
-  });
-}
-
-async function waitForHealth(port, pathname, markerHeader, attempts) {
-  for (let i = 0; i < attempts; i += 1) {
-    if (await healthOk(port, pathname, markerHeader)) return true;
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-  return false;
 }
 
 function detached(command, args, options = {}) {
@@ -351,28 +316,52 @@ function startInstallerDetached(root, reason) {
   return true;
 }
 
-function readPid(file) {
-  try {
-    const value = fs.readFileSync(file, "utf8").trim();
-    return value ? Number(value) : null;
-  } catch {
-    return null;
+function runServiceScript(root, scriptName, action, logName) {
+  trimLog(path.join(STATE_DIR, logName));
+  const bash = bashPath();
+  const script = path.join(root, "scripts", scriptName);
+  if (!bash || !fs.existsSync(script)) {
+    appendLog(
+      logName,
+      `[claude-smart] codex hook: cannot run ${scriptName}; bash or script missing`,
+    );
+    emitOk();
+    return 0;
   }
-}
-
-function pidAlive(pid) {
-  if (!pid || Number.isNaN(pid)) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
+  const result = spawnSync(bash, [script, action], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PLUGIN_ROOT: root,
+      CLAUDE_PLUGIN_ROOT: root,
+      CLAUDE_SMART_HOST: "codex",
+      CLAUDE_SMART_CLI_PATH: process.env.CLAUDE_SMART_CLI_PATH || codexCompatPath(root),
+      BACKEND_PORT: String(DEFAULT_BACKEND_PORT),
+      EMBEDDING_PORT: String(DEFAULT_EMBEDDING_PORT),
+      DASHBOARD_PORT: String(DASHBOARD_PORT),
+      PORT: String(DASHBOARD_PORT),
+      REFLEXIO_URL: readBackendUrl(),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: SERVICE_SCRIPT_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  const stderr = String(result.stderr || "").trim();
+  if (stderr) appendLog(logName, stderr);
+  if (result.error) {
+    appendLog(
+      logName,
+      `[claude-smart] codex hook: ${scriptName} ${action} failed: ${result.error.message}`,
+    );
   }
-}
-
-function writePid(file, pid) {
-  ensureDir(path.dirname(file));
-  fs.writeFileSync(file, `${pid}\n`);
+  if (result.signal) {
+    appendLog(
+      logName,
+      `[claude-smart] codex hook: ${scriptName} ${action} terminated by ${result.signal}`,
+    );
+  }
+  emitNormalizedHookOutput(result.stdout);
+  return typeof result.status === "number" ? result.status : 0;
 }
 
 function ensurePluginRoot(root) {
@@ -403,89 +392,11 @@ function ensurePluginRoot(root) {
 }
 
 async function startBackend(root) {
-  trimLog(path.join(STATE_DIR, "backend.log"));
-  const bash = bashPath();
-  const script = path.join(root, "scripts", "backend-service.sh");
-  if (!bash || !fs.existsSync(script)) {
-    appendLog("backend.log", "[claude-smart] backend: backend-service.sh unavailable; skipping local backend start");
-    emitOk();
-    return;
-  }
-  const result = spawnSync(
-    bash,
-    [script, "start"],
-    {
-      cwd: root,
-      env: {
-        ...process.env,
-        CLAUDE_SMART_HOST: "codex",
-        CLAUDE_SMART_CLI_PATH: process.env.CLAUDE_SMART_CLI_PATH || codexCompatPath(root),
-      },
-      text: true,
-      encoding: "utf8",
-      input: "",
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 45000,
-      windowsHide: true,
-    },
-  );
-  if (result.error) {
-    appendLog("backend.log", `[claude-smart] backend-service.sh failed to run: ${result.error.message}`);
-  }
-  if (result.stderr) {
-    appendLog("backend.log", `[claude-smart] backend-service.sh stderr: ${String(result.stderr).slice(0, 1000)}`);
-  }
-  emitNormalizedHookOutput(result.stdout);
+  runServiceScript(root, "backend-service.sh", "start", "backend.log");
 }
 
 async function startDashboard(root) {
-  if (process.env.CLAUDE_SMART_DASHBOARD_AUTOSTART === "0") {
-    emitOk();
-    return;
-  }
-  const dashboard = path.join(root, "dashboard");
-  if (!fs.existsSync(dashboard)) {
-    emitOk();
-    return;
-  }
-  const pidFile = path.join(STATE_DIR, "dashboard.pid");
-  if (
-    pidAlive(readPid(pidFile)) &&
-    await healthOk(DASHBOARD_PORT, "/api/health", "x-claude-smart-dashboard")
-  ) {
-    emitOk();
-    return;
-  }
-  const npm = npmPath();
-  if (!npm) {
-    startInstallerDetached(root, "dashboard: npm not on PATH");
-  }
-  const readyNpm = npmPath();
-  if (!readyNpm) {
-    appendLog("dashboard.log", "[claude-smart] dashboard: npm not on PATH; installer recovery scheduled; skipping");
-    emitOk();
-    return;
-  }
-  if (!fs.existsSync(path.join(dashboard, ".next"))) {
-    const buildPidFile = path.join(STATE_DIR, "dashboard-build.pid");
-    if (!pidAlive(readPid(buildPidFile))) {
-      const pid = detached(readyNpm, ["run", "build"], { cwd: dashboard });
-      writePid(buildPidFile, pid);
-      appendLog("dashboard.log", "[claude-smart] dashboard: .next missing; started background build");
-    }
-    emitOk();
-    return;
-  }
-  const env = {
-    ...process.env,
-    PORT: String(DASHBOARD_PORT),
-    REFLEXIO_URL: readBackendUrl(),
-    CLAUDE_SMART_DASHBOARD_WORKSPACE: process.cwd(),
-  };
-  const pid = detached(readyNpm, ["run", "start"], { cwd: dashboard, env });
-  writePid(pidFile, pid);
-  await waitForHealth(DASHBOARD_PORT, "/api/health", "x-claude-smart-dashboard", 5);
-  emitOk();
+  runServiceScript(root, "dashboard-service.sh", "start", "dashboard.log");
 }
 
 function runHook(root, event) {

--- a/plugin/scripts/dashboard-open.sh
+++ b/plugin/scripts/dashboard-open.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start backend + dashboard (idempotent), wait briefly for dashboard to come
-# up, print statuses, then open http://localhost:3001 in the default browser.
+# up, print statuses, then open the dashboard in the default browser.
 #
 # Exists so the /claude-smart:dashboard slash command can invoke a single
 # plain `bash <script>` with no inline $(...) or ${...:-...} expansion in
@@ -18,6 +18,8 @@ STATE_DIR="$HOME/.claude-smart"
 BACKEND_LOG="$STATE_DIR/backend.log"
 DASHBOARD_LOG="$STATE_DIR/dashboard.log"
 DASHBOARD_UNAVAILABLE="$(claude_smart_dashboard_unavailable_marker)"
+BACKEND_PORT="${BACKEND_PORT:-8071}"
+DASHBOARD_PORT="${DASHBOARD_PORT:-${PORT:-3001}}"
 
 # Capture start-command output so we can surface fatal errors (e.g. uv/npm
 # missing, port collisions, .next not built) rather than silently swallow
@@ -64,7 +66,7 @@ failed=0
 if [ "$backend_status" = "not running" ]; then
     failed=1
     echo ""
-    echo "ERROR: backend failed to start on http://localhost:8071"
+    echo "ERROR: backend failed to start on http://localhost:$BACKEND_PORT"
     [ -n "$backend_start_out" ] && echo "$backend_start_out"
     show_log_tail "backend" "$BACKEND_LOG"
 fi
@@ -75,7 +77,7 @@ if [ "$dashboard_status" = "not running" ]; then
     if claude_smart_pid_alive_file "$BUILD_PID_FILE"; then
         echo "dashboard: still building (first-run cost, ~1-2 min). Re-run /claude-smart:dashboard in a minute."
     else
-        echo "ERROR: dashboard failed to start on http://localhost:3001"
+        echo "ERROR: dashboard failed to start on http://localhost:$DASHBOARD_PORT"
         [ -n "$dashboard_start_out" ] && echo "$dashboard_start_out"
         if [ -f "$DASHBOARD_UNAVAILABLE" ]; then
             echo ""
@@ -92,7 +94,7 @@ if [ "$failed" = "1" ]; then
     exit 1
 fi
 
-URL="http://localhost:3001"
+URL="http://localhost:$DASHBOARD_PORT"
 PY_BIN=$(claude_smart_resolve_python || true)
 if [ -n "$PY_BIN" ] && "$PY_BIN" -m webbrowser "$URL"; then
     echo "Opened $URL"

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -216,10 +216,6 @@ case "$CMD" in
       claude_smart_clear_dashboard_unavailable
       emit_ok; exit 0
     fi
-    if marker_responds; then
-      claude_smart_clear_dashboard_unavailable
-      emit_ok; exit 0
-    fi
     if ! kill -0 "$dash_pid" 2>/dev/null; then
       sleep 2
       if port_occupied; then

--- a/plugin/scripts/dashboard-service.sh
+++ b/plugin/scripts/dashboard-service.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Auto-start the claude-smart Next.js dashboard (port 3001) if it's not
-# already running. Mirrors how claude-mem boots its worker on SessionStart:
+# Auto-start the claude-smart Next.js dashboard if it's not already running.
+# Mirrors how claude-mem boots its worker on SessionStart:
 # detached, returns immediately so the hook doesn't block the session.
 #
 # Subcommands:
-#   start         probe the port; spawn `npm run start` if our dashboard
-#                 isn't already answering. Never builds in foreground — if
+#   start         probe the port; spawn local `next start` if no claude-smart
+#                 dashboard is already answering. Never builds in foreground — if
 #                 .next is missing, logs and bails (Setup is responsible for
 #                 the build; rerun it or restart Claude Code to retry).
 #   stop          kill the recorded process group, and (if our dashboard
@@ -28,7 +28,10 @@ fi
 claude_smart_prepend_node_bins
 claude_smart_source_reflexio_env
 
-PORT=3001
+BACKEND_PORT="${BACKEND_PORT:-8071}"
+PORT="${DASHBOARD_PORT:-${PORT:-3001}}"
+export BACKEND_PORT
+claude_smart_derive_reflexio_url_from_backend_port
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "dashboard-service.sh" "$@"
@@ -48,116 +51,46 @@ kill_group() {
   claude_smart_kill_tree "$1"
 }
 
+dashboard_pid_command_matches() {
+  pid="$1"
+  cmdline="$(claude_smart_pid_command "$pid" | tr '\n' ' ' || true)"
+  [ -n "$cmdline" ] || return 1
+  case "$cmdline" in
+    *"$DASHBOARD_DIR"*|*next-server*|*next*start*|*node*next*|*claude-smart*dashboard*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+kill_recorded_dashboard() {
+  if [ -f "$PID_FILE" ]; then
+    pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && dashboard_pid_command_matches "$pid"; then
+      kill_group "$pid"
+    fi
+    rm -f "$PID_FILE"
+  fi
+}
+
 # True if the marker header served by app/api/health is present on the
 # port. Requires curl — absence is reported as false. This deliberately
 # accepts any claude-smart dashboard, including stale cache versions, so
 # stop/uninstall can safely reap them without touching foreign listeners.
 marker_responds() {
   command -v curl >/dev/null 2>&1 || return 1
-  curl -sfI "http://127.0.0.1:$PORT/api/health" 2>/dev/null \
+  curl -sfI --connect-timeout 1 --max-time 2 "http://127.0.0.1:$PORT/api/health" 2>/dev/null \
     | grep -qi '^x-claude-smart-dashboard:'
 }
 
-dashboard_health_headers() {
-  command -v curl >/dev/null 2>&1 || return 1
-  curl -sfI --connect-timeout 2 --max-time 5 "http://127.0.0.1:$PORT/api/health" 2>/dev/null
-}
-
-header_value_from() {
-  header_name="$1"
-  awk -v wanted="$header_name" '
-    BEGIN { wanted = tolower(wanted) ":" }
-    {
-      line = $0
-      sub(/\r$/, "", line)
-      lower = tolower(line)
-      if (index(lower, wanted) == 1) {
-        sub(/^[^:]*:[[:space:]]*/, "", line)
-        print line
-        exit
-      }
-    }
-  '
-}
-
-canonical_dir() {
-  dir="$1"
-  (cd "$dir" 2>/dev/null && pwd -P) || printf '%s\n' "$dir"
-}
-
-normalize_identity_path() {
-  path="$1"
-  if claude_smart_is_windows; then
-    if command -v cygpath >/dev/null 2>&1; then
-      path="$(cygpath -u "$path" 2>/dev/null || printf '%s\n' "$path")"
-    else
-      path="$(
-        printf '%s\n' "$path" | awk '{
-          gsub(/\\/, "/")
-          if ($0 ~ /^[A-Za-z]:/) {
-            drive = tolower(substr($0, 1, 1))
-            sub(/^[A-Za-z]:/, "/" drive)
-          }
-          print
-        }'
-      )"
-    fi
-  fi
-  while [ "${path%/}" != "$path" ] && [ "$path" != "/" ]; do
-    path="${path%/}"
-  done
-  printf '%s\n' "$path"
-}
-
-# True only if *this plugin root's* dashboard is on the port. The generic
-# x-claude-smart-dashboard marker is intentionally not enough: after an
-# install/update, an older cache can keep serving port 3001 until restarted.
-dashboard_matches_current_root() {
-  expected_root="$(normalize_identity_path "$(canonical_dir "$PLUGIN_ROOT")")"
-  headers="$(dashboard_health_headers)" || return 1
-  printf '%s\n' "$headers" | grep -qi '^x-claude-smart-dashboard:' || return 1
-  actual_root="$(printf '%s\n' "$headers" | header_value_from "x-claude-smart-plugin-root")"
-  [ -n "$actual_root" ] || return 1
-  actual_root="$(normalize_identity_path "$actual_root")"
-  [ "$actual_root" = "$expected_root" ]
-}
-
 # Kill a claude-smart dashboard listener currently holding the port. Gated by
-# marker_responds so a foreign app on 3001 is never killed.
+# marker_responds so a foreign listener on the dashboard port is never killed.
 stop_dashboard_listener() {
   marker_responds || return 0
-  command -v lsof >/dev/null 2>&1 || return 0
-  port_pid=$(lsof -t -i ":$PORT" -sTCP:LISTEN 2>/dev/null | head -n1)
-  [ -n "$port_pid" ] || return 0
-  kill -TERM "$port_pid" 2>/dev/null || true
-  for _ in 1 2 3 4 5; do
-    kill -0 "$port_pid" 2>/dev/null || return 0
-    sleep 0.2
-  done
-  kill -KILL "$port_pid" 2>/dev/null || true
-}
-
-# True only if *our* dashboard is on the port. Uses plugin-root identity so a
-# stale claude-smart listener doesn't cause us to silently skip starting.
-is_our_dashboard_running() {
-  if [ -f "$PID_FILE" ]; then
-    pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      # PID alive — still verify the port responds with our marker so we
-      # don't claim "running" when the server crashed but the group leader
-      # lingered.
-      if command -v curl >/dev/null 2>&1; then
-        dashboard_matches_current_root && return 0
-      else
-        # No curl — fall back to PID liveness alone.
-        return 0
-      fi
-    fi
-  fi
-  # No PID or dead PID — probe the port for our marker (recovers after a
-  # stale PID file from a crash).
-  dashboard_matches_current_root && return 0
-  return 1
+  kill_recorded_dashboard
+  claude_smart_reap_port_listeners_matching "$PORT" \
+    '*next-server*' \
+    '*next*start*' \
+    '*node*next*' \
+    '*claude-smart*dashboard*' || true
 }
 
 # True if *something* is listening on the port, regardless of marker.
@@ -168,6 +101,46 @@ port_occupied() {
     # Use a connect-only probe as a secondary signal.
   fi
   (echo >"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null
+}
+
+resolve_next_bin() {
+  if claude_smart_is_windows; then
+    for candidate in "$DASHBOARD_DIR/node_modules/.bin/next.cmd" "$DASHBOARD_DIR/node_modules/.bin/next"; do
+      [ -f "$candidate" ] && { printf '%s\n' "$candidate"; return 0; }
+    done
+  else
+    for candidate in "$DASHBOARD_DIR/node_modules/.bin/next" "$DASHBOARD_DIR/node_modules/.bin/next.cmd"; do
+      [ -f "$candidate" ] && { printf '%s\n' "$candidate"; return 0; }
+    done
+  fi
+  return 1
+}
+
+spawn_dashboard() {
+  NEXT_BIN="$(resolve_next_bin || true)"
+  if [ -z "$NEXT_BIN" ]; then
+    reason="local Next.js binary is missing; run claude-smart install/update to restore dashboard dependencies"
+    echo "[claude-smart] dashboard: $reason" >>"$LOG_FILE"
+    claude_smart_write_dashboard_unavailable "$reason"
+    return 1
+  fi
+  cd "$DASHBOARD_DIR"
+  export CLAUDE_SMART_DASHBOARD_WORKSPACE="$WORKSPACE_CWD"
+  # Invoke Next directly so custom DASHBOARD_PORT/PORT values are honored
+  # without relying on package.json's fixed start script.
+  CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached "$NEXT_BIN" start -p "$PORT" -H 127.0.0.1 >>"$LOG_FILE" 2>&1
+  dash_pid=$!
+  echo "$dash_pid" > "$PID_FILE"
+}
+
+wait_for_dashboard_marker() {
+  attempts="$1"
+  while [ "$attempts" -gt 0 ]; do
+    marker_responds && return 0
+    attempts=$((attempts - 1))
+    sleep 1
+  done
+  marker_responds
 }
 
 case "$CMD" in
@@ -181,11 +154,19 @@ case "$CMD" in
       emit_ok; exit 0
     fi
     if [ ! -d "$DASHBOARD_DIR" ]; then emit_ok; exit 0; fi
-    if is_our_dashboard_running; then claude_smart_clear_dashboard_unavailable; emit_ok; exit 0; fi
-    if marker_responds; then
-      echo "[claude-smart] dashboard: stale claude-smart dashboard on port $PORT; restarting from $PLUGIN_ROOT" >>"$LOG_FILE"
-      stop_dashboard_listener
+    if marker_responds; then claude_smart_clear_dashboard_unavailable; emit_ok; exit 0; fi
+    if ! claude_smart_service_lock "dashboard"; then
+      for _ in 1 2 3 4 5; do
+        if marker_responds; then
+          claude_smart_clear_dashboard_unavailable
+          emit_ok; exit 0
+        fi
+        sleep 0.2
+      done
+      emit_ok; exit 0
     fi
+    trap 'claude_smart_service_unlock "dashboard"' EXIT
+    if marker_responds; then claude_smart_clear_dashboard_unavailable; emit_ok; exit 0; fi
     if port_occupied; then
       echo "[claude-smart] dashboard: port $PORT held by another process; skipping" >>"$LOG_FILE"
       emit_ok; exit 0
@@ -221,8 +202,6 @@ case "$CMD" in
       emit_ok; exit 0
     fi
 
-    cd "$DASHBOARD_DIR"
-
     # Detach so the hook returns immediately. claude_smart_spawn_detached
     # picks the strongest primitive available:
     #   - Linux: setsid (puts child in its own session/group, pid==pgid).
@@ -230,36 +209,45 @@ case "$CMD" in
     #   - Windows: nohup alone (no process groups; tree-kill via taskkill).
     # Caller-side `>>file 2>&1` redirection is honoured before the child
     # detaches, so per-OS log paths stay identical.
-    export CLAUDE_SMART_DASHBOARD_WORKSPACE="$WORKSPACE_CWD"
-    CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached "$NPM_BIN" run start >>"$LOG_FILE" 2>&1
-    dash_pid=$!
-    # Record the spawned pid, not a pgid sampled with ps. On POSIX,
-    # setsid/python os.setsid make this pid the new process group leader;
-    # sampling immediately can race and capture the caller's pgid instead.
-    # On Windows, claude_smart_kill_tree translates the MSYS pid to WINPID.
-    echo "$dash_pid" > "$PID_FILE"
-    dashboard_ready=0
-    for _ in 1 2 3 4 5; do
-      if dashboard_matches_current_root; then
-        dashboard_ready=1
-        claude_smart_clear_dashboard_unavailable
-        break
+    if ! spawn_dashboard; then
+      emit_ok; exit 0
+    fi
+    if wait_for_dashboard_marker 5; then
+      claude_smart_clear_dashboard_unavailable
+      emit_ok; exit 0
+    fi
+    if marker_responds; then
+      claude_smart_clear_dashboard_unavailable
+      emit_ok; exit 0
+    fi
+    if ! kill -0 "$dash_pid" 2>/dev/null; then
+      sleep 2
+      if port_occupied; then
+        if marker_responds; then
+          claude_smart_clear_dashboard_unavailable
+        else
+          claude_smart_write_dashboard_unavailable "dashboard process exited and port $PORT is now held by a non-claude-smart listener; see $LOG_FILE"
+        fi
+      else
+        echo "[claude-smart] dashboard: first start exited before readiness; retrying once" >>"$LOG_FILE"
+        if spawn_dashboard; then
+          if wait_for_dashboard_marker 5; then
+            claude_smart_clear_dashboard_unavailable
+          else
+            claude_smart_write_dashboard_unavailable "dashboard process spawned but did not respond on http://127.0.0.1:$PORT within 5s; see $LOG_FILE"
+          fi
+        fi
       fi
-      sleep 1
-    done
-    if [ "$dashboard_ready" != "1" ]; then
+    else
       claude_smart_write_dashboard_unavailable "dashboard process spawned but did not respond on http://127.0.0.1:$PORT within 5s; see $LOG_FILE"
     fi
     emit_ok
     ;;
   stop)
-    if [ -f "$PID_FILE" ]; then
-      kill_group "$(cat "$PID_FILE" 2>/dev/null)"
-      rm -f "$PID_FILE"
-    fi
+    kill_recorded_dashboard
     # Fallback: if a claude-smart dashboard is still responding on the port (e.g.,
     # was started outside this script, or the PGID kill missed because
-    # the process wasn't the group leader) kill whoever owns the port.
+    # the process wasn't the group leader) reap only dashboard-shaped listeners.
     # Gated on the marker header so we never touch a foreign listener.
     stop_dashboard_listener
     emit_ok
@@ -269,15 +257,12 @@ case "$CMD" in
     # interactions/playbooks between sessions. Opt in to teardown by setting
     # CLAUDE_SMART_DASHBOARD_STOP_ON_END=1 in the environment.
     if [ "${CLAUDE_SMART_DASHBOARD_STOP_ON_END:-0}" = "1" ]; then
-      if [ -f "$PID_FILE" ]; then
-        kill_group "$(cat "$PID_FILE" 2>/dev/null)"
-        rm -f "$PID_FILE"
-      fi
+      kill_recorded_dashboard
     fi
     emit_ok
     ;;
   status)
-    if is_our_dashboard_running; then echo "running on http://localhost:$PORT"; else echo "not running"; fi
+    if marker_responds; then echo "running on http://localhost:$PORT"; else echo "not running"; fi
     ;;
   *)
     emit_ok

--- a/plugin/scripts/hook_entry.sh
+++ b/plugin/scripts/hook_entry.sh
@@ -44,10 +44,13 @@ claude_smart_source_login_path
 # Explicit fallback for the astral.sh installer's default paths, in case
 # the user's login-shell rc hasn't yet been re-sourced to pick them up.
 claude_smart_prepend_astral_bins
+BACKEND_PORT="${BACKEND_PORT:-8071}"
+export BACKEND_PORT
 claude_smart_source_reflexio_env
 
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "hook_entry.sh" "$@"
+claude_smart_derive_reflexio_url_from_backend_port
 
 FAILURE_MARKER="$HOME/.claude-smart/install-failed"
 STATE_DIR="$HOME/.claude-smart"

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -20,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 
 _ENV_URL = "REFLEXIO_URL"
 _ENV_API_KEY = "REFLEXIO_API_KEY"
-_DEFAULT_URL = "http://localhost:8071/"
 # Cap every HTTP round-trip from a hook so a hung backend can't stall the
 # Claude Code / Codex session. reflexio's client default is 300s, which is
 # fine for batch workloads but unacceptable on the hook path — a single
@@ -31,6 +30,24 @@ _SEARCH_MODE_HYBRID = "hybrid"  # reflexio.models.config_schema.SearchMode.HYBRI
 _UNIFIED_ENTITY_TYPES = ("profiles", "user_playbooks", "agent_playbooks")
 _AGENT_PLAYBOOK_APPROVAL_STATUSES = ("pending", "approved")
 _REJECTED_AGENT_PLAYBOOK_STATUS = "rejected"
+_LOCAL_8071_URLS = {
+    "http://localhost:8071",
+    "http://localhost:8071/",
+    "http://127.0.0.1:8071",
+    "http://127.0.0.1:8071/",
+}
+
+
+def _default_url() -> str:
+    return f"http://localhost:{os.environ.get('BACKEND_PORT', '8071')}/"
+
+
+def _configured_url() -> str:
+    url = os.environ.get(_ENV_URL, "")
+    backend_port = os.environ.get("BACKEND_PORT", "")
+    if url in _LOCAL_8071_URLS and backend_port not in {"", "8071"}:
+        return _default_url()
+    return url or _default_url()
 
 
 @dataclass
@@ -48,7 +65,7 @@ class Adapter:
 
     def __post_init__(self) -> None:
         env_config.load_reflexio_env()
-        self.url = self.url or os.environ.get(_ENV_URL, _DEFAULT_URL)
+        self.url = self.url or _configured_url()
         self.api_key = self.api_key or os.environ.get(_ENV_API_KEY, "")
         self._client: Any | None = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ def clear_reflexio_connection_env(monkeypatch, tmp_path):
     monkeypatch.delenv("REFLEXIO_API_KEY", raising=False)
     monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_READ_ONLY", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_MANAGED_SETUP", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_CLI", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_CLI_PATH", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_OPENCODE_PATH", raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/host_learning_harness.py
+++ b/tests/host_learning_harness.py
@@ -37,7 +37,7 @@ class FakeReflexioAdapter:
         return True
 
     def search_all(
-        self, *, project_id: str, query: str, top_k: int
+        self, *, project_id: str, query: str, top_k: int, session_id: str | None = None
     ) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
         from claude_smart import runtime
 
@@ -46,6 +46,7 @@ class FakeReflexioAdapter:
                 "project_id": project_id,
                 "query": query,
                 "top_k": top_k,
+                "session_id": session_id,
                 "host": runtime.host(),
             }
         )
@@ -236,6 +237,7 @@ def run_host_learning_happy_path(
                 "project_id": project.name,
                 "query": prompt,
                 "top_k": 3,
+                "session_id": session_id,
                 "host": host,
             }
         ]

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -28,9 +28,11 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 PLUGIN_ROOT="$REPO_ROOT/plugin"
 
-BACKEND_PORT=8071
+BACKEND_PORT="${BACKEND_PORT:-8071}"
 EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"
-DASHBOARD_PORT=3001
+DASHBOARD_PORT="${DASHBOARD_PORT:-3001}"
+export BACKEND_PORT EMBEDDING_PORT DASHBOARD_PORT
+BACKEND_HEALTH_TIMEOUT_SECONDS="${BACKEND_HEALTH_TIMEOUT_SECONDS:-90}"
 
 # Sandbox HOME so real ~/.reflexio, ~/.claude-smart, ~/.claude stay
 # untouched. Created once, reused across stages within a single run.
@@ -221,9 +223,9 @@ stage_setup_hook() {
 stage_backend() {
   log "backend: starting"
   bash "$PLUGIN_ROOT/scripts/backend-service.sh" start >/dev/null
-  log "backend: polling http://127.0.0.1:$BACKEND_PORT/health (20s)"
-  if ! poll_200 "http://127.0.0.1:$BACKEND_PORT/health" 20; then
-    fail "backend /health did not return 200 within 20s"
+  log "backend: polling http://127.0.0.1:$BACKEND_PORT/health (${BACKEND_HEALTH_TIMEOUT_SECONDS}s)"
+  if ! poll_200 "http://127.0.0.1:$BACKEND_PORT/health" "$BACKEND_HEALTH_TIMEOUT_SECONDS"; then
+    fail "backend /health did not return 200 within ${BACKEND_HEALTH_TIMEOUT_SECONDS}s"
   fi
   if [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}" = "1" ]; then
     log "backend: polling http://127.0.0.1:$EMBEDDING_PORT/health (120s)"

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -162,6 +162,55 @@ def test_adapter_process_env_overrides_reflexio_env(monkeypatch, tmp_path) -> No
     }
 
 
+def test_adapter_default_url_follows_backend_port(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        reflexio_adapter.env_config, "CLAUDE_SMART_ENV_PATH", tmp_path / "missing.env"
+    )
+    monkeypatch.delenv("REFLEXIO_URL", raising=False)
+    monkeypatch.delenv("REFLEXIO_API_KEY", raising=False)
+    monkeypatch.setenv("BACKEND_PORT", "8171")
+    seen: dict[str, str] = {}
+
+    class FakeReflexioClient:
+        def __init__(self, *, url_endpoint: str, api_key: str):
+            seen["url_endpoint"] = url_endpoint
+            seen["api_key"] = api_key
+
+    monkeypatch.setitem(
+        sys.modules,
+        "reflexio",
+        SimpleNamespace(ReflexioClient=FakeReflexioClient),
+    )
+
+    assert reflexio_adapter.Adapter()._get_client() is not None
+    assert seen == {"url_endpoint": "http://localhost:8171/", "api_key": ""}
+
+
+def test_adapter_local_default_file_url_follows_backend_port(monkeypatch, tmp_path) -> None:
+    env_path = tmp_path / ".claude-smart" / ".env"
+    env_path.parent.mkdir()
+    env_path.write_text('REFLEXIO_URL="http://localhost:8071/"\n')
+    monkeypatch.setattr(reflexio_adapter.env_config, "CLAUDE_SMART_ENV_PATH", env_path)
+    monkeypatch.delenv("REFLEXIO_URL", raising=False)
+    monkeypatch.delenv("REFLEXIO_API_KEY", raising=False)
+    monkeypatch.setenv("BACKEND_PORT", "8171")
+    seen: dict[str, str] = {}
+
+    class FakeReflexioClient:
+        def __init__(self, *, url_endpoint: str, api_key: str):
+            seen["url_endpoint"] = url_endpoint
+            seen["api_key"] = api_key
+
+    monkeypatch.setitem(
+        sys.modules,
+        "reflexio",
+        SimpleNamespace(ReflexioClient=FakeReflexioClient),
+    )
+
+    assert reflexio_adapter.Adapter()._get_client() is not None
+    assert seen == {"url_endpoint": "http://localhost:8171/", "api_key": ""}
+
+
 def test_publish_returns_true_on_success() -> None:
     client = _FakeClient()
     a = _adapter_with(client)

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -55,11 +55,21 @@ def test_codex_hook_loads_managed_reflexio_env_and_skips_backend_start() -> None
     assert "function loadReflexioEnv()" in script
     assert '"REFLEXIO_API_KEY"' in script
     assert '"CLAUDE_SMART_READ_ONLY"' in script
+    assert "function runServiceScript(root, scriptName, action, logName)" in script
+    assert "function parsePort(value, fallback)" in script
+    assert "function parsePositiveInteger(value, fallback)" in script
+    assert "const SERVICE_SCRIPT_TIMEOUT_MS = parsePositiveInteger" in script
+    assert "timeout: SERVICE_SCRIPT_TIMEOUT_MS" in script
+    assert 'runServiceScript(root, "backend-service.sh", "start", "backend.log")' in script
+    assert (
+        'runServiceScript(root, "dashboard-service.sh", "start", "dashboard.log")'
+        in script
+    )
     assert "loadReflexioEnv();" in script
     # Backend start (including the remote-REFLEXIO_URL skip) is delegated to
     # backend-service.sh; codex-hook.js no longer decides locally.
     assert "function reflexioUrlIsRemote()" not in script
-    assert '[script, "start"]' in script
+    assert "[script, action]" in script
     assert "backend-service.sh" in script
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
     assert "remote REFLEXIO_URL configured; skipping local backend start" in backend

--- a/tests/test_dashboard_managed_reflexio.py
+++ b/tests/test_dashboard_managed_reflexio.py
@@ -16,6 +16,8 @@ def test_dashboard_config_knows_reflexio_api_key() -> None:
     ).read_text()
 
     assert '"REFLEXIO_API_KEY"' in config
+    assert "function defaultReflexioUrl()" in config
+    assert 'process.env.BACKEND_PORT || "8071"' in config
     assert "REFLEXIO_API_KEY: string;" in types
     assert "REFLEXIO_API_KEY_SET?: boolean;" in types
     assert "<Label>REFLEXIO_API_KEY</Label>" in page
@@ -63,6 +65,8 @@ def test_dashboard_proxy_forwards_bearer_auth_without_client_auth() -> None:
     ).read_text()
 
     assert 'headers.delete("authorization")' in route
+    assert "function defaultUrl()" in route
+    assert 'process.env.BACKEND_PORT || "8071"' in route
     assert 'headers.set("user-agent", "claude-smart")' in route
     assert 'headers.set("authorization", `Bearer ${apiKey}`)' in route
     assert "readConfig" in route

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -31,6 +31,7 @@ CLI_SH = REPO_ROOT / "plugin" / "scripts" / "cli.sh"
 CODEX_COMPAT = REPO_ROOT / "plugin" / "scripts" / "codex-claude-compat"
 CODEX_HOOK = REPO_ROOT / "plugin" / "scripts" / "codex-hook.js"
 BACKEND_LOG_RUNNER = REPO_ROOT / "plugin" / "scripts" / "backend-log-runner.sh"
+BACKEND_PYTHON_RUNNER = REPO_ROOT / "plugin" / "scripts" / "backend-python-runner.py"
 NODE_INSTALLER = REPO_ROOT / "bin" / "claude-smart.js"
 HEALTH_ROUTE = (
     REPO_ROOT / "plugin" / "dashboard" / "app" / "api" / "health" / "route.ts"
@@ -183,9 +184,13 @@ def _seed_backend_service_test_plugin(tmp_path: Path, *, port: int) -> Path:
     vendor_package.mkdir(parents=True, exist_ok=True)
     (vendor_package / "__init__.py").write_text('__version__ = "0.0.0-test"\n')
     backend_service = plugin_root / "scripts" / "backend-service.sh"
-    backend_service.write_text(
-        backend_service.read_text().replace("\nPORT=8071\n", f"\nPORT={port}\n")
+    backend_text = backend_service.read_text()
+    backend_text = backend_text.replace("\nPORT=8071\n", f"\nPORT={port}\n")
+    backend_text = backend_text.replace(
+        '\nPORT="${BACKEND_PORT:-8071}"\n',
+        f'\nPORT="${{BACKEND_PORT:-{port}}}"\n',
     )
+    backend_service.write_text(backend_text)
     return plugin_root
 
 
@@ -414,7 +419,8 @@ def test_backend_service_uses_prepared_venv_reflexio_cli() -> None:
     service = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
     assert 'backend_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"' in service
-    assert '"$backend_python" -m reflexio.cli services start' in service
+    assert '"$backend_python" "$HERE/backend-python-runner.py"' in service
+    assert "-- services start" in service
     assert 'uv run --project "$PLUGIN_ROOT" --no-sync --quiet' not in service
     assert "ensure_vendored_reflexio_active" in service
     assert 'plugin_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"' in service
@@ -491,7 +497,8 @@ def test_detached_spawns_with_log_redirection_preserve_output_on_windows() -> No
     ) in dashboard
     assert (
         "CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached "
-        '"$NPM_BIN" run start >>"$LOG_FILE" 2>&1' in dashboard
+        '"$NEXT_BIN" start -p "$PORT" -H 127.0.0.1 >>"$LOG_FILE" 2>&1'
+        in dashboard
     )
 
 
@@ -1260,21 +1267,18 @@ def test_dashboard_health_exposes_plugin_identity_for_stale_process_detection() 
     assert "x-claude-smart-version" in route
 
 
-def test_dashboard_service_restarts_stale_claude_smart_dashboard() -> None:
+def test_dashboard_service_accepts_shared_marker_dashboard_without_root_reap() -> None:
     dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
 
-    assert "dashboard_matches_current_root()" in dashboard
-    assert "x-claude-smart-plugin-root" in dashboard
-    assert "curl -sfI --connect-timeout 2 --max-time 5" in dashboard
+    assert "dashboard_matches_current_root()" not in dashboard
+    assert "curl -sfI --connect-timeout 1 --max-time 2" in dashboard
     assert 'curl -sf --max-time 2 -o /dev/null "http://127.0.0.1:$PORT"' in dashboard
-    assert "normalize_identity_path()" in dashboard
-    assert "cygpath -u" in dashboard
-    assert 'expected_root="$(normalize_identity_path ' in dashboard
-    assert 'actual_root="$(normalize_identity_path "$actual_root")"' in dashboard
-    assert '[ "$actual_root" = "$expected_root" ]' in dashboard
-    assert "stale claude-smart dashboard on port $PORT; restarting" in dashboard
+    assert "normalize_identity_path()" not in dashboard
+    assert "cygpath -u" not in dashboard
+    assert 'if marker_responds; then claude_smart_clear_dashboard_unavailable; emit_ok; exit 0; fi' in dashboard
+    assert "stale claude-smart dashboard on port $PORT; restarting" not in dashboard
     assert "stop_dashboard_listener" in dashboard
-    assert "foreign app on 3001 is never killed" in dashboard
+    assert "foreign listener" in dashboard
 
 
 def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
@@ -1309,14 +1313,80 @@ def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
     )
     assert 'PYTHONPATH="$backend_pythonpath"' in backend
     assert "pid_uses_current_vendor_root()" in backend
+    assert "plugin_version_from_root()" in backend
+    assert "backend_pid_current_or_compatible()" in backend
+    assert "backend_pid_strictly_older_than_plugin()" in backend
+    assert "classify_backend_listener()" in backend
     assert "backend_owned_by_current_vendor()" in backend
     assert "backend_owned_by_stale_claude_smart()" in backend
+    assert 'PID_FILE="$STATE_DIR/backend.$backend_pid_key.pid"' in backend
+    assert 'SHARED_PID_FILE="$STATE_DIR/backend.pid"' in backend
+    assert "backend-python-runner.py" in backend
+    assert "--claude-smart-backend=1" in backend
+    assert '"--claude-smart-plugin-root=$PLUGIN_ROOT_CANONICAL"' in backend
+    assert '"--claude-smart-version=$PLUGIN_VERSION"' in backend
+    assert '"--claude-smart-reflexio-vendor-root=$VENDORED_REFLEXIO_FOR_PYTHON"' in backend
+    assert "CLAUDE_SMART_BACKEND=1" in backend
+    assert 'CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"' in backend
+    assert 'CLAUDE_SMART_VERSION="$PLUGIN_VERSION"' in backend
     assert "stop_stale_backend_listener_if_owned" in backend
-    assert "looks_like_claude_smart_backend_pid \"$pid\" && ! pid_uses_current_vendor_root \"$pid\"" in backend
+    assert "backend_pid_strictly_older_than_plugin" in backend
     assert "if stop_stale_backend_listener_if_owned; then" in backend
     assert "if port_occupied; then" in backend
-    assert "not using bundled Reflexio" in backend
+    assert "older than plugin $PLUGIN_VERSION" in backend
     assert "foreign or ambiguous backend on http://localhost:$PORT" in backend
+
+
+def test_backend_python_runner_exposes_metadata_and_forwards_reflexio_args(
+    tmp_path: Path,
+) -> None:
+    package_dir = tmp_path / "reflexio"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("")
+    (package_dir / "cli.py").write_text(
+        "import json\n"
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "Path(os.environ['OUT']).write_text(json.dumps({\n"
+        "    'argv': sys.argv,\n"
+        "    'backend': os.environ.get('CLAUDE_SMART_BACKEND'),\n"
+        "    'version': os.environ.get('CLAUDE_SMART_VERSION'),\n"
+        "    'vendor': os.environ.get('CLAUDE_SMART_REFLEXIO_VENDOR_ROOT'),\n"
+        "}))\n"
+    )
+    output = tmp_path / "out.json"
+    env = os.environ.copy()
+    env.update({"OUT": str(output), "PYTHONPATH": str(tmp_path)})
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(BACKEND_PYTHON_RUNNER),
+            "--claude-smart-backend=1",
+            "--claude-smart-version=0.2.49",
+            "--claude-smart-reflexio-vendor-root=/tmp/vendor/reflexio",
+            "--",
+            "services",
+            "start",
+            "--only",
+            "backend",
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output.read_text())
+    assert payload == {
+        "argv": ["reflexio.cli", "services", "start", "--only", "backend"],
+        "backend": "1",
+        "version": "0.2.49",
+        "vendor": "/tmp/vendor/reflexio",
+    }
 
 
 def test_installers_start_backend_and_refresh_dashboard_services() -> None:
@@ -2138,22 +2208,22 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     assert "embedding_matches_current_root()" not in backend
     assert 'health_headers "$EMBEDDING_PORT" "/health"' not in backend
     assert "embedding_owned_by_current_vendor()" in backend
+    assert "embedding_current_or_compatible()" in backend
     assert "wait_for_health()" in backend
-    assert "wait_for_health backend_healthy 10 1" in backend
+    assert "wait_for_health backend_owned_by_current_vendor 10 1" in backend
     assert "wait_for_health embedding_owned_by_current_vendor 5 3" in backend
     assert "spawn_backend()" not in backend
     assert "Embedding service did not become healthy" in backend
     assert "semantic retrieval remains unavailable" in backend
     assert "clear_minilm_cache" not in backend
     assert "clearing MiniLM cache" not in backend
-    assert "restarting local services" not in backend
     assert "backend_healthy && embedding_healthy" not in backend
     start_match = re.search(r"(?ms)^  start\)\n(?P<body>.*?)(?=^  stop\)\n)", backend)
     assert start_match, "backend-service.sh start case not found"
     start_case = start_match.group("body")
     assert "full_stop" not in start_case
     assert "backend_started" not in start_case
-    assert "if wait_for_health backend_healthy 10 1; then" in start_case
+    assert "if wait_for_health backend_owned_by_current_vendor 10 1; then" in start_case
     assert "if ! wait_for_health embedding_owned_by_current_vendor 5 3; then" in start_case
     assert (
         "running on http://localhost:$PORT "
@@ -2178,8 +2248,8 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
         bin_dir / "lsof",
         "#!/bin/sh\n"
         'case " $* " in\n'
-        '  *" -t -i :8071 -sTCP:LISTEN "*) printf "12345\\n"; exit 0 ;;\n'
-        '  *" -t -i :8072 -sTCP:LISTEN "*) exit 0 ;;\n'
+        '  *" -t -i :8071 -sTCP:LISTEN "*|*" -tiTCP:8071 -sTCP:LISTEN "*) printf "12345\\n"; exit 0 ;;\n'
+        '  *" -t -i :8072 -sTCP:LISTEN "*|*" -tiTCP:8072 -sTCP:LISTEN "*) exit 0 ;;\n'
         '  *" -a -p 12345 -d cwd -Fn "*) printf "n%s\\n" "$PWD"; exit 0 ;;\n'
         "esac\n"
         "exit 0\n",
@@ -2187,7 +2257,7 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     _write_executable(
         bin_dir / "ps",
         "#!/bin/sh\n"
-        'printf "python -m reflexio.cli CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=%s PYTHONPATH=%s\\n" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT"\n',
+        'printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=0.2.49 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$PWD" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT"\n',
     )
     _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
     env = _isolated_env(tmp_path)
@@ -2243,17 +2313,28 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
         pytest.skip("process termination fixture is POSIX-only")
     port = 19000 + (abs(hash(tmp_path.name)) % 1000)
     plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
-    old_vendor = tmp_path / "old-plugin" / "vendor" / "reflexio"
+    old_root = tmp_path / "old-plugin"
+    old_vendor = old_root / "vendor" / "reflexio"
+    (old_root / ".codex-plugin").mkdir(parents=True)
+    old_vendor.mkdir(parents=True)
+    (old_root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "0.0.1"})
+    )
     (tmp_path / "stale-listener").write_text("1\n")
     stale = subprocess.Popen(["/bin/sleep", "60"])
+    stale_runner = subprocess.Popen(["/bin/sleep", "60"])
+    current = subprocess.Popen(["/bin/sleep", "60"])
+    current_runner = subprocess.Popen(["/bin/sleep", "60"])
     try:
         _write_fake_plugin_python(
             plugin_root,
             "#!/bin/sh\n"
             'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
-            'if [ "$1" = "-m" ]; then\n'
+            'case "$1" in\n'
+            "  *backend-python-runner.py)\n"
             '  printf "spawned backend\\n" >> "$HOME/python.log"\n'
-            "fi\n"
+            "  ;;\n"
+            "esac\n"
             "exit 0\n",
         )
         bin_dir = tmp_path / "bin"
@@ -2277,11 +2358,12 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
             bin_dir / "lsof",
             "#!/bin/sh\n"
             'case " $* " in\n'
-            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*)\n'
-            '    if [ -f "$HOME/stale-listener" ]; then printf "%s\\n" "$STALE_PID"; fi\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*)\n'
+            '    if [ -f "$HOME/stale-listener" ]; then printf "%s\\n" "$STALE_PID"; else printf "%s\\n" "$CURRENT_PID"; fi\n'
             "    exit 0\n"
             "    ;;\n"
             '  *" -a -p $STALE_PID -d cwd -Fn "*) printf "n%s\\n" "$OLD_VENDOR"; exit 0 ;;\n'
+            '  *" -a -p $CURRENT_PID -d cwd -Fn "*) printf "n%s\\n" "$PWD"; exit 0 ;;\n'
             '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*)\n'
             '    if [ -f "$HOME/stale-listener" ]; then printf "python %s\\n" "$STALE_PID"; fi\n'
             "    exit 0\n"
@@ -2292,8 +2374,22 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
         _write_executable(
             bin_dir / "ps",
             "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -o ppid= "*)\n'
+            '    if [ "${2:-}" = "$STALE_PID" ]; then printf "%s\\n" "$STALE_RUNNER_PID";\n'
+            '    elif [ "${2:-}" = "$CURRENT_PID" ]; then printf "%s\\n" "$CURRENT_RUNNER_PID";\n'
+            '    else printf "0\\n"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
             'if [ "${3:-}" = "$STALE_PID" ]; then\n'
-            '  printf "python -m reflexio.cli CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=%s PYTHONPATH=%s\\n" "$OLD_VENDOR" "$OLD_VENDOR"\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$STALE_RUNNER_PID" ]; then\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=0.0.1 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$OLD_ROOT" "$OLD_VENDOR"\n'
+            'elif [ "${3:-}" = "$CURRENT_PID" ]; then\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$CURRENT_RUNNER_PID" ]; then\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=0.2.49 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$PWD" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT"\n'
             "fi\n",
         )
         _write_executable(
@@ -2312,9 +2408,13 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
                 "CLAUDE_SMART_HOST": "codex",
                 "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
                 "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "CURRENT_PID": str(current.pid),
+                "CURRENT_RUNNER_PID": str(current_runner.pid),
+                "OLD_ROOT": str(old_root),
                 "OLD_VENDOR": str(old_vendor),
                 "REFLEXIO_URL": "",
                 "STALE_PID": str(stale.pid),
+                "STALE_RUNNER_PID": str(stale_runner.pid),
             }
         )
 
@@ -2331,13 +2431,276 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
         assert result.stdout.strip() == '{"continue":true}'
         stale.wait(timeout=5)
         assert "spawned backend" in (tmp_path / "python.log").read_text()
-        assert "not using bundled Reflexio" in (
+        assert "older than plugin" in (
             tmp_path / ".claude-smart" / "backend.log"
         ).read_text()
     finally:
         if stale.poll() is None:
             stale.terminate()
             stale.wait(timeout=5)
+        if stale_runner.poll() is None:
+            stale_runner.terminate()
+            stale_runner.wait(timeout=5)
+        if current.poll() is None:
+            current.terminate()
+            current.wait(timeout=5)
+        if current_runner.poll() is None:
+            current_runner.terminate()
+            current_runner.wait(timeout=5)
+
+
+def test_backend_start_accepts_newer_other_root_without_downgrade(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 22000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    newer_root = tmp_path / "newer-plugin"
+    newer_vendor = newer_root / "vendor" / "reflexio"
+    (newer_root / ".codex-plugin").mkdir(parents=True)
+    newer_vendor.mkdir(parents=True)
+    (newer_root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "9.9.9"})
+    )
+    peer = subprocess.Popen(["/bin/sleep", "60"])
+    peer_runner = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            'if [ "$1" = "-" ]; then exit 0; fi\n'
+            'case "$1" in *backend-python-runner.py) printf "spawned backend\\n" >> "$HOME/python.log" ;; esac\n'
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "curl",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT/health"*) exit 0 ;;\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT"*) exit 0 ;;\n'
+            "esac\n"
+            "exit 22\n",
+        )
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$PEER_PID"; exit 0 ;;\n'
+            '  *" -a -p $PEER_PID -d cwd -Fn "*) printf "n%s\\n" "$NEWER_ROOT"; exit 0 ;;\n'
+            '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*) printf "python (pid %s)\\n" "$PEER_PID"; exit 0 ;;\n'
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -o ppid= "*)\n'
+            '    if [ "${2:-}" = "$PEER_PID" ]; then printf "%s\\n" "$PEER_RUNNER_PID"; else printf "0\\n"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            'if [ "${3:-}" = "$PEER_PID" ]; then\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$PEER_RUNNER_PID" ]; then\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=9.9.9 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$NEWER_ROOT" "$NEWER_VENDOR"\n'
+            "fi\n",
+        )
+        _write_executable(
+            bin_dir / "uv",
+            '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
+        )
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "NEWER_ROOT": str(newer_root),
+                "NEWER_VENDOR": str(newer_vendor),
+                "PEER_PID": str(peer.pid),
+                "PEER_RUNNER_PID": str(peer_runner.pid),
+                "REFLEXIO_URL": "",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        assert peer.poll() is None
+        assert not (tmp_path / "python.log").exists()
+    finally:
+        if peer.poll() is None:
+            peer.terminate()
+            peer.wait(timeout=5)
+        if peer_runner.poll() is None:
+            peer_runner.terminate()
+            peer_runner.wait(timeout=5)
+
+
+def test_backend_stop_does_not_kill_newer_peer_from_shared_pid(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 23000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    newer_root = tmp_path / "newer-plugin"
+    newer_vendor = newer_root / "vendor" / "reflexio"
+    (newer_root / ".codex-plugin").mkdir(parents=True)
+    newer_vendor.mkdir(parents=True)
+    (newer_root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "9.9.9"})
+    )
+    peer = subprocess.Popen(["/bin/sleep", "60"])
+    peer_runner = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        state_dir = tmp_path / ".claude-smart"
+        state_dir.mkdir()
+        (state_dir / "backend.pid").write_text(f"{peer_runner.pid}\n")
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "curl",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT/health"*) exit 0 ;;\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT"*) exit 0 ;;\n'
+            "esac\n"
+            "exit 22\n",
+        )
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$PEER_PID"; exit 0 ;;\n'
+            '  *" -a -p $PEER_PID -d cwd -Fn "*) printf "n%s\\n" "$NEWER_ROOT"; exit 0 ;;\n'
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -o ppid= "*)\n'
+            '    if [ "${2:-}" = "$PEER_PID" ]; then printf "%s\\n" "$PEER_RUNNER_PID"; else printf "0\\n"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            'if [ "${3:-}" = "$PEER_PID" ]; then\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$PEER_RUNNER_PID" ]; then\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=9.9.9 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$NEWER_ROOT" "$NEWER_VENDOR"\n'
+            "fi\n",
+        )
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "NEWER_ROOT": str(newer_root),
+                "NEWER_VENDOR": str(newer_vendor),
+                "PEER_PID": str(peer.pid),
+                "PEER_RUNNER_PID": str(peer_runner.pid),
+                "REFLEXIO_URL": "",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "stop"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        assert peer.poll() is None
+        assert peer_runner.poll() is None
+    finally:
+        if peer.poll() is None:
+            peer.terminate()
+            peer.wait(timeout=5)
+        if peer_runner.poll() is None:
+            peer_runner.terminate()
+            peer_runner.wait(timeout=5)
+
+
+def test_backend_start_waits_for_existing_service_lock_without_spawn(
+    tmp_path: Path,
+) -> None:
+    port = 24000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    locker = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        state_dir = tmp_path / ".claude-smart"
+        lock_dir = state_dir / "backend.start.lock"
+        lock_dir.mkdir(parents=True)
+        (lock_dir / "pid").write_text(f"{locker.pid}\n")
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(bin_dir / "curl", "#!/bin/sh\nexit 22\n")
+        _write_executable(bin_dir / "lsof", "#!/bin/sh\nexit 0\n")
+        _write_executable(
+            bin_dir / "uv",
+            '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
+        )
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "REFLEXIO_URL": "",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        assert not (tmp_path / "python.log").exists()
+    finally:
+        if locker.poll() is None:
+            locker.terminate()
+            locker.wait(timeout=5)
 
 
 def test_backend_service_does_not_kill_foreign_listener(tmp_path: Path) -> None:
@@ -2351,7 +2714,7 @@ def test_backend_service_does_not_kill_foreign_listener(tmp_path: Path) -> None:
             plugin_root,
             "#!/bin/sh\n"
             'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
-            'if [ "$1" = "-m" ]; then printf "spawned backend\\n" >> "$HOME/python.log"; fi\n'
+            'case "$1" in *backend-python-runner.py) printf "spawned backend\\n" >> "$HOME/python.log" ;; esac\n'
             "exit 0\n",
         )
         bin_dir = tmp_path / "bin"
@@ -2369,7 +2732,7 @@ def test_backend_service_does_not_kill_foreign_listener(tmp_path: Path) -> None:
             bin_dir / "lsof",
             "#!/bin/sh\n"
             'case " $* " in\n'
-            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$FOREIGN_PID"; exit 0 ;;\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$FOREIGN_PID"; exit 0 ;;\n'
             '  *" -a -p $FOREIGN_PID -d cwd -Fn "*) printf "n/tmp/foreign\\n"; exit 0 ;;\n'
             '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*) printf "foreign (pid %s)\\n" "$FOREIGN_PID"; exit 0 ;;\n'
             "esac\n"
@@ -2430,7 +2793,7 @@ def test_backend_service_preflight_rejects_non_bundled_reflexio(
         "    *) exit 0 ;;\n"
         "  esac\n"
         "fi\n"
-        'if [ "$1" = "-m" ]; then printf "spawned backend\\n" >> "$HOME/python.log"; fi\n'
+        'case "$1" in *backend-python-runner.py) printf "spawned backend\\n" >> "$HOME/python.log" ;; esac\n'
         "exit 0\n",
     )
     bin_dir = tmp_path / "bin"
@@ -2517,10 +2880,19 @@ def test_codex_hook_recovers_missing_dependencies_without_cli_command() -> None:
     script = CODEX_HOOK.read_text()
 
     assert "function startInstallerDetached(root, reason)" in script
-    assert 'startInstallerDetached(root, "dashboard: npm not on PATH")' in script
     assert 'startInstallerDetached(root, "hook: uv not on PATH")' in script
-    assert 'path.join(root, "scripts", "backend-service.sh")' in script
-    assert '[script, "start"]' in script
+    assert "function runServiceScript(root, scriptName, action, logName)" in script
+    assert 'path.join(root, "scripts", scriptName)' in script
+    assert "[script, action]" in script
+    assert 'runServiceScript(root, "backend-service.sh", "start", "backend.log")' in script
+    assert (
+        'runServiceScript(root, "dashboard-service.sh", "start", "dashboard.log")'
+        in script
+    )
+    assert "SERVICE_SCRIPT_TIMEOUT_MS" in script
+    assert "parsePort(process.env.BACKEND_PORT, 8071)" in script
+    assert "parsePort(process.env.EMBEDDING_PORT, 8072)" in script
+    assert "parsePort(process.env.DASHBOARD_PORT" in script
     assert "port 8071 occupied; trying 8072" not in script
 
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -205,6 +205,45 @@ def _write_fake_plugin_python(plugin_root: Path, body: str) -> Path:
     return fake_python
 
 
+def _backend_pid_key(plugin_root: Path) -> str:
+    result = subprocess.run(
+        [
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            'root="$(cd "$1" && pwd -P)"; printf "%s" "$root" | cksum',
+            "bash",
+            str(plugin_root),
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.split()[0]
+
+
+def _backend_service_env(
+    tmp_path: Path,
+    bin_dir: Path,
+    port: int,
+    **extra: str,
+) -> dict[str, str]:
+    env = _isolated_env(tmp_path)
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "BACKEND_TEST_PORT": str(port),
+            "CLAUDE_SMART_HOST": "codex",
+            "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+            "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+            "REFLEXIO_URL": "",
+        }
+    )
+    env.update(extra)
+    return env
+
+
 def _fake_claude_install_script() -> str:
     """Default fake `claude` body that logs every call and exits 0.
 
@@ -1267,16 +1306,11 @@ def test_dashboard_health_exposes_plugin_identity_for_stale_process_detection() 
     assert "x-claude-smart-version" in route
 
 
-def test_dashboard_service_accepts_shared_marker_dashboard_without_root_reap() -> None:
+def test_dashboard_service_accepts_healthy_shared_dashboard_marker() -> None:
     dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
 
-    assert "dashboard_matches_current_root()" not in dashboard
     assert "curl -sfI --connect-timeout 1 --max-time 2" in dashboard
     assert 'curl -sf --max-time 2 -o /dev/null "http://127.0.0.1:$PORT"' in dashboard
-    assert "normalize_identity_path()" not in dashboard
-    assert "cygpath -u" not in dashboard
-    assert 'if marker_responds; then claude_smart_clear_dashboard_unavailable; emit_ok; exit 0; fi' in dashboard
-    assert "stale claude-smart dashboard on port $PORT; restarting" not in dashboard
     assert "stop_dashboard_listener" in dashboard
     assert "foreign listener" in dashboard
 
@@ -1284,12 +1318,8 @@ def test_dashboard_service_accepts_shared_marker_dashboard_without_root_reap() -
 def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
-    assert 'export CLAUDE_SMART_BACKEND="1"' not in backend
-    assert 'export CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"' not in backend
-    assert 'export CLAUDE_SMART_VERSION="$PLUGIN_VERSION"' not in backend
     assert "x-claude-smart-backend" not in backend
     assert "x-claude-smart-plugin-root" not in backend
-    assert "backend_matches_current_root()" not in backend
     assert "CLAUDE_SMART_REFLEXIO_VENDOR_ROOT" in backend
     assert 'VENDORED_REFLEXIO="$PLUGIN_ROOT_CANONICAL/vendor/reflexio"' in backend
     assert (
@@ -1312,13 +1342,6 @@ def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
         in backend
     )
     assert 'PYTHONPATH="$backend_pythonpath"' in backend
-    assert "pid_uses_current_vendor_root()" in backend
-    assert "plugin_version_from_root()" in backend
-    assert "backend_pid_current_or_compatible()" in backend
-    assert "backend_pid_strictly_older_than_plugin()" in backend
-    assert "classify_backend_listener()" in backend
-    assert "backend_owned_by_current_vendor()" in backend
-    assert "backend_owned_by_stale_claude_smart()" in backend
     assert 'PID_FILE="$STATE_DIR/backend.$backend_pid_key.pid"' in backend
     assert 'SHARED_PID_FILE="$STATE_DIR/backend.pid"' in backend
     assert "backend-python-runner.py" in backend
@@ -1329,10 +1352,10 @@ def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
     assert "CLAUDE_SMART_BACKEND=1" in backend
     assert 'CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"' in backend
     assert 'CLAUDE_SMART_VERSION="$PLUGIN_VERSION"' in backend
-    assert "stop_stale_backend_listener_if_owned" in backend
-    assert "backend_pid_strictly_older_than_plugin" in backend
-    assert "if stop_stale_backend_listener_if_owned; then" in backend
-    assert "if port_occupied; then" in backend
+    assert "path_is_or_under_root()" in backend
+    assert '*"$PLUGIN_ROOT_CANONICAL"*)' not in backend
+    assert '*"$VENDORED_REFLEXIO"*)' not in backend
+    assert '*"$VENDORED_REFLEXIO_FOR_PYTHON"*)' not in backend
     assert "older than plugin $PLUGIN_VERSION" in backend
     assert "foreign or ambiguous backend on http://localhost:$PORT" in backend
 
@@ -2204,27 +2227,10 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     """claude-smart reports degraded vectors; Reflexio owns MiniLM cache repair."""
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
-    assert "embedding_healthy()" not in backend
-    assert "embedding_matches_current_root()" not in backend
-    assert 'health_headers "$EMBEDDING_PORT" "/health"' not in backend
-    assert "embedding_owned_by_current_vendor()" in backend
-    assert "embedding_current_or_compatible()" in backend
-    assert "wait_for_health()" in backend
-    assert "wait_for_health backend_owned_by_current_vendor 10 1" in backend
-    assert "wait_for_health embedding_owned_by_current_vendor 5 3" in backend
-    assert "spawn_backend()" not in backend
     assert "Embedding service did not become healthy" in backend
     assert "semantic retrieval remains unavailable" in backend
     assert "clear_minilm_cache" not in backend
     assert "clearing MiniLM cache" not in backend
-    assert "backend_healthy && embedding_healthy" not in backend
-    start_match = re.search(r"(?ms)^  start\)\n(?P<body>.*?)(?=^  stop\)\n)", backend)
-    assert start_match, "backend-service.sh start case not found"
-    start_case = start_match.group("body")
-    assert "full_stop" not in start_case
-    assert "backend_started" not in start_case
-    assert "if wait_for_health backend_owned_by_current_vendor 10 1; then" in start_case
-    assert "if ! wait_for_health embedding_owned_by_current_vendor 5 3; then" in start_case
     assert (
         "running on http://localhost:$PORT "
         "(bundled Reflexio at $VENDORED_REFLEXIO; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
@@ -2400,22 +2406,16 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
             bin_dir / "sleep",
             "#!/bin/sh\nrm -f \"$HOME/stale-listener\"\nexit 0\n",
         )
-        env = _isolated_env(tmp_path)
-        env.update(
-            {
-                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
-                "BACKEND_TEST_PORT": str(port),
-                "CLAUDE_SMART_HOST": "codex",
-                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
-                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
-                "CURRENT_PID": str(current.pid),
-                "CURRENT_RUNNER_PID": str(current_runner.pid),
-                "OLD_ROOT": str(old_root),
-                "OLD_VENDOR": str(old_vendor),
-                "REFLEXIO_URL": "",
-                "STALE_PID": str(stale.pid),
-                "STALE_RUNNER_PID": str(stale_runner.pid),
-            }
+        env = _backend_service_env(
+            tmp_path,
+            bin_dir,
+            port,
+            CURRENT_PID=str(current.pid),
+            CURRENT_RUNNER_PID=str(current_runner.pid),
+            OLD_ROOT=str(old_root),
+            OLD_VENDOR=str(old_vendor),
+            STALE_PID=str(stale.pid),
+            STALE_RUNNER_PID=str(stale_runner.pid),
         )
 
         result = subprocess.run(
@@ -2449,7 +2449,7 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
             current_runner.wait(timeout=5)
 
 
-def test_backend_start_reaps_legacy_other_root_from_pythonpath_assignment(
+def test_backend_start_reaps_older_markerless_peer_from_other_root(
     tmp_path: Path,
 ) -> None:
     if os.name == "nt":
@@ -2547,22 +2547,16 @@ def test_backend_start_reaps_legacy_other_root_from_pythonpath_assignment(
             bin_dir / "sleep",
             '#!/bin/sh\nrm -f "$HOME/legacy-listener"\nexit 0\n',
         )
-        env = _isolated_env(tmp_path)
-        env.update(
-            {
-                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
-                "BACKEND_TEST_PORT": str(port),
-                "CLAUDE_SMART_HOST": "codex",
-                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
-                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
-                "CURRENT_PID": str(current.pid),
-                "CURRENT_RUNNER_PID": str(current_runner.pid),
-                "LEGACY_PID": str(legacy.pid),
-                "LEGACY_RUNNER_PID": str(legacy_runner.pid),
-                "OLD_ROOT": str(old_root),
-                "OLD_VENDOR": str(old_vendor),
-                "REFLEXIO_URL": "",
-            }
+        env = _backend_service_env(
+            tmp_path,
+            bin_dir,
+            port,
+            CURRENT_PID=str(current.pid),
+            CURRENT_RUNNER_PID=str(current_runner.pid),
+            LEGACY_PID=str(legacy.pid),
+            LEGACY_RUNNER_PID=str(legacy_runner.pid),
+            OLD_ROOT=str(old_root),
+            OLD_VENDOR=str(old_vendor),
         )
 
         result = subprocess.run(
@@ -2668,20 +2662,14 @@ def test_backend_start_accepts_unknown_version_legacy_peer(
             '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
         )
         _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
-        env = _isolated_env(tmp_path)
-        env.update(
-            {
-                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
-                "BACKEND_TEST_PORT": str(port),
-                "CLAUDE_SMART_HOST": "codex",
-                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
-                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
-                "PEER_PID": str(peer.pid),
-                "PEER_ROOT": str(peer_root),
-                "PEER_RUNNER_PID": str(peer_runner.pid),
-                "PEER_VENDOR": str(peer_vendor),
-                "REFLEXIO_URL": "",
-            }
+        env = _backend_service_env(
+            tmp_path,
+            bin_dir,
+            port,
+            PEER_PID=str(peer.pid),
+            PEER_ROOT=str(peer_root),
+            PEER_RUNNER_PID=str(peer_runner.pid),
+            PEER_VENDOR=str(peer_vendor),
         )
 
         result = subprocess.run(
@@ -2778,21 +2766,15 @@ def test_backend_start_accepts_compatible_other_root_without_downgrade(
             '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
         )
         _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
-        env = _isolated_env(tmp_path)
-        env.update(
-            {
-                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
-                "BACKEND_TEST_PORT": str(port),
-                "CLAUDE_SMART_HOST": "codex",
-                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
-                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
-                "PEER_PID": str(peer.pid),
-                "PEER_ROOT": str(peer_root),
-                "PEER_RUNNER_PID": str(peer_runner.pid),
-                "PEER_VENDOR": str(peer_vendor),
-                "PEER_VERSION": peer_version,
-                "REFLEXIO_URL": "",
-            }
+        env = _backend_service_env(
+            tmp_path,
+            bin_dir,
+            port,
+            PEER_PID=str(peer.pid),
+            PEER_ROOT=str(peer_root),
+            PEER_RUNNER_PID=str(peer_runner.pid),
+            PEER_VENDOR=str(peer_vendor),
+            PEER_VERSION=peer_version,
         )
 
         result = subprocess.run(
@@ -2873,20 +2855,14 @@ def test_backend_stop_does_not_kill_newer_peer_from_shared_pid(
             "fi\n",
         )
         _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
-        env = _isolated_env(tmp_path)
-        env.update(
-            {
-                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
-                "BACKEND_TEST_PORT": str(port),
-                "CLAUDE_SMART_HOST": "codex",
-                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
-                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
-                "NEWER_ROOT": str(newer_root),
-                "NEWER_VENDOR": str(newer_vendor),
-                "PEER_PID": str(peer.pid),
-                "PEER_RUNNER_PID": str(peer_runner.pid),
-                "REFLEXIO_URL": "",
-            }
+        env = _backend_service_env(
+            tmp_path,
+            bin_dir,
+            port,
+            NEWER_ROOT=str(newer_root),
+            NEWER_VENDOR=str(newer_vendor),
+            PEER_PID=str(peer.pid),
+            PEER_RUNNER_PID=str(peer_runner.pid),
         )
 
         result = subprocess.run(
@@ -2902,6 +2878,8 @@ def test_backend_stop_does_not_kill_newer_peer_from_shared_pid(
         assert result.stdout.strip() == '{"continue":true}'
         assert peer.poll() is None
         assert peer_runner.poll() is None
+        assert (state_dir / "backend.pid").exists()
+        assert "shared pid" in (state_dir / "backend.log").read_text()
     finally:
         if peer.poll() is None:
             peer.terminate()
@@ -3002,17 +2980,7 @@ def test_backend_start_waits_for_existing_service_lock_without_spawn(
             '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
         )
         _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
-        env = _isolated_env(tmp_path)
-        env.update(
-            {
-                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
-                "BACKEND_TEST_PORT": str(port),
-                "CLAUDE_SMART_HOST": "codex",
-                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
-                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
-                "REFLEXIO_URL": "",
-            }
-        )
+        env = _backend_service_env(tmp_path, bin_dir, port)
 
         result = subprocess.run(
             ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
@@ -3030,6 +2998,100 @@ def test_backend_start_waits_for_existing_service_lock_without_spawn(
         if locker.poll() is None:
             locker.terminate()
             locker.wait(timeout=5)
+
+
+def test_backend_start_honors_startup_grace_for_recorded_pid(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("process fixture is POSIX-only")
+    port = 24500 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    warming = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        state_dir = tmp_path / ".claude-smart"
+        state_dir.mkdir()
+        (state_dir / f"backend.{_backend_pid_key(plugin_root)}.pid").write_text(
+            f"{warming.pid}\n"
+        )
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(bin_dir / "curl", "#!/bin/sh\nexit 22\n")
+        _write_executable(bin_dir / "lsof", "#!/bin/sh\nexit 0\n")
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'if [ "${3:-}" = "$WARMING_PID" ]; then\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=0.2.49 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$PWD" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT"\n'
+            "fi\n",
+        )
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _backend_service_env(
+            tmp_path,
+            bin_dir,
+            port,
+            CLAUDE_SMART_BACKEND_START_GRACE_SECONDS="not-a-number",
+            WARMING_PID=str(warming.pid),
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        assert warming.poll() is None
+        assert not (tmp_path / "python.log").exists()
+        assert "recorded backend process is still running but not healthy yet" in (
+            state_dir / "backend.log"
+        ).read_text()
+    finally:
+        if warming.poll() is None:
+            warming.terminate()
+            warming.wait(timeout=5)
+
+
+def test_service_lock_recovers_dead_stale_lock(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".claude-smart"
+    lock_dir = state_dir / "backend.start.lock"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "pid").write_text("999999\n")
+    old = time.time() - 120
+    os.utime(lock_dir, (old, old))
+
+    env = _isolated_env(tmp_path)
+    result = subprocess.run(
+        [
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            (
+                f'. "{LIB}"; '
+                "CLAUDE_SMART_SERVICE_LOCK_STALE_SECONDS=60 "
+                "claude_smart_service_lock backend; cat \"$HOME/.claude-smart/backend.start.lock/pid\""
+            ),
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().isdigit()
 
 
 def test_backend_service_does_not_kill_foreign_listener(tmp_path: Path) -> None:
@@ -3168,29 +3230,15 @@ def test_backend_service_preflight_rejects_non_bundled_reflexio(
 
 
 def test_backend_service_full_stop_reaps_embedding_port() -> None:
-    """full_stop must sweep both the backend port and the embedding port.
-
-    Without this, a stale embedding service (uvicorn
-    reflexio.server.llm.embedding_service) can survive ``/claude-smart:restart``
-    and block subsequent boots when something else is squatting 8071.
-    """
+    """full_stop must sweep both the backend port and the embedding port."""
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
-    assert "stop_marked_backend_listener" not in backend
-    assert "stop_legacy_backend_listener_if_owned" not in backend
-    assert "stop_backend_listener_if_owned" in backend
-    assert "stop_stale_embedding_listener_if_owned" in backend
-    assert "x-claude-smart-embedding" not in backend
-    assert "looks_like_claude_smart_backend_pid" in backend
-    assert "pid_uses_current_vendor_root" in backend
-    assert "*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*" not in backend
-    assert '".claude-smart/.env"' not in backend
-    assert '"local-agent-mode-sessions"' not in backend
-    assert (
-        "reap_port_listeners \"$EMBEDDING_PORT\" '*reflexio*' '*uvicorn*'"
-        not in backend
-    )
-    assert "reap_port_listeners()" not in backend
+    full_stop_match = re.search(r"(?ms)^full_stop\(\) \{\n(?P<body>.*?)^\}", backend)
+    assert full_stop_match, "backend-service.sh full_stop function not found"
+    full_stop = full_stop_match.group("body")
+    assert "kill_recorded_backend" in full_stop
+    assert "stop_backend_listener_if_owned" in full_stop
+    assert "stop_stale_embedding_listener_if_owned" in full_stop
 
 
 def test_backend_service_surfaces_port_holder_on_skip() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -2647,6 +2647,71 @@ def test_backend_stop_does_not_kill_newer_peer_from_shared_pid(
             peer_runner.wait(timeout=5)
 
 
+def test_backend_stop_reaps_legacy_same_root_shared_pid(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 23500 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    legacy = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        state_dir = tmp_path / ".claude-smart"
+        state_dir.mkdir()
+        (state_dir / "backend.pid").write_text(f"{legacy.pid}\n")
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -a -p $LEGACY_PID -d cwd -Fn "*) printf "n%s\\n" "$PWD"; exit 0 ;;\n'
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -o ppid= "*) printf "0\\n"; exit 0 ;;\n'
+            "esac\n"
+            'if [ "${3:-}" = "$LEGACY_PID" ]; then\n'
+            '  printf "python -m reflexio.cli services start --only backend --no-reload --workers 1\\n"\n'
+            "fi\n",
+        )
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "LEGACY_PID": str(legacy.pid),
+                "REFLEXIO_URL": "",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "stop"],
+            cwd=plugin_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        legacy.wait(timeout=5)
+    finally:
+        if legacy.poll() is None:
+            legacy.terminate()
+            legacy.wait(timeout=5)
+
+
 def test_backend_start_waits_for_existing_service_lock_without_spawn(
     tmp_path: Path,
 ) -> None:
@@ -2854,7 +2919,9 @@ def test_backend_service_full_stop_reaps_embedding_port() -> None:
     assert "x-claude-smart-embedding" not in backend
     assert "looks_like_claude_smart_backend_pid" in backend
     assert "pid_uses_current_vendor_root" in backend
-    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in backend
+    assert "*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*" not in backend
+    assert '".claude-smart/.env"' not in backend
+    assert '"local-agent-mode-sessions"' not in backend
     assert (
         "reap_port_listeners \"$EMBEDDING_PORT\" '*reflexio*' '*uvicorn*'"
         not in backend

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -2449,19 +2449,282 @@ def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
             current_runner.wait(timeout=5)
 
 
-def test_backend_start_accepts_newer_other_root_without_downgrade(
+def test_backend_start_reaps_legacy_other_root_from_pythonpath_assignment(
     tmp_path: Path,
 ) -> None:
     if os.name == "nt":
         pytest.skip("process termination fixture is POSIX-only")
     port = 22000 + (abs(hash(tmp_path.name)) % 1000)
     plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
-    newer_root = tmp_path / "newer-plugin"
-    newer_vendor = newer_root / "vendor" / "reflexio"
-    (newer_root / ".codex-plugin").mkdir(parents=True)
-    newer_vendor.mkdir(parents=True)
-    (newer_root / ".codex-plugin" / "plugin.json").write_text(
-        json.dumps({"version": "9.9.9"})
+    old_root = (
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.0.1"
+    )
+    old_vendor = old_root / "vendor" / "reflexio"
+    (old_root / ".codex-plugin").mkdir(parents=True)
+    old_vendor.mkdir(parents=True)
+    (old_root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "0.0.1"})
+    )
+    (tmp_path / "legacy-listener").write_text("1\n")
+    legacy = subprocess.Popen(["/bin/sleep", "60"])
+    legacy_runner = subprocess.Popen(["/bin/sleep", "60"])
+    current = subprocess.Popen(["/bin/sleep", "60"])
+    current_runner = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            'if [ "$1" = "-" ]; then exit 0; fi\n'
+            'case "$1" in *backend-python-runner.py) printf "spawned backend\\n" >> "$HOME/python.log" ;; esac\n'
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "curl",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT/health"*)\n'
+            '    if [ -f "$HOME/legacy-listener" ]; then exit 22; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT"*)\n'
+            '    if [ -f "$HOME/legacy-listener" ]; then exit 0; fi\n'
+            "    exit 22\n"
+            "    ;;\n"
+            "esac\n"
+            "exit 22\n",
+        )
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*)\n'
+            '    if [ -f "$HOME/legacy-listener" ]; then printf "%s\\n" "$LEGACY_PID"; else printf "%s\\n" "$CURRENT_PID"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            '  *" -a -p $LEGACY_PID -d cwd -Fn "*) printf "n%s\\n" "$OLD_ROOT"; exit 0 ;;\n'
+            '  *" -a -p $LEGACY_RUNNER_PID -d cwd -Fn "*) printf "n%s\\n" "$OLD_ROOT"; exit 0 ;;\n'
+            '  *" -a -p $CURRENT_PID -d cwd -Fn "*) printf "n%s\\n" "$PWD"; exit 0 ;;\n'
+            '  *" -a -p $CURRENT_RUNNER_PID -d cwd -Fn "*) printf "n%s\\n" "$PWD"; exit 0 ;;\n'
+            '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*) printf "python (pid %s)\\n" "$LEGACY_PID"; exit 0 ;;\n'
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -o ppid= "*)\n'
+            '    if [ "${2:-}" = "$LEGACY_PID" ]; then printf "%s\\n" "$LEGACY_RUNNER_PID";\n'
+            '    elif [ "${2:-}" = "$CURRENT_PID" ]; then printf "%s\\n" "$CURRENT_RUNNER_PID";\n'
+            '    else printf "0\\n"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            'if [ "${3:-}" = "$LEGACY_PID" ]; then\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$LEGACY_RUNNER_PID" ]; then\n'
+            '  printf "bash backend-log-runner.sh backend.log -- env PYTHONIOENCODING=utf-8 PYTHONPATH=%s:/other/path python -m reflexio.cli services start --only backend --no-reload --workers 1\\n" "$OLD_VENDOR"\n'
+            'elif [ "${3:-}" = "$CURRENT_PID" ]; then\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$CURRENT_RUNNER_PID" ]; then\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=0.2.49 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$PWD" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT"\n'
+            "fi\n",
+        )
+        _write_executable(
+            bin_dir / "uv",
+            '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
+        )
+        _write_executable(
+            bin_dir / "sleep",
+            '#!/bin/sh\nrm -f "$HOME/legacy-listener"\nexit 0\n',
+        )
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "CURRENT_PID": str(current.pid),
+                "CURRENT_RUNNER_PID": str(current_runner.pid),
+                "LEGACY_PID": str(legacy.pid),
+                "LEGACY_RUNNER_PID": str(legacy_runner.pid),
+                "OLD_ROOT": str(old_root),
+                "OLD_VENDOR": str(old_vendor),
+                "REFLEXIO_URL": "",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        legacy.wait(timeout=5)
+        assert "spawned backend" in (tmp_path / "python.log").read_text()
+        assert (
+            "older than plugin"
+            in (tmp_path / ".claude-smart" / "backend.log").read_text()
+        )
+    finally:
+        if legacy.poll() is None:
+            legacy.terminate()
+            legacy.wait(timeout=5)
+        if legacy_runner.poll() is None:
+            legacy_runner.terminate()
+            legacy_runner.wait(timeout=5)
+        if current.poll() is None:
+            current.terminate()
+            current.wait(timeout=5)
+        if current_runner.poll() is None:
+            current_runner.terminate()
+            current_runner.wait(timeout=5)
+
+
+def test_backend_start_accepts_unknown_version_legacy_peer(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 22500 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    peer_root = (
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "missing-manifest"
+    )
+    peer_vendor = peer_root / "vendor" / "reflexio"
+    peer_vendor.mkdir(parents=True)
+    peer = subprocess.Popen(["/bin/sleep", "60"])
+    peer_runner = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            'if [ "$1" = "-" ]; then exit 0; fi\n'
+            'case "$1" in *backend-python-runner.py) printf "spawned backend\\n" >> "$HOME/python.log" ;; esac\n'
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "curl",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT/health"*) exit 0 ;;\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT"*) exit 0 ;;\n'
+            "esac\n"
+            "exit 22\n",
+        )
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$PEER_PID"; exit 0 ;;\n'
+            '  *" -a -p $PEER_PID -d cwd -Fn "*) printf "n%s\\n" "$PEER_ROOT"; exit 0 ;;\n'
+            '  *" -a -p $PEER_RUNNER_PID -d cwd -Fn "*) printf "n%s\\n" "$PEER_ROOT"; exit 0 ;;\n'
+            '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*) printf "python (pid %s)\\n" "$PEER_PID"; exit 0 ;;\n'
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -o ppid= "*)\n'
+            '    if [ "${2:-}" = "$PEER_PID" ]; then printf "%s\\n" "$PEER_RUNNER_PID"; else printf "0\\n"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            'if [ "${3:-}" = "$PEER_PID" ]; then\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$PEER_RUNNER_PID" ]; then\n'
+            '  printf "bash backend-log-runner.sh backend.log -- env PYTHONIOENCODING=utf-8 PYTHONPATH=%s:/other/path python -m reflexio.cli services start --only backend --no-reload --workers 1\\n" "$PEER_VENDOR"\n'
+            "fi\n",
+        )
+        _write_executable(
+            bin_dir / "uv",
+            '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
+        )
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "PEER_PID": str(peer.pid),
+                "PEER_ROOT": str(peer_root),
+                "PEER_RUNNER_PID": str(peer_runner.pid),
+                "PEER_VENDOR": str(peer_vendor),
+                "REFLEXIO_URL": "",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        assert peer.poll() is None
+        assert peer_runner.poll() is None
+        assert not (tmp_path / "python.log").exists()
+    finally:
+        if peer.poll() is None:
+            peer.terminate()
+            peer.wait(timeout=5)
+        if peer_runner.poll() is None:
+            peer_runner.terminate()
+            peer_runner.wait(timeout=5)
+
+
+@pytest.mark.parametrize("peer_version", ["current", "9.9.9", "0.2.50-beta"])
+def test_backend_start_accepts_compatible_other_root_without_downgrade(
+    tmp_path: Path, peer_version: str
+) -> None:
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 22600 + (abs(hash(f"{tmp_path.name}-{peer_version}")) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    if peer_version == "current":
+        peer_version = json.loads(
+            (plugin_root / ".codex-plugin" / "plugin.json").read_text()
+        )["version"]
+    peer_root = tmp_path / "peer-plugin"
+    peer_vendor = peer_root / "vendor" / "reflexio"
+    (peer_root / ".codex-plugin").mkdir(parents=True)
+    peer_vendor.mkdir(parents=True)
+    (peer_root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": peer_version})
     )
     peer = subprocess.Popen(["/bin/sleep", "60"])
     peer_runner = subprocess.Popen(["/bin/sleep", "60"])
@@ -2490,7 +2753,7 @@ def test_backend_start_accepts_newer_other_root_without_downgrade(
             "#!/bin/sh\n"
             'case " $* " in\n'
             '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$PEER_PID"; exit 0 ;;\n'
-            '  *" -a -p $PEER_PID -d cwd -Fn "*) printf "n%s\\n" "$NEWER_ROOT"; exit 0 ;;\n'
+            '  *" -a -p $PEER_PID -d cwd -Fn "*) printf "n%s\\n" "$PEER_ROOT"; exit 0 ;;\n'
             '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*) printf "python (pid %s)\\n" "$PEER_PID"; exit 0 ;;\n'
             "esac\n"
             "exit 0\n",
@@ -2507,7 +2770,7 @@ def test_backend_start_accepts_newer_other_root_without_downgrade(
             'if [ "${3:-}" = "$PEER_PID" ]; then\n'
             '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
             'elif [ "${3:-}" = "$PEER_RUNNER_PID" ]; then\n'
-            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=9.9.9 --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$NEWER_ROOT" "$NEWER_VENDOR"\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=%s --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$PEER_ROOT" "$PEER_VERSION" "$PEER_VENDOR"\n'
             "fi\n",
         )
         _write_executable(
@@ -2523,10 +2786,11 @@ def test_backend_start_accepts_newer_other_root_without_downgrade(
                 "CLAUDE_SMART_HOST": "codex",
                 "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
                 "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
-                "NEWER_ROOT": str(newer_root),
-                "NEWER_VENDOR": str(newer_vendor),
                 "PEER_PID": str(peer.pid),
+                "PEER_ROOT": str(peer_root),
                 "PEER_RUNNER_PID": str(peer_runner.pid),
+                "PEER_VENDOR": str(peer_vendor),
+                "PEER_VERSION": peer_version,
                 "REFLEXIO_URL": "",
             }
         )


### PR DESCRIPTION
## What Was Annoying

claude-smart can be started by Claude Code, Codex, OpenCode, install/update flows, and old plugin cache roots. Those callers could race each other, misread a healthy service as stale, or kill/restart a backend that another compatible claude-smart root was already using.

This PR fixes #111 by making claude-smart converge on one safe local backend/dashboard without depending on Reflexio CLI changes.

## What Changed

- Adds shared start locks for backend/dashboard startup so concurrent hooks do not stampede.
- Moves backend ownership detection from HTTP headers to process metadata: runner argv markers, plugin root, vendored Reflexio path, process ancestry, and plugin version.
- Reuses healthy compatible claude-smart peers from other cache roots: same version, newer version, or unknown version stays running.
- Replaces only proven current-root services or strictly older claude-smart services, so upgrades can self-heal without killing foreign listeners.
- Preserves legacy `~/.claude-smart/backend.pid` only as guarded migration input while writing per-root backend PID files going forward.
- Keeps dashboard acceptance marker-based: a healthy claude-smart dashboard marker is accepted even when it came from another cache root.
- Carries custom `BACKEND_PORT`, `EMBEDDING_PORT`, and `DASHBOARD_PORT` through hooks, scripts, adapters, dashboard config, and tests.

## How It Works

```mermaid
flowchart TD
  A["Host starts claude-smart"] --> B["backend-service.sh"]
  B --> C{"Backend port listener?"}
  C -- "No" --> D["Start current backend"]
  C -- "Foreign" --> E["Report conflict\nDo not kill"]
  C -- "claude-smart" --> F{"Version/root check"}
  F -- "current / same / newer / unknown" --> G["Reuse existing backend"]
  F -- "strictly older" --> H["Reap stale backend"]
  H --> D
  D --> I["Return continue"]
  E --> I
  G --> I
```

The backend still calls the normal Reflexio start command after claude-smart has made its own ownership decision:

`reflexio services start --only backend --no-reload --workers 1`

## Compatibility Notes

- Backend `x-claude-smart-*` identity headers are intentionally no longer the source of truth. Backend identity now comes from managed process metadata; operational checks should use `backend-service.sh status` or process inspection. The dashboard still exposes its own marker because it owns that route directly.
- `backend-python-runner.py` is part of the managed backend start contract. It runs through the prepared plugin venv and keeps claude-smart ownership/version/vendor metadata visible in argv for later stop/restart decisions.
- A legacy shared `~/.claude-smart/backend.pid` from another cache root may remain when ownership cannot be proven. That is intentional: listener classification controls startup, and leaving an unowned shared PID is safer than cross-root killing.
- The time-based waits are bounded startup coordination, not correctness gates. Health polling, startup grace, and stale-lock recovery are covered by tests.

## How It Was Verified

- `bash -n plugin/scripts/backend-service.sh plugin/scripts/dashboard-service.sh plugin/scripts/_lib.sh plugin/scripts/backend-log-runner.sh plugin/scripts/hook_entry.sh plugin/scripts/dashboard-open.sh tests/integration/integration.sh`
- `uv run --project plugin --with pytest pytest tests/test_install_scripts.py -k 'backend_service or backend_start or backend_stop or service_lock or dashboard_service_accepts_healthy_shared_dashboard_marker' -q` -> 24 passed
- `uv run --project plugin --with pytest pytest tests/test_install_scripts.py -q` -> 135 passed, 1 warning
- `uv run --project plugin --with pytest pytest tests -q` -> 637 passed, 9 warnings
- `uvx ruff check plugin/scripts/backend-python-runner.py tests/test_install_scripts.py` -> passed
- `python3 -m py_compile plugin/scripts/backend-python-runner.py`
- `node --check plugin/scripts/codex-hook.js`
- `git diff --check`

## Risks / Follow-ups

- Nothing.


