### PR TITLE
feat: verify backend runtime identity via response headers

### DIFF
--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -63,6 +63,21 @@ fi
 # explicitly if we can resolve it from our own (post-login-path) PATH.
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "backend-service.sh" "$@"
+PLUGIN_ROOT_CANONICAL="$(cd "$PLUGIN_ROOT" 2>/dev/null && pwd -P || printf '%s\n' "$PLUGIN_ROOT")"
+PLUGIN_VERSION="$(
+  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    "$PLUGIN_ROOT/.codex-plugin/plugin.json" 2>/dev/null | head -n1
+)"
+if [ -z "$PLUGIN_VERSION" ]; then
+  PLUGIN_VERSION="$(
+    sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$PLUGIN_ROOT/pyproject.toml" 2>/dev/null | head -n1
+  )"
+fi
+PLUGIN_VERSION="${PLUGIN_VERSION:-unknown}"
+export CLAUDE_SMART_BACKEND="1"
+export CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"
+export CLAUDE_SMART_VERSION="$PLUGIN_VERSION"
 
 if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
   if [ "${CLAUDE_SMART_HOST:-claude-code}" = "opencode" ]; then
@@ -134,19 +149,91 @@ kill_group() {
   claude_smart_kill_tree "$1"
 }
 
-# True if /health returns 200. Reflexio's /health is a plain GET with no
-# marker header, so we can't distinguish our backend from someone else's
-# reflexio on the same port — if you run two reflexio instances on 8071
-# you'll get collision regardless of what we do here.
+health_headers() {
+  port="$1"
+  path="${2:-/health}"
+  command -v curl >/dev/null 2>&1 || return 1
+  curl -sf --connect-timeout 2 --max-time 5 -D - -o /dev/null "http://127.0.0.1:$port$path" 2>/dev/null
+}
+
+header_value_from() {
+  header_name="$1"
+  awk -v wanted="$header_name" '
+    BEGIN { wanted = tolower(wanted) ":" }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      lower = tolower(line)
+      if (index(lower, wanted) == 1) {
+        sub(/^[^:]*:[[:space:]]*/, "", line)
+        print line
+        exit
+      }
+    }
+  '
+}
+
+canonical_dir() {
+  dir="$1"
+  (cd "$dir" 2>/dev/null && pwd -P) || printf '%s\n' "$dir"
+}
+
+normalize_identity_path() {
+  path="$1"
+  if claude_smart_is_windows; then
+    if command -v cygpath >/dev/null 2>&1; then
+      path="$(cygpath -u "$path" 2>/dev/null || printf '%s\n' "$path")"
+    else
+      path="$(
+        printf '%s\n' "$path" | awk '{
+          gsub(/\\/, "/")
+          if ($0 ~ /^[A-Za-z]:/) {
+            drive = tolower(substr($0, 1, 1))
+            sub(/^[A-Za-z]:/, "/" drive)
+          }
+          print
+        }'
+      )"
+    fi
+  fi
+  while [ "${path%/}" != "$path" ] && [ "$path" != "/" ]; do
+    path="${path%/}"
+  done
+  printf '%s\n' "$path"
+}
+
+identity_matches_current_root() {
+  marker="$1"
+  headers="$2"
+  expected_root="$(normalize_identity_path "$(canonical_dir "$PLUGIN_ROOT")")"
+  printf '%s\n' "$headers" | grep -qi "^$marker:" || return 1
+  actual_root="$(printf '%s\n' "$headers" | header_value_from "x-claude-smart-plugin-root")"
+  [ -n "$actual_root" ] || return 1
+  actual_root="$(normalize_identity_path "$actual_root")"
+  [ "$actual_root" = "$expected_root" ]
+}
+
+# True if /health returns 200, regardless of runtime identity. Used only for
+# generic liveness; ownership checks use backend_matches_current_root.
 backend_healthy() {
   command -v curl >/dev/null 2>&1 || return 1
   curl -sf --connect-timeout 1 --max-time 1 -o /dev/null "http://127.0.0.1:$PORT/health" 2>/dev/null
 }
 
-embedding_healthy() {
+backend_has_claude_smart_marker() {
+  headers="$(health_headers "$PORT" "/health")" || return 1
+  printf '%s\n' "$headers" | grep -qi '^x-claude-smart-backend:'
+}
+
+backend_matches_current_root() {
+  headers="$(health_headers "$PORT" "/health")" || return 1
+  identity_matches_current_root "x-claude-smart-backend" "$headers"
+}
+
+embedding_matches_current_root() {
   [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
-  command -v curl >/dev/null 2>&1 || return 1
-  curl -sf --connect-timeout 1 --max-time 1 -o /dev/null "http://127.0.0.1:$EMBEDDING_PORT/health" 2>/dev/null
+  headers="$(health_headers "$EMBEDDING_PORT" "/health")" || return 1
+  identity_matches_current_root "x-claude-smart-embedding" "$headers"
 }
 
 wait_for_health() {
@@ -173,12 +260,16 @@ is_our_backend_running() {
   if [ -f "$PID_FILE" ]; then
     pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      backend_healthy && return 0
+      if command -v curl >/dev/null 2>&1; then
+        backend_matches_current_root && return 0
+      else
+        return 0
+      fi
     fi
   fi
-  # Recover from a missing PID file if a foreign-but-functional reflexio
-  # is already serving — no need to start a second one.
-  backend_healthy && return 0
+  # Recover from a missing PID file only when the listener proves it belongs
+  # to this plugin root. A generic healthy Reflexio process is not enough.
+  backend_matches_current_root && return 0
   return 1
 }
 
@@ -192,39 +283,87 @@ port_occupied() {
   (echo >"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null
 }
 
-# Reap listeners still holding the given port after the PID file kill
-# when their command line matches one of the supplied patterns. Filters
-# by cmdline so we don't knock over an
-# unrelated service a user has bound there — symmetric with start's
-# refusal to stomp on a foreign listener. Silent on failure.
-reap_port_listeners() {
-  port="${1:-$PORT}"
-  shift || true
-  [ "$#" -eq 0 ] && return 0
+port_listener_pids() {
   command -v lsof >/dev/null 2>&1 || return 0
-  candidates=$(lsof -ti:"$port" 2>/dev/null) || candidates=""
-  [ -z "$candidates" ] && return 0
-  ours=""
-  for pid in $candidates; do
-    cmdline=$(ps -p "$pid" -o command= 2>/dev/null || true)
-    for pattern in "$@"; do
-      if [[ "$cmdline" == $pattern ]]; then
-        ours="$ours $pid"
-        break
-      fi
-    done
-  done
-  [ -z "$ours" ] && return 0
+  lsof -t -i ":$1" -sTCP:LISTEN 2>/dev/null || true
+}
+
+pid_details() {
+  pid="$1"
+  {
+    ps eww -p "$pid" -o command= 2>/dev/null \
+      || ps -p "$pid" -o command= 2>/dev/null \
+      || true
+    if command -v lsof >/dev/null 2>&1; then
+      lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n/cwd=/p' || true
+    fi
+  } | tr '\n' ' '
+}
+
+looks_like_claude_smart_backend_pid() {
+  pid="$1"
+  text="$(pid_details "$pid")"
+  [ -n "$text" ] || return 1
+  case "$text" in
+    *CLAUDE_SMART_BACKEND=1*|*CLAUDE_SMART_USE_LOCAL_CLI=1*|*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*|*".claude-smart/.env"*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"local-agent-mode-sessions"*|*"$PLUGIN_ROOT_CANONICAL"*|*"$HOME/.reflexio/plugin-root"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+stop_port_pids() {
+  pids="$1"
+  [ -n "$pids" ] || return 0
   # shellcheck disable=SC2086
-  kill -TERM $ours 2>/dev/null || true
+  kill -TERM $pids 2>/dev/null || true
   sleep 1
   remaining=""
-  for pid in $ours; do
+  for pid in $pids; do
     kill -0 "$pid" 2>/dev/null && remaining="$remaining $pid"
   done
   [ -z "$remaining" ] && return 0
   # shellcheck disable=SC2086
   kill -KILL $remaining 2>/dev/null || true
+}
+
+stop_marked_backend_listener() {
+  backend_has_claude_smart_marker || return 1
+  stop_port_pids "$(port_listener_pids "$PORT")"
+}
+
+stop_legacy_backend_listener_if_owned() {
+  backend_healthy || return 1
+  pids="$(port_listener_pids "$PORT")"
+  [ -n "$pids" ] || return 1
+  ours=""
+  for pid in $pids; do
+    if looks_like_claude_smart_backend_pid "$pid"; then
+      ours="$ours $pid"
+    fi
+  done
+  [ -n "$ours" ] || return 1
+  stop_port_pids "$ours"
+}
+
+stop_stale_embedding_listener_if_owned() {
+  [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
+  embedding_matches_current_root && return 0
+  headers="$(health_headers "$EMBEDDING_PORT" "/health" 2>/dev/null || true)"
+  if printf '%s\n' "$headers" | grep -qi '^x-claude-smart-embedding:'; then
+    stop_port_pids "$(port_listener_pids "$EMBEDDING_PORT")"
+    return 0
+  fi
+  pids="$(port_listener_pids "$EMBEDDING_PORT")"
+  [ -n "$pids" ] || return 0
+  ours=""
+  for pid in $pids; do
+    if looks_like_claude_smart_backend_pid "$pid"; then
+      ours="$ours $pid"
+    fi
+  done
+  [ -n "$ours" ] || return 0
+  stop_port_pids "$ours"
 }
 
 # Describe what (if anything) is currently listening on $1. Returns
@@ -265,23 +404,21 @@ PY
   uv pip install --project "$PLUGIN_ROOT" --python "$plugin_python" --quiet --reinstall --no-deps "$vendor" >&2
 }
 
-# Full shutdown: kill the recorded process group (if any) then sweep
-# both the backend port and the embedding-service port for surviving
-# reflexio listeners. Used by both `stop` and the opt-in `session-end`
-# path so a stale/missing PID file doesn't produce a silent no-op, and
-# so a stale embedding service on EMBEDDING_PORT doesn't block the next
-# fresh boot (e.g. when codex-hook.js falls back to 8072 for the main
-# backend because 8071 is held by another app).
+# Full shutdown: kill the recorded process group (if any) then sweep stale
+# claude-smart-owned backend/embedding listeners. Foreign services on the same
+# ports are left alone.
 full_stop() {
   if [ -f "$PID_FILE" ]; then
     kill_group "$(cat "$PID_FILE" 2>/dev/null)"
     rm -f "$PID_FILE"
   fi
-  reap_port_listeners "$PORT" '*reflexio*' '*uvicorn*'
+  if backend_has_claude_smart_marker; then
+    stop_marked_backend_listener || true
+  else
+    stop_legacy_backend_listener_if_owned || true
+  fi
   if [ -n "${EMBEDDING_PORT:-}" ] && [ "$EMBEDDING_PORT" != "$PORT" ]; then
-    reap_port_listeners "$EMBEDDING_PORT" \
-      '*reflexio.server.llm.embedding_service:app*' \
-      '*reflexio*embedding_service*'
+    stop_stale_embedding_listener_if_owned || true
   fi
 }
 
@@ -300,9 +437,20 @@ case "$CMD" in
       emit_ok; exit 0
     fi
     if is_our_backend_running; then
-      embedding_healthy || log_embedding_degraded
+      embedding_matches_current_root || log_embedding_degraded
       emit_ok; exit 0
     fi
+    if backend_has_claude_smart_marker; then
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+        "[claude-smart] backend: stale claude-smart backend on port $PORT; restarting from $PLUGIN_ROOT"
+      stop_marked_backend_listener || true
+    else
+      if stop_legacy_backend_listener_if_owned; then
+        claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+          "[claude-smart] backend: replaced legacy claude-smart backend on port $PORT that did not expose identity headers"
+      fi
+    fi
+    stop_stale_embedding_listener_if_owned || true
     if port_occupied; then
       # is_our_backend_running already ruled out a healthy Reflexio backend.
       # Anything still holding the port would make uvicorn fail to bind, so
@@ -390,10 +538,10 @@ case "$CMD" in
 
     # Give uvicorn about 20s to answer /health. The first boot after a fresh
     # checkout may be slower; if it catches up later, the next hook observes it.
-    if wait_for_health backend_healthy 10 1; then
+    if wait_for_health backend_matches_current_root 10 1; then
       # The Node installer waits 45s for this script. Each curl probe is also
       # bounded so a wedged listener cannot outlive the caller's timeout budget.
-      if ! wait_for_health embedding_healthy 5 3; then
+      if ! wait_for_health embedding_matches_current_root 5 3; then
         log_embedding_degraded
       fi
     else
@@ -422,12 +570,16 @@ case "$CMD" in
   status)
     if claude_smart_reflexio_url_is_remote; then
       echo "remote configured at $REFLEXIO_URL"
-    elif backend_healthy; then
-      if embedding_healthy; then
-        echo "running on http://localhost:$PORT"
+    elif backend_matches_current_root; then
+      if embedding_matches_current_root; then
+        echo "running on http://localhost:$PORT (plugin $PLUGIN_VERSION at $PLUGIN_ROOT_CANONICAL)"
       else
-        echo "running on http://localhost:$PORT (embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
+        echo "running on http://localhost:$PORT (plugin $PLUGIN_VERSION at $PLUGIN_ROOT_CANONICAL; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
       fi
+    elif backend_has_claude_smart_marker; then
+      echo "stale claude-smart backend on http://localhost:$PORT"
+    elif backend_healthy; then
+      echo "foreign or legacy backend on http://localhost:$PORT (identity headers missing)"
     else
       echo "not running"
     fi

--- a/plugin/scripts/codex-hook.js
+++ b/plugin/scripts/codex-hook.js
@@ -11,7 +11,6 @@ const HOME = os.homedir();
 const STATE_DIR = path.join(HOME, ".claude-smart");
 const REFLEXIO_DIR = path.join(HOME, ".reflexio");
 const DEFAULT_BACKEND_PORT = 8071;
-const FALLBACK_BACKEND_PORT = 8072;
 const DASHBOARD_PORT = 3001;
 const LOG_MAX_BYTES = 10000000;
 
@@ -223,11 +222,6 @@ function backendUrlFile() {
   return stateFile("backend-url");
 }
 
-function writeBackendUrl(port) {
-  ensureDir(STATE_DIR);
-  fs.writeFileSync(backendUrlFile(), `http://localhost:${port}/\n`);
-}
-
 function unquoteEnvValue(value) {
   const trimmed = String(value || "").trim();
   if (trimmed.length >= 2) {
@@ -279,12 +273,6 @@ function loadReflexioEnv() {
   }
 }
 
-function reflexioUrlIsRemote() {
-  const url = process.env.REFLEXIO_URL || "";
-  if (!url) return false;
-  return !/^http:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i.test(url);
-}
-
 function codexCompatPath(root) {
   const filename = process.platform === "win32"
     ? "codex-claude-compat.cmd"
@@ -322,29 +310,6 @@ function healthOk(port, pathname, markerHeader) {
     );
     req.on("timeout", () => req.destroy());
     req.on("error", () => resolve(false));
-    req.end();
-  });
-}
-
-function portOccupied(port) {
-  return new Promise((resolve) => {
-    const req = http.request(
-      {
-        host: "127.0.0.1",
-        port,
-        path: "/",
-        method: "GET",
-        timeout: 900,
-      },
-      (res) => {
-        res.resume();
-        resolve(true);
-      },
-    );
-    req.on("timeout", () => req.destroy());
-    req.on("error", (err) => {
-      resolve(err && err.code !== "ECONNREFUSED");
-    });
     req.end();
   });
 }
@@ -439,76 +404,38 @@ function ensurePluginRoot(root) {
 
 async function startBackend(root) {
   trimLog(path.join(STATE_DIR, "backend.log"));
-  if (process.env.CLAUDE_SMART_BACKEND_AUTOSTART === "0") {
+  const bash = bashPath();
+  const script = path.join(root, "scripts", "backend-service.sh");
+  if (!bash || !fs.existsSync(script)) {
+    appendLog("backend.log", "[claude-smart] backend: backend-service.sh unavailable; skipping local backend start");
     emitOk();
     return;
   }
-  if (reflexioUrlIsRemote()) {
-    appendLog("backend.log", "[claude-smart] backend: remote REFLEXIO_URL configured; skipping local backend start");
-    emitOk();
-    return;
-  }
-  const pidFile = path.join(STATE_DIR, "backend.pid");
-  for (const port of [DEFAULT_BACKEND_PORT, FALLBACK_BACKEND_PORT]) {
-    if (pidAlive(readPid(pidFile)) && await healthOk(port, "/health")) {
-      writeBackendUrl(port);
-      emitOk();
-      return;
-    }
-    if (await healthOk(port, "/health")) {
-      writeBackendUrl(port);
-      emitOk();
-      return;
-    }
-  }
-  const uv = uvPath();
-  if (!uv) {
-    startInstallerDetached(root, "backend: uv not on PATH");
-  }
-  const readyUv = uvPath();
-  if (!readyUv) {
-    appendLog("backend.log", "[claude-smart] backend: uv not on PATH; installer recovery scheduled; skipping");
-    emitOk();
-    return;
-  }
-  let selectedPort = DEFAULT_BACKEND_PORT;
-  if (await portOccupied(DEFAULT_BACKEND_PORT)) {
-    appendLog("backend.log", "[claude-smart] backend: port 8071 occupied; trying 8072");
-    selectedPort = FALLBACK_BACKEND_PORT;
-  }
-  const backendUrl = `http://localhost:${selectedPort}/`;
-  const env = {
-    ...process.env,
-    BACKEND_PORT: String(selectedPort),
-    REFLEXIO_URL: backendUrl,
-    CLAUDE_SMART_USE_LOCAL_CLI: process.env.CLAUDE_SMART_USE_LOCAL_CLI || "1",
-    CLAUDE_SMART_USE_LOCAL_EMBEDDING: process.env.CLAUDE_SMART_USE_LOCAL_EMBEDDING || "1",
-    CLAUDE_SMART_HOST: "codex",
-    CLAUDE_SMART_CLI_PATH: process.env.CLAUDE_SMART_CLI_PATH || codexCompatPath(root),
-    INTERACTION_CLEANUP_THRESHOLD: process.env.INTERACTION_CLEANUP_THRESHOLD || "500",
-    INTERACTION_CLEANUP_DELETE_COUNT: process.env.INTERACTION_CLEANUP_DELETE_COUNT || "200",
-  };
-  const pid = detached(
-    readyUv,
-    [
-      "run",
-      "--project",
-      root,
-      "--quiet",
-      "reflexio",
-      "services",
-      "start",
-      "--only",
-      "backend",
-      "--no-reload",
-    ],
-    { cwd: root, env },
+  const result = spawnSync(
+    bash,
+    [script, "start"],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        CLAUDE_SMART_HOST: "codex",
+        CLAUDE_SMART_CLI_PATH: process.env.CLAUDE_SMART_CLI_PATH || codexCompatPath(root),
+      },
+      text: true,
+      encoding: "utf8",
+      input: "",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 45000,
+      windowsHide: true,
+    },
   );
-  writePid(pidFile, pid);
-  if (await waitForHealth(selectedPort, "/health", null, 10)) {
-    writeBackendUrl(selectedPort);
+  if (result.error) {
+    appendLog("backend.log", `[claude-smart] backend-service.sh failed to run: ${result.error.message}`);
   }
-  emitOk();
+  if (result.stderr) {
+    appendLog("backend.log", `[claude-smart] backend-service.sh stderr: ${String(result.stderr).slice(0, 1000)}`);
+  }
+  emitNormalizedHookOutput(result.stdout);
 }
 
 async function startDashboard(root) {

--- a/tests/test_codex_support.py
+++ b/tests/test_codex_support.py
@@ -55,9 +55,14 @@ def test_codex_hook_loads_managed_reflexio_env_and_skips_backend_start() -> None
     assert "function loadReflexioEnv()" in script
     assert '"REFLEXIO_API_KEY"' in script
     assert '"CLAUDE_SMART_READ_ONLY"' in script
-    assert "function reflexioUrlIsRemote()" in script
-    assert "remote REFLEXIO_URL configured; skipping local backend start" in script
     assert "loadReflexioEnv();" in script
+    # Backend start (including the remote-REFLEXIO_URL skip) is delegated to
+    # backend-service.sh; codex-hook.js no longer decides locally.
+    assert "function reflexioUrlIsRemote()" not in script
+    assert '[script, "start"]' in script
+    assert "backend-service.sh" in script
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+    assert "remote REFLEXIO_URL configured; skipping local backend start" in backend
 
 
 def test_codex_marketplace_points_at_plugin_root() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -467,8 +467,7 @@ def test_detached_spawns_with_log_redirection_preserve_output_on_windows() -> No
     ) in dashboard
     assert (
         "CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached "
-        '"$NPM_BIN" run start >>"$LOG_FILE" 2>&1'
-        in dashboard
+        '"$NPM_BIN" run start >>"$LOG_FILE" 2>&1' in dashboard
     )
 
 
@@ -909,7 +908,7 @@ def test_node_installer_updates_existing_host_and_local_defaults(
     runtime_env_path = tmp_path / ".claude-smart" / ".env"
     env_path.parent.mkdir()
     runtime_env_path.parent.mkdir()
-    stale = "# keep\nCLAUDE_SMART_HOST=codex\nCLAUDE_SMART_READ_ONLY=\"1\"\n"
+    stale = '# keep\nCLAUDE_SMART_HOST=codex\nCLAUDE_SMART_READ_ONLY="1"\n'
     env_path.write_text(stale)
     runtime_env_path.write_text(stale)
     script = (
@@ -1252,6 +1251,25 @@ def test_dashboard_service_restarts_stale_claude_smart_dashboard() -> None:
     assert "stale claude-smart dashboard on port $PORT; restarting" in dashboard
     assert "stop_dashboard_listener" in dashboard
     assert "foreign app on 3001 is never killed" in dashboard
+
+
+def test_backend_service_verifies_current_plugin_identity() -> None:
+    backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+
+    assert 'export CLAUDE_SMART_BACKEND="1"' in backend
+    assert 'export CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"' in backend
+    assert 'export CLAUDE_SMART_VERSION="$PLUGIN_VERSION"' in backend
+    assert "backend_matches_current_root()" in backend
+    assert "x-claude-smart-backend" in backend
+    assert "x-claude-smart-plugin-root" in backend
+    assert "normalize_identity_path()" in backend
+    assert "cygpath -u" in backend
+    assert 'expected_root="$(normalize_identity_path ' in backend
+    assert 'actual_root="$(normalize_identity_path "$actual_root")"' in backend
+    assert '[ "$actual_root" = "$expected_root" ]' in backend
+    assert "stale claude-smart backend on port $PORT; restarting" in backend
+    assert "replaced legacy claude-smart backend" in backend
+    assert "foreign or legacy backend on http://localhost:$PORT" in backend
 
 
 def test_installers_start_backend_and_refresh_dashboard_services() -> None:
@@ -1792,9 +1810,9 @@ def test_smart_install_rerun_preserves_existing_host(tmp_path: Path) -> None:
 
     assert second.returncode == 0, second.stderr
     env_lines = runtime_env.read_text().splitlines()
-    assert [
-        line for line in env_lines if line.startswith("CLAUDE_SMART_HOST=")
-    ] == ["CLAUDE_SMART_HOST=opencode"]
+    assert [line for line in env_lines if line.startswith("CLAUDE_SMART_HOST=")] == [
+        "CLAUDE_SMART_HOST=opencode"
+    ]
     assert (tmp_path / "uv.log").read_text().count(
         "sync --locked --python 3.12 --quiet"
     ) == 1
@@ -1853,7 +1871,15 @@ def test_smart_install_redirects_reflexio_stray_copies_to_stable_root(
     ~/.reflexio), so it must hold regardless of the mangled name's prefix/case.
     """
     session_root = tmp_path / ".reflexio" / copy_dirname / "plugin"
-    stable_root = tmp_path / ".claude" / "plugins" / "cache" / "reflexioai" / "claude-smart" / "0.2.42"
+    stable_root = (
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.2.42"
+    )
     fake_bin = tmp_path / "bin"
     for root in (session_root, stable_root):
         scripts = root / "scripts"
@@ -1910,7 +1936,15 @@ def test_smart_install_redirects_reflexio_stray_copies_to_stable_root(
 
 
 def test_ensure_plugin_root_canonicalizes_symlink_target(tmp_path: Path) -> None:
-    plugin_root = tmp_path / ".codex" / "plugins" / "cache" / "reflexioai" / "claude-smart" / "0.2.43"
+    plugin_root = (
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.2.43"
+    )
     scripts = plugin_root / "scripts"
     scripts.mkdir(parents=True)
     shutil.copy2(
@@ -2039,12 +2073,13 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     """claude-smart reports degraded vectors; Reflexio owns MiniLM cache repair."""
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
-    assert "embedding_healthy()" in backend
-    assert 'http://127.0.0.1:$EMBEDDING_PORT/health' in backend
-    assert "--connect-timeout 1 --max-time 1" in backend
+    assert "embedding_healthy()" not in backend
+    assert "embedding_matches_current_root()" in backend
+    assert 'health_headers "$EMBEDDING_PORT" "/health"' in backend
+    assert "--connect-timeout 2 --max-time 5" in backend
     assert "wait_for_health()" in backend
-    assert "wait_for_health backend_healthy 10 1" in backend
-    assert "wait_for_health embedding_healthy 5 3" in backend
+    assert "wait_for_health backend_matches_current_root 10 1" in backend
+    assert "wait_for_health embedding_matches_current_root 5 3" in backend
     assert "spawn_backend()" not in backend
     assert "Embedding service did not become healthy" in backend
     assert "semantic retrieval remains unavailable" in backend
@@ -2057,11 +2092,11 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     start_case = start_match.group("body")
     assert "full_stop" not in start_case
     assert "backend_started" not in start_case
-    assert "if wait_for_health backend_healthy 10 1; then" in start_case
-    assert "if ! wait_for_health embedding_healthy 5 3; then" in start_case
+    assert "if wait_for_health backend_matches_current_root 10 1; then" in start_case
+    assert "if ! wait_for_health embedding_matches_current_root 5 3; then" in start_case
     assert (
         "running on http://localhost:$PORT "
-        "(embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
+        "(plugin $PLUGIN_VERSION at $PLUGIN_ROOT_CANONICAL; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
     ) in backend
 
     bin_dir = tmp_path / "bin"
@@ -2071,7 +2106,15 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
         "#!/bin/sh\n"
         'printf "%s\\n" "$*" >> "$HOME/curl.log"\n'
         'case " $* " in\n'
-        '  *" http://127.0.0.1:8071/health "*) exit 0 ;;\n'
+        '  *" http://127.0.0.1:8071/health "*)\n'
+        '    case " $* " in *" -D - "*)\n'
+        '      printf "HTTP/1.1 200 OK\\r\\n"\n'
+        '      printf "x-claude-smart-backend: 1\\r\\n"\n'
+        '      printf "x-claude-smart-plugin-root: %s\\r\\n" "$CLAUDE_SMART_PLUGIN_ROOT"\n'
+        "      ;;\n"
+        "    esac\n"
+        "    exit 0\n"
+        "    ;;\n"
         '  *" http://127.0.0.1:8072/health "*) exit 22 ;;\n'
         "esac\n"
         "exit 22\n",
@@ -2088,7 +2131,11 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     )
 
     status = subprocess.run(
-        ["bash", str(REPO_ROOT / "plugin" / "scripts" / "backend-service.sh"), "status"],
+        [
+            "bash",
+            str(REPO_ROOT / "plugin" / "scripts" / "backend-service.sh"),
+            "status",
+        ],
         env=env,
         text=True,
         capture_output=True,
@@ -2098,7 +2145,8 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     assert status.returncode == 0, status.stderr
     assert status.stdout.strip() == (
         "running on http://localhost:8071 "
-        "(embedding degraded on http://127.0.0.1:8072)"
+        f"(plugin {json.loads((REPO_ROOT / 'plugin' / '.codex-plugin' / 'plugin.json').read_text())['version']} at {REPO_ROOT / 'plugin'}; "
+        "embedding degraded on http://127.0.0.1:8072)"
     )
 
     start = subprocess.run(
@@ -2138,9 +2186,7 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     cold_bin_dir.mkdir()
     _write_executable(
         cold_bin_dir / "uv",
-        "#!/bin/sh\n"
-        'printf "uv %s\\n" "$*" >> "$HOME/uv.log"\n'
-        "exit 0\n",
+        '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
     )
     _write_executable(cold_bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
     _write_executable(
@@ -2150,9 +2196,17 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
         'case " $* " in\n'
         '  *" http://127.0.0.1:8071/health "*)\n'
         '    count=$(cat "$HOME/backend-health-count" 2>/dev/null || echo 0)\n'
-        '    count=$((count + 1))\n'
+        "    count=$((count + 1))\n"
         '    printf "%s\\n" "$count" > "$HOME/backend-health-count"\n'
-        '    [ "$count" -ge 3 ] && exit 0\n'
+        '    if [ "$count" -ge 3 ]; then\n'
+        '      case " $* " in *" -D - "*)\n'
+        '        printf "HTTP/1.1 200 OK\\r\\n"\n'
+        '        printf "x-claude-smart-backend: 1\\r\\n"\n'
+        '        printf "x-claude-smart-plugin-root: %s\\r\\n" "$CLAUDE_SMART_PLUGIN_ROOT"\n'
+        "        ;;\n"
+        "      esac\n"
+        "      exit 0\n"
+        "    fi\n"
         "    exit 22\n"
         "    ;;\n"
         '  *" http://127.0.0.1:8072/health "*) exit 22 ;;\n'
@@ -2196,15 +2250,17 @@ def test_backend_service_full_stop_reaps_embedding_port() -> None:
     """
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
-    assert 'reap_port_listeners "$PORT"' in backend
-    assert 'reap_port_listeners "$EMBEDDING_PORT"' in backend
-    assert "'*reflexio.server.llm.embedding_service:app*'" in backend
-    assert "'*reflexio*embedding_service*'" in backend
-    assert "'*embedding_service*'" not in backend
+    assert "stop_marked_backend_listener" in backend
+    assert "stop_legacy_backend_listener_if_owned" in backend
+    assert "stop_stale_embedding_listener_if_owned" in backend
+    assert "x-claude-smart-embedding" in backend
+    assert "looks_like_claude_smart_backend_pid" in backend
+    assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in backend
     assert (
         "reap_port_listeners \"$EMBEDDING_PORT\" '*reflexio*' '*uvicorn*'"
         not in backend
     )
+    assert "reap_port_listeners()" not in backend
 
 
 def test_backend_service_surfaces_port_holder_on_skip() -> None:
@@ -2225,9 +2281,11 @@ def test_codex_hook_recovers_missing_dependencies_without_cli_command() -> None:
     script = CODEX_HOOK.read_text()
 
     assert "function startInstallerDetached(root, reason)" in script
-    assert 'startInstallerDetached(root, "backend: uv not on PATH")' in script
     assert 'startInstallerDetached(root, "dashboard: npm not on PATH")' in script
     assert 'startInstallerDetached(root, "hook: uv not on PATH")' in script
+    assert 'path.join(root, "scripts", "backend-service.sh")' in script
+    assert '[script, "start"]' in script
+    assert "port 8071 occupied; trying 8072" not in script
 
 
 def test_smart_install_waits_on_existing_lock() -> None:
@@ -2878,7 +2936,9 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _npm_install_global_tarball(tarball: Path, *, prefix: Path, env: dict[str, str]) -> None:
+def _npm_install_global_tarball(
+    tarball: Path, *, prefix: Path, env: dict[str, str]
+) -> None:
     npm = shutil.which("npm")
     if not npm:
         pytest.skip("npm is required for package install smoke tests")
@@ -2931,7 +2991,9 @@ def _install_opencode_tarball_fixture(
     _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
 
     env = os.environ.copy()
-    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    test_path = (
+        f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    )
     env.update(
         {
             "HOME": str(home),
@@ -3001,9 +3063,7 @@ def _assert_installed_host_learning_e2e(
             "HOME": str(home),
             "PYTHONPATH": os.pathsep.join(pythonpath_entries),
             "CLAUDE_SMART_STATE_DIR": str(home / ".claude-smart" / f"{host}-sessions"),
-            "CLAUDE_SMART_HOOK_LOG": str(
-                home / ".claude-smart" / f"{host}-hook.log"
-            ),
+            "CLAUDE_SMART_HOOK_LOG": str(home / ".claude-smart" / f"{host}-hook.log"),
             "CLAUDE_SMART_ENABLE_OPTIMIZER": "0",
             "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
             "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
@@ -3051,7 +3111,9 @@ def test_claude_code_fresh_tarball_install_prepares_matching_cache(
     _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
 
     env = os.environ.copy()
-    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    test_path = (
+        f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    )
     env.update(
         {
             "HOME": str(home),
@@ -3081,7 +3143,9 @@ def test_claude_code_fresh_tarball_install_prepares_matching_cache(
     installed_package = prefix / "lib" / "node_modules" / "claude-smart"
     version = next(
         line.split("=", 1)[1].strip().strip('"')
-        for line in (installed_package / "plugin" / "pyproject.toml").read_text().splitlines()
+        for line in (installed_package / "plugin" / "pyproject.toml")
+        .read_text()
+        .splitlines()
         if line.strip().startswith("version =")
     )
     cache_plugin = (
@@ -3130,7 +3194,9 @@ def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
     _write_bootstrap_uv(uv_bin / "uv", mode="fresh")
 
     env = os.environ.copy()
-    test_path = f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    test_path = (
+        f"{prefix / 'bin'}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    )
     env.update(
         {
             "HOME": str(home),
@@ -3166,13 +3232,7 @@ def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
         home / ".claude" / "plugins" / "marketplaces" / "reflexioai" / "plugin"
     )
     cache_plugin = (
-        home
-        / ".codex"
-        / "plugins"
-        / "cache"
-        / "reflexioai"
-        / "claude-smart"
-        / version
+        home / ".codex" / "plugins" / "cache" / "reflexioai" / "claude-smart" / version
     )
     for root in [marketplace_plugin, cache_plugin]:
         assert (root / "pyproject.toml").exists()
@@ -3258,8 +3318,8 @@ def test_opencode_fresh_tarball_install_uses_local_file_plugin(
 def test_opencode_fresh_tarball_uninstall_removes_plugin_and_keeps_data(
     tmp_path: Path,
 ) -> None:
-    home, prefix, project, xdg, env, install_result = (
-        _install_opencode_tarball_fixture(tmp_path)
+    home, prefix, project, xdg, env, install_result = _install_opencode_tarball_fixture(
+        tmp_path
     )
     assert install_result.returncode == 0, install_result.stderr
 
@@ -3502,7 +3562,9 @@ def test_node_installer_preserves_occupied_plugin_root(tmp_path: Path) -> None:
     node = shutil.which("node")
     if not node:
         pytest.skip("node is required for installer wrapper tests")
-    home, plugin_root, env = _prepare_node_bootstrap_sync_fixture(tmp_path, mode="fresh")
+    home, plugin_root, env = _prepare_node_bootstrap_sync_fixture(
+        tmp_path, mode="fresh"
+    )
     occupied = home / ".reflexio" / "plugin-root"
     occupied.mkdir(parents=True)
     sentinel = occupied / "keep.txt"
@@ -3537,7 +3599,9 @@ def test_node_installer_windows_local_embedding_preflight_surfaces_marker(
     node = shutil.which("node")
     if not node:
         pytest.skip("node is required for installer wrapper tests")
-    home, plugin_root, env = _prepare_node_bootstrap_sync_fixture(tmp_path, mode="fresh")
+    home, plugin_root, env = _prepare_node_bootstrap_sync_fixture(
+        tmp_path, mode="fresh"
+    )
     scripts = plugin_root / "scripts"
     scripts.mkdir()
     shutil.copy2(LIB, scripts / "_lib.sh")
@@ -3602,9 +3666,7 @@ def test_node_installer_windows_local_embedding_preflight_surfaces_marker(
 
 
 def test_node_installer_non_lock_sync_failure_stays_strict(tmp_path: Path) -> None:
-    result, home, plugin_root = _run_node_bootstrap(
-        tmp_path, mode="non_lock_failure"
-    )
+    result, home, plugin_root = _run_node_bootstrap(tmp_path, mode="non_lock_failure")
 
     assert result.returncode == 1
     assert "uv sync failed" in result.stderr
@@ -3819,7 +3881,9 @@ def test_windows_private_node_path_skips_posix_bin_probe(tmp_path: Path) -> None
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    assert result.stdout.split(":", 1)[0] == str(tmp_path / ".claude-smart" / "node" / "current")
+    assert result.stdout.split(":", 1)[0] == str(
+        tmp_path / ".claude-smart" / "node" / "current"
+    )
 
 
 def test_windows_path_conversion_falls_back_without_cygpath(tmp_path: Path) -> None:
@@ -3887,21 +3951,21 @@ def test_windows_plugin_root_tracks_cache_junction_metadata(tmp_path: Path) -> N
     _write_executable(
         fake_bin / "cmd.exe",
         "#!/bin/sh\n"
-        "[ \"$1\" = \"//C\" ] || exit 2\n"
+        '[ "$1" = "//C" ] || exit 2\n'
         "shift\n"
-        "case \"$1\" in\n"
+        'case "$1" in\n'
         "  rmdir)\n"
-        "    rm -rf \"$2\"\n"
+        '    rm -rf "$2"\n'
         "    exit 0\n"
         "    ;;\n"
         "  mklink)\n"
-        "    [ \"$2\" = \"//J\" ] || exit 3\n"
-        "    link=\"$3\"\n"
-        "    target=\"$4\"\n"
-        "    rm -rf \"$link\"\n"
-        "    mkdir -p \"$link\"\n"
-        "    cp \"$target/pyproject.toml\" \"$link/pyproject.toml\"\n"
-        "    printf '%s\\n' \"$target\" > \"$link/target.txt\"\n"
+        '    [ "$2" = "//J" ] || exit 3\n'
+        '    link="$3"\n'
+        '    target="$4"\n'
+        '    rm -rf "$link"\n'
+        '    mkdir -p "$link"\n'
+        '    cp "$target/pyproject.toml" "$link/pyproject.toml"\n'
+        '    printf \'%s\\n\' "$target" > "$link/target.txt"\n'
         "    exit 0\n"
         "    ;;\n"
         "esac\n"
@@ -3911,7 +3975,12 @@ def test_windows_plugin_root_tracks_cache_junction_metadata(tmp_path: Path) -> N
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
 
     first = subprocess.run(
-        ["/bin/bash", str(scripts / "ensure-plugin-root.sh"), str(old_cache), "--force"],
+        [
+            "/bin/bash",
+            str(scripts / "ensure-plugin-root.sh"),
+            str(old_cache),
+            "--force",
+        ],
         env=env,
         text=True,
         capture_output=True,
@@ -3928,12 +3997,16 @@ def test_windows_plugin_root_tracks_cache_junction_metadata(tmp_path: Path) -> N
     link = tmp_path / ".reflexio" / "plugin-root"
     assert first.returncode == 0, first.stderr
     assert second.returncode == 0, second.stderr
-    assert (tmp_path / ".reflexio" / "plugin-root.txt").read_text().strip() == str(new_cache)
+    assert (tmp_path / ".reflexio" / "plugin-root.txt").read_text().strip() == str(
+        new_cache
+    )
     assert (link / "target.txt").read_text().strip() == str(new_cache)
     assert "cache-tracking, was" in second.stderr
 
 
-def test_windows_plugin_root_warns_when_junction_metadata_missing(tmp_path: Path) -> None:
+def test_windows_plugin_root_warns_when_junction_metadata_missing(
+    tmp_path: Path,
+) -> None:
     scripts = tmp_path / "plugin" / "scripts"
     scripts.mkdir(parents=True)
     shutil.copy2(
@@ -3941,7 +4014,15 @@ def test_windows_plugin_root_warns_when_junction_metadata_missing(tmp_path: Path
         scripts / "ensure-plugin-root.sh",
     )
     shutil.copy2(REPO_ROOT / "plugin" / "scripts" / "_lib.sh", scripts / "_lib.sh")
-    new_root = tmp_path / ".codex" / "plugins" / "cache" / "reflexioai" / "claude-smart" / "0.2.48"
+    new_root = (
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.2.48"
+    )
     new_root.mkdir(parents=True)
     (new_root / "pyproject.toml").write_text("[project]\nname='new'\n")
     link = tmp_path / ".reflexio" / "plugin-root"
@@ -3977,7 +4058,9 @@ def test_windows_private_node_current_uses_backup_restore() -> None:
     assert 'mv "$install_dir" "$node_root/current"' in smart_install
     assert 'if ! mv "$old_current" "$node_root/current"; then' in smart_install
     assert "could not restore previous private Node.js install" in smart_install
-    assert "previous install remains at $old_current for manual recovery" in smart_install
+    assert (
+        "previous install remains at $old_current for manual recovery" in smart_install
+    )
     assert 'rm -rf "$node_root/current" 2>/dev/null || true' not in smart_install
 
 
@@ -4171,9 +4254,10 @@ def test_codex_hook_redirects_reflexio_stray_copy_to_stable_root(
     assert (reflexio / "plugin-root").resolve() == stable_root
     assert json.loads(result.stdout) == {"continue": True}
     assert not (reflexio / "plugin-root").resolve() == stray_root
-    assert "redirecting stray plugin copy" in (
-        tmp_path / ".claude-smart" / "backend.log"
-    ).read_text()
+    assert (
+        "redirecting stray plugin copy"
+        in (tmp_path / ".claude-smart" / "backend.log").read_text()
+    )
 
 
 def test_codex_hook_preserves_occupied_plugin_root(tmp_path: Path) -> None:
@@ -4181,7 +4265,15 @@ def test_codex_hook_preserves_occupied_plugin_root(tmp_path: Path) -> None:
     if not node:
         pytest.skip("node is required for codex hook wrapper tests")
 
-    plugin_root = tmp_path / ".codex" / "plugins" / "cache" / "reflexioai" / "claude-smart" / "0.2.47"
+    plugin_root = (
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.2.47"
+    )
     plugin_root.mkdir(parents=True)
     (plugin_root / "pyproject.toml").write_text("[project]\nname='claude-smart'\n")
     occupied = tmp_path / ".reflexio" / "plugin-root"


### PR DESCRIPTION
## Summary
- Backend port ownership was decided by a bare `GET /health` probe, which cannot tell *our* backend apart from any other Reflexio (or stale/foreign) process bound to the same port. This PR makes ownership decisions based on **runtime identity** instead of mere liveness.
- The backend now advertises its identity via `x-claude-smart-*` response headers (backend marker, plugin root, version), and management logic only treats a listener as "ours" when its plugin root matches the current one.
- `codex-hook.js` no longer duplicates backend-start logic (port selection, remote-URL skip, fallback to 8072); it delegates entirely to `backend-service.sh start`, keeping a single source of truth.

## Changes
**`plugin/scripts/backend-service.sh`**
- Export identity env vars on launch: `CLAUDE_SMART_BACKEND=1`, `CLAUDE_SMART_PLUGIN_ROOT` (canonical), `CLAUDE_SMART_VERSION`.
- New identity helpers: `health_headers`, `header_value_from`, `canonical_dir`, `normalize_identity_path` (cross-platform, incl. `cygpath`/Windows drive normalization), `identity_matches_current_root`.
- Replace liveness checks with root-matching checks: `backend_matches_current_root`, `embedding_matches_current_root`, plus `backend_has_claude_smart_marker`.
- Replace pattern-based `reap_port_listeners` with identity-aware teardown: `port_listener_pids`, `pid_details`, `looks_like_claude_smart_backend_pid`, `stop_port_pids`, `stop_marked_backend_listener`, `stop_legacy_backend_listener_if_owned`, `stop_stale_embedding_listener_if_owned`. Foreign services on the same ports are left untouched.
- `status` now reports plugin version + root, and distinguishes stale-claude-smart / foreign-legacy / not-running states.

**`plugin/scripts/codex-hook.js`**
- `startBackend` now shells out to `backend-service.sh start` and normalizes its hook output; removes the local port-selection, `writeBackendUrl`, `reflexioUrlIsRemote`, `portOccupied`, and 8072-fallback code.

**Tests**
- `tests/test_install_scripts.py`, `tests/test_codex_support.py`: assert the new identity-header contract, the delegation to `backend-service.sh`, and the updated `status` output; drop assertions on the removed helpers.

## Test Plan
- `uv run pytest tests/test_install_scripts.py tests/test_codex_support.py -o 'addopts='`
- The `status` integration test drives `backend-service.sh` with a stub `curl` that emits `x-claude-smart-*` headers and verifies the version/root-aware status line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved backend startup and status reporting with clearer plugin/version information.
  * Added smarter identity checks so the app can detect the correct local backend and embedding service.

* **Bug Fixes**
  * Reduced false “running” detections by verifying service identity instead of only checking if a port responds.
  * Improved shutdown behavior so only the correct related processes are stopped, avoiding unintended cleanup of unrelated listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->