### PR TITLE
fix: isolate claude-smart reflexio runtime

### DIFF
--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -64,20 +64,12 @@ fi
 PLUGIN_ROOT="$(cd "$HERE/.." && pwd)"
 claude_smart_reexec_stable_plugin_root_if_needed "$PLUGIN_ROOT" "backend-service.sh" "$@"
 PLUGIN_ROOT_CANONICAL="$(cd "$PLUGIN_ROOT" 2>/dev/null && pwd -P || printf '%s\n' "$PLUGIN_ROOT")"
-PLUGIN_VERSION="$(
-  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
-    "$PLUGIN_ROOT/.codex-plugin/plugin.json" 2>/dev/null | head -n1
-)"
-if [ -z "$PLUGIN_VERSION" ]; then
-  PLUGIN_VERSION="$(
-    sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
-      "$PLUGIN_ROOT/pyproject.toml" 2>/dev/null | head -n1
-  )"
+VENDORED_REFLEXIO="$PLUGIN_ROOT_CANONICAL/vendor/reflexio"
+VENDORED_REFLEXIO_FOR_PYTHON="$VENDORED_REFLEXIO"
+if claude_smart_is_windows; then
+  VENDORED_REFLEXIO_FOR_PYTHON="$(claude_smart_to_windows_path "$VENDORED_REFLEXIO")"
 fi
-PLUGIN_VERSION="${PLUGIN_VERSION:-unknown}"
-export CLAUDE_SMART_BACKEND="1"
-export CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"
-export CLAUDE_SMART_VERSION="$PLUGIN_VERSION"
+export CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON"
 
 if [ -z "${CLAUDE_SMART_CLI_PATH:-}" ]; then
   if [ "${CLAUDE_SMART_HOST:-claude-code}" = "opencode" ]; then
@@ -149,91 +141,11 @@ kill_group() {
   claude_smart_kill_tree "$1"
 }
 
-health_headers() {
-  port="$1"
-  path="${2:-/health}"
-  command -v curl >/dev/null 2>&1 || return 1
-  curl -sf --connect-timeout 2 --max-time 5 -D - -o /dev/null "http://127.0.0.1:$port$path" 2>/dev/null
-}
-
-header_value_from() {
-  header_name="$1"
-  awk -v wanted="$header_name" '
-    BEGIN { wanted = tolower(wanted) ":" }
-    {
-      line = $0
-      sub(/\r$/, "", line)
-      lower = tolower(line)
-      if (index(lower, wanted) == 1) {
-        sub(/^[^:]*:[[:space:]]*/, "", line)
-        print line
-        exit
-      }
-    }
-  '
-}
-
-canonical_dir() {
-  dir="$1"
-  (cd "$dir" 2>/dev/null && pwd -P) || printf '%s\n' "$dir"
-}
-
-normalize_identity_path() {
-  path="$1"
-  if claude_smart_is_windows; then
-    if command -v cygpath >/dev/null 2>&1; then
-      path="$(cygpath -u "$path" 2>/dev/null || printf '%s\n' "$path")"
-    else
-      path="$(
-        printf '%s\n' "$path" | awk '{
-          gsub(/\\/, "/")
-          if ($0 ~ /^[A-Za-z]:/) {
-            drive = tolower(substr($0, 1, 1))
-            sub(/^[A-Za-z]:/, "/" drive)
-          }
-          print
-        }'
-      )"
-    fi
-  fi
-  while [ "${path%/}" != "$path" ] && [ "$path" != "/" ]; do
-    path="${path%/}"
-  done
-  printf '%s\n' "$path"
-}
-
-identity_matches_current_root() {
-  marker="$1"
-  headers="$2"
-  expected_root="$(normalize_identity_path "$(canonical_dir "$PLUGIN_ROOT")")"
-  printf '%s\n' "$headers" | grep -qi "^$marker:" || return 1
-  actual_root="$(printf '%s\n' "$headers" | header_value_from "x-claude-smart-plugin-root")"
-  [ -n "$actual_root" ] || return 1
-  actual_root="$(normalize_identity_path "$actual_root")"
-  [ "$actual_root" = "$expected_root" ]
-}
-
 # True if /health returns 200, regardless of runtime identity. Used only for
-# generic liveness; ownership checks use backend_matches_current_root.
+# generic liveness; ownership checks inspect the listener process.
 backend_healthy() {
   command -v curl >/dev/null 2>&1 || return 1
   curl -sf --connect-timeout 1 --max-time 1 -o /dev/null "http://127.0.0.1:$PORT/health" 2>/dev/null
-}
-
-backend_has_claude_smart_marker() {
-  headers="$(health_headers "$PORT" "/health")" || return 1
-  printf '%s\n' "$headers" | grep -qi '^x-claude-smart-backend:'
-}
-
-backend_matches_current_root() {
-  headers="$(health_headers "$PORT" "/health")" || return 1
-  identity_matches_current_root "x-claude-smart-backend" "$headers"
-}
-
-embedding_matches_current_root() {
-  [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
-  headers="$(health_headers "$EMBEDDING_PORT" "/health")" || return 1
-  identity_matches_current_root "x-claude-smart-embedding" "$headers"
 }
 
 wait_for_health() {
@@ -251,26 +163,6 @@ wait_for_health() {
 log_embedding_degraded() {
   claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
     "[claude-smart] backend: Embedding service did not become healthy on port $EMBEDDING_PORT; semantic retrieval remains unavailable until the local embedding daemon recovers"
-}
-
-# True only if the recorded PID is alive AND /health responds. A stale
-# PID file from a crashed backend is not enough — we must see the port
-# actually answer, so next hook retries cleanly.
-is_our_backend_running() {
-  if [ -f "$PID_FILE" ]; then
-    pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      if command -v curl >/dev/null 2>&1; then
-        backend_matches_current_root && return 0
-      else
-        return 0
-      fi
-    fi
-  fi
-  # Recover from a missing PID file only when the listener proves it belongs
-  # to this plugin root. A generic healthy Reflexio process is not enough.
-  backend_matches_current_root && return 0
-  return 1
 }
 
 # Best-effort port probe. curl catches responsive HTTP listeners; /dev/tcp
@@ -305,10 +197,105 @@ looks_like_claude_smart_backend_pid() {
   text="$(pid_details "$pid")"
   [ -n "$text" ] || return 1
   case "$text" in
-    *CLAUDE_SMART_BACKEND=1*|*CLAUDE_SMART_USE_LOCAL_CLI=1*|*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*|*".claude-smart/.env"*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"local-agent-mode-sessions"*|*"$PLUGIN_ROOT_CANONICAL"*|*"$HOME/.reflexio/plugin-root"*)
+    *CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=*|*CLAUDE_SMART_USE_LOCAL_CLI=1*|*CLAUDE_SMART_USE_LOCAL_EMBEDDING=1*|*".claude-smart/.env"*|*"reflexioai/claude-smart"*|*"reflexioai\\claude-smart"*|*"local-agent-mode-sessions"*|*"$PLUGIN_ROOT_CANONICAL"*|*"$HOME/.reflexio/plugin-root"*)
       return 0
       ;;
   esac
+  return 1
+}
+
+pid_uses_current_vendor_root() {
+  pid="$1"
+  text="$(pid_details "$pid")"
+  [ -n "$text" ] || return 1
+  case "$text" in
+    *"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO"*|*"CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"PYTHONPATH=$VENDORED_REFLEXIO"*|*"PYTHONPATH=$VENDORED_REFLEXIO_FOR_PYTHON"*|*"$VENDORED_REFLEXIO"*|*"$VENDORED_REFLEXIO_FOR_PYTHON"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+backend_owned_by_current_vendor() {
+  backend_healthy || return 1
+  pids="$(port_listener_pids "$PORT")"
+  for pid in $pids; do
+    if looks_like_claude_smart_backend_pid "$pid" && pid_uses_current_vendor_root "$pid"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+backend_owned_by_stale_claude_smart() {
+  pids="$(port_listener_pids "$PORT")"
+  for pid in $pids; do
+    if looks_like_claude_smart_backend_pid "$pid" && ! pid_uses_current_vendor_root "$pid"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+embedding_owned_by_current_vendor() {
+  [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
+  pids="$(port_listener_pids "$EMBEDDING_PORT")"
+  for pid in $pids; do
+    if looks_like_claude_smart_backend_pid "$pid" && pid_uses_current_vendor_root "$pid"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+verify_bundled_reflexio_import() {
+  python_bin="$1"
+  pythonpath="$2"
+  vendor_root_for_python="$3"
+  [ -d "$VENDORED_REFLEXIO/reflexio" ] || {
+    echo "bundled Reflexio package not found at $VENDORED_REFLEXIO" >&2
+    return 1
+  }
+  PYTHONPATH="$pythonpath" "$python_bin" - "$vendor_root_for_python" <<'PY'
+from pathlib import Path
+import sys
+
+vendor = Path(sys.argv[1]).resolve()
+try:
+    import reflexio
+except Exception as exc:
+    print(f"failed to import bundled reflexio from {vendor}: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+module = Path(reflexio.__file__).resolve()
+try:
+    module.relative_to(vendor)
+except ValueError:
+    print(
+        f"reflexio import resolved outside bundled vendor: {module} (expected under {vendor})",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+}
+
+# True only if the recorded PID is alive, /health responds, and the listener
+# process is using this package's bundled Reflexio import path.
+is_our_backend_running() {
+  if [ -f "$PID_FILE" ]; then
+    pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      if command -v curl >/dev/null 2>&1; then
+        backend_healthy && pid_uses_current_vendor_root "$pid" && return 0
+      else
+        pid_uses_current_vendor_root "$pid" && return 0
+      fi
+    fi
+  fi
+  # Recover from a missing PID file only when the listener proves it belongs
+  # to the current vendored Reflexio package. A generic healthy service is not
+  # enough.
+  backend_owned_by_current_vendor && return 0
   return 1
 }
 
@@ -327,13 +314,7 @@ stop_port_pids() {
   kill -KILL $remaining 2>/dev/null || true
 }
 
-stop_marked_backend_listener() {
-  backend_has_claude_smart_marker || return 1
-  stop_port_pids "$(port_listener_pids "$PORT")"
-}
-
-stop_legacy_backend_listener_if_owned() {
-  backend_healthy || return 1
+stop_backend_listener_if_owned() {
   pids="$(port_listener_pids "$PORT")"
   [ -n "$pids" ] || return 1
   ours=""
@@ -346,19 +327,25 @@ stop_legacy_backend_listener_if_owned() {
   stop_port_pids "$ours"
 }
 
+stop_stale_backend_listener_if_owned() {
+  backend_owned_by_stale_claude_smart || return 1
+  stale=""
+  for pid in $(port_listener_pids "$PORT"); do
+    if looks_like_claude_smart_backend_pid "$pid" && ! pid_uses_current_vendor_root "$pid"; then
+      stale="$stale $pid"
+    fi
+  done
+  [ -n "$stale" ] || return 1
+  stop_port_pids "$stale"
+}
+
 stop_stale_embedding_listener_if_owned() {
   [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-}" = "1" ] || return 0
-  embedding_matches_current_root && return 0
-  headers="$(health_headers "$EMBEDDING_PORT" "/health" 2>/dev/null || true)"
-  if printf '%s\n' "$headers" | grep -qi '^x-claude-smart-embedding:'; then
-    stop_port_pids "$(port_listener_pids "$EMBEDDING_PORT")"
-    return 0
-  fi
   pids="$(port_listener_pids "$EMBEDDING_PORT")"
   [ -n "$pids" ] || return 0
   ours=""
   for pid in $pids; do
-    if looks_like_claude_smart_backend_pid "$pid"; then
+    if looks_like_claude_smart_backend_pid "$pid" && ! pid_uses_current_vendor_root "$pid"; then
       ours="$ours $pid"
     fi
   done
@@ -412,11 +399,7 @@ full_stop() {
     kill_group "$(cat "$PID_FILE" 2>/dev/null)"
     rm -f "$PID_FILE"
   fi
-  if backend_has_claude_smart_marker; then
-    stop_marked_backend_listener || true
-  else
-    stop_legacy_backend_listener_if_owned || true
-  fi
+  stop_backend_listener_if_owned || true
   if [ -n "${EMBEDDING_PORT:-}" ] && [ "$EMBEDDING_PORT" != "$PORT" ]; then
     stop_stale_embedding_listener_if_owned || true
   fi
@@ -437,18 +420,12 @@ case "$CMD" in
       emit_ok; exit 0
     fi
     if is_our_backend_running; then
-      embedding_matches_current_root || log_embedding_degraded
+      embedding_owned_by_current_vendor || log_embedding_degraded
       emit_ok; exit 0
     fi
-    if backend_has_claude_smart_marker; then
+    if stop_stale_backend_listener_if_owned; then
       claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
-        "[claude-smart] backend: stale claude-smart backend on port $PORT; restarting from $PLUGIN_ROOT"
-      stop_marked_backend_listener || true
-    else
-      if stop_legacy_backend_listener_if_owned; then
-        claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
-          "[claude-smart] backend: replaced legacy claude-smart backend on port $PORT that did not expose identity headers"
-      fi
+        "[claude-smart] backend: replaced claude-smart backend on port $PORT that was not using bundled Reflexio at $VENDORED_REFLEXIO"
     fi
     stop_stale_embedding_listener_if_owned || true
     if port_occupied; then
@@ -500,14 +477,14 @@ case "$CMD" in
     export REFLEXIO_STORAGE="sqlite"
 
     backend_pythonpath="${PYTHONPATH:-}"
-    if [ -d "$PLUGIN_ROOT/vendor/reflexio/reflexio" ]; then
-      vendor_pythonpath="$PLUGIN_ROOT/vendor/reflexio"
+    if [ -d "$VENDORED_REFLEXIO/reflexio" ]; then
+      vendor_pythonpath="$VENDORED_REFLEXIO"
       pythonpath_sep=":"
       if claude_smart_is_windows; then
         # Native Windows Python expects ;-separated Windows-style paths in
         # PYTHONPATH; MSYS does not auto-convert arbitrary env vars.
         pythonpath_sep=";"
-        vendor_pythonpath="$(claude_smart_to_windows_path "$vendor_pythonpath")"
+        vendor_pythonpath="$VENDORED_REFLEXIO_FOR_PYTHON"
       fi
       backend_pythonpath="$vendor_pythonpath${backend_pythonpath:+$pythonpath_sep$backend_pythonpath}"
     fi
@@ -524,6 +501,12 @@ case "$CMD" in
     # Claude Code sessions or wanting zero-downtime recycling.
     workers="${CLAUDE_SMART_BACKEND_WORKERS:-1}"
     backend_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"
+    if ! verify_bundled_reflexio_import "$backend_python" "$backend_pythonpath" "$VENDORED_REFLEXIO_FOR_PYTHON"; then
+      reason="bundled Reflexio import preflight failed"
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: $reason"
+      emit_start_failure "$reason"
+      exit 0
+    fi
     # Record the spawned pid, not a pgid sampled with ps. On POSIX,
     # setsid/python os.setsid make this pid the new process group leader;
     # sampling immediately can race and capture the caller's pgid instead.
@@ -538,10 +521,10 @@ case "$CMD" in
 
     # Give uvicorn about 20s to answer /health. The first boot after a fresh
     # checkout may be slower; if it catches up later, the next hook observes it.
-    if wait_for_health backend_matches_current_root 10 1; then
+    if wait_for_health backend_healthy 10 1; then
       # The Node installer waits 45s for this script. Each curl probe is also
       # bounded so a wedged listener cannot outlive the caller's timeout budget.
-      if ! wait_for_health embedding_matches_current_root 5 3; then
+      if ! wait_for_health embedding_owned_by_current_vendor 5 3; then
         log_embedding_degraded
       fi
     else
@@ -570,16 +553,16 @@ case "$CMD" in
   status)
     if claude_smart_reflexio_url_is_remote; then
       echo "remote configured at $REFLEXIO_URL"
-    elif backend_matches_current_root; then
-      if embedding_matches_current_root; then
-        echo "running on http://localhost:$PORT (plugin $PLUGIN_VERSION at $PLUGIN_ROOT_CANONICAL)"
+    elif backend_owned_by_current_vendor; then
+      if embedding_owned_by_current_vendor; then
+        echo "running on http://localhost:$PORT (bundled Reflexio at $VENDORED_REFLEXIO)"
       else
-        echo "running on http://localhost:$PORT (plugin $PLUGIN_VERSION at $PLUGIN_ROOT_CANONICAL; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
+        echo "running on http://localhost:$PORT (bundled Reflexio at $VENDORED_REFLEXIO; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
       fi
-    elif backend_has_claude_smart_marker; then
-      echo "stale claude-smart backend on http://localhost:$PORT"
+    elif backend_owned_by_stale_claude_smart; then
+      echo "stale claude-smart backend on http://localhost:$PORT (not using bundled Reflexio at $VENDORED_REFLEXIO)"
     elif backend_healthy; then
-      echo "foreign or legacy backend on http://localhost:$PORT (identity headers missing)"
+      echo "foreign or ambiguous backend on http://localhost:$PORT (not managed by claude-smart)"
     else
       echo "not running"
     fi

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -107,6 +107,49 @@ poll_header() {
   return 1
 }
 
+read_reflexio_lock_field() {
+  local field="$1"
+  python3 - "$REPO_ROOT/reflexio.lock.json" "$field" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+value = payload.get(sys.argv[2])
+if not isinstance(value, str) or not value:
+    raise SystemExit(f"missing field: {sys.argv[2]}")
+print(value)
+PY
+}
+
+prepare_vendored_reflexio() {
+  local vendor_dir="$PLUGIN_ROOT/vendor/reflexio"
+  if [ -f "$vendor_dir/pyproject.toml" ] && [ -d "$vendor_dir/reflexio" ]; then
+    log "setup: vendored Reflexio already present"
+    return 0
+  fi
+
+  local reflexio_path="${REFLEXIO_PATH:-$REPO_ROOT/../reflexio}"
+  if [ ! -f "$reflexio_path/pyproject.toml" ]; then
+    local repo commit clone_dir
+    repo="$(read_reflexio_lock_field repo)"
+    commit="$(read_reflexio_lock_field commit)"
+    clone_dir="$HOME/reflexio-vendor-source"
+    log "setup: cloning locked Reflexio source $commit"
+    rm -rf "$clone_dir"
+    git clone --quiet "$repo" "$clone_dir"
+    git -C "$clone_dir" checkout --quiet "$commit"
+    reflexio_path="$clone_dir"
+  else
+    log "setup: using Reflexio source at $reflexio_path"
+  fi
+
+  python3 "$REPO_ROOT/scripts/vendor-reflexio.py" \
+    --reflexio-path "$reflexio_path" \
+    --bundle-only \
+    --write
+}
+
 stage_setup() {
   log "setup: sandbox HOME=$HOME"
   if ! command -v claude >/dev/null 2>&1; then
@@ -115,6 +158,8 @@ stage_setup() {
   # Plugin subcommands are local-config only, but the CLI may probe for
   # auth on first launch; a dummy key prevents a hang at a login prompt.
   export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-dummy-for-plugin-install}"
+
+  prepare_vendored_reflexio
 
   log "setup: claude plugin marketplace add $REPO_ROOT"
   if ! claude plugin marketplace add "$REPO_ROOT" >"$HOME/marketplace-add.log" 2>&1; then

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -177,6 +177,26 @@ def _seed_fake_claude_cache(tmp_path: Path) -> Path:
     return cache_dir
 
 
+def _seed_backend_service_test_plugin(tmp_path: Path, *, port: int) -> Path:
+    plugin_root = _seed_fake_claude_cache(tmp_path)
+    backend_service = plugin_root / "scripts" / "backend-service.sh"
+    backend_service.write_text(
+        backend_service.read_text().replace("\nPORT=8071\n", f"\nPORT={port}\n")
+    )
+    return plugin_root
+
+
+def _write_fake_plugin_python(plugin_root: Path, body: str) -> Path:
+    fake_python = (
+        plugin_root
+        / ".venv"
+        / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    )
+    fake_python.parent.mkdir(parents=True)
+    _write_executable(fake_python, body)
+    return fake_python
+
+
 def _fake_claude_install_script() -> str:
     """Default fake `claude` body that logs every call and exits 0.
 
@@ -399,7 +419,8 @@ def test_backend_service_uses_prepared_venv_reflexio_cli() -> None:
         'uv pip install --project "$PLUGIN_ROOT" --python "$plugin_python" '
         '--quiet --reinstall --no-deps "$vendor"'
     ) in service
-    assert 'vendor_pythonpath="$PLUGIN_ROOT/vendor/reflexio"' in service
+    assert 'vendor_pythonpath="$VENDORED_REFLEXIO"' in service
+    assert 'verify_bundled_reflexio_import "$backend_python"' in service
     assert 'PYTHONPATH="$backend_pythonpath"' in service
 
 
@@ -1253,23 +1274,33 @@ def test_dashboard_service_restarts_stale_claude_smart_dashboard() -> None:
     assert "foreign app on 3001 is never killed" in dashboard
 
 
-def test_backend_service_verifies_current_plugin_identity() -> None:
+def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
-    assert 'export CLAUDE_SMART_BACKEND="1"' in backend
-    assert 'export CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"' in backend
-    assert 'export CLAUDE_SMART_VERSION="$PLUGIN_VERSION"' in backend
-    assert "backend_matches_current_root()" in backend
-    assert "x-claude-smart-backend" in backend
-    assert "x-claude-smart-plugin-root" in backend
-    assert "normalize_identity_path()" in backend
-    assert "cygpath -u" in backend
-    assert 'expected_root="$(normalize_identity_path ' in backend
-    assert 'actual_root="$(normalize_identity_path "$actual_root")"' in backend
-    assert '[ "$actual_root" = "$expected_root" ]' in backend
-    assert "stale claude-smart backend on port $PORT; restarting" in backend
-    assert "replaced legacy claude-smart backend" in backend
-    assert "foreign or legacy backend on http://localhost:$PORT" in backend
+    assert 'export CLAUDE_SMART_BACKEND="1"' not in backend
+    assert 'export CLAUDE_SMART_PLUGIN_ROOT="$PLUGIN_ROOT_CANONICAL"' not in backend
+    assert 'export CLAUDE_SMART_VERSION="$PLUGIN_VERSION"' not in backend
+    assert "x-claude-smart-backend" not in backend
+    assert "x-claude-smart-plugin-root" not in backend
+    assert "backend_matches_current_root()" not in backend
+    assert "CLAUDE_SMART_REFLEXIO_VENDOR_ROOT" in backend
+    assert 'VENDORED_REFLEXIO="$PLUGIN_ROOT_CANONICAL/vendor/reflexio"' in backend
+    assert "verify_bundled_reflexio_import()" in backend
+    assert "reflexio.__file__" in backend
+    assert "module.relative_to(vendor)" in backend
+    assert "reflexio import resolved outside bundled vendor" in backend
+    assert "bundled Reflexio import preflight failed" in backend
+    assert 'vendor_pythonpath="$VENDORED_REFLEXIO"' in backend
+    assert 'PYTHONPATH="$backend_pythonpath"' in backend
+    assert "pid_uses_current_vendor_root()" in backend
+    assert "backend_owned_by_current_vendor()" in backend
+    assert "backend_owned_by_stale_claude_smart()" in backend
+    assert "stop_stale_backend_listener_if_owned" in backend
+    assert "looks_like_claude_smart_backend_pid \"$pid\" && ! pid_uses_current_vendor_root \"$pid\"" in backend
+    assert "if stop_stale_backend_listener_if_owned; then" in backend
+    assert "if port_occupied; then" in backend
+    assert "not using bundled Reflexio" in backend
+    assert "foreign or ambiguous backend on http://localhost:$PORT" in backend
 
 
 def test_installers_start_backend_and_refresh_dashboard_services() -> None:
@@ -2074,12 +2105,12 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
     assert "embedding_healthy()" not in backend
-    assert "embedding_matches_current_root()" in backend
-    assert 'health_headers "$EMBEDDING_PORT" "/health"' in backend
-    assert "--connect-timeout 2 --max-time 5" in backend
+    assert "embedding_matches_current_root()" not in backend
+    assert 'health_headers "$EMBEDDING_PORT" "/health"' not in backend
+    assert "embedding_owned_by_current_vendor()" in backend
     assert "wait_for_health()" in backend
-    assert "wait_for_health backend_matches_current_root 10 1" in backend
-    assert "wait_for_health embedding_matches_current_root 5 3" in backend
+    assert "wait_for_health backend_healthy 10 1" in backend
+    assert "wait_for_health embedding_owned_by_current_vendor 5 3" in backend
     assert "spawn_backend()" not in backend
     assert "Embedding service did not become healthy" in backend
     assert "semantic retrieval remains unavailable" in backend
@@ -2092,11 +2123,11 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     start_case = start_match.group("body")
     assert "full_stop" not in start_case
     assert "backend_started" not in start_case
-    assert "if wait_for_health backend_matches_current_root 10 1; then" in start_case
-    assert "if ! wait_for_health embedding_matches_current_root 5 3; then" in start_case
+    assert "if wait_for_health backend_healthy 10 1; then" in start_case
+    assert "if ! wait_for_health embedding_owned_by_current_vendor 5 3; then" in start_case
     assert (
         "running on http://localhost:$PORT "
-        "(plugin $PLUGIN_VERSION at $PLUGIN_ROOT_CANONICAL; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
+        "(bundled Reflexio at $VENDORED_REFLEXIO; embedding degraded on http://127.0.0.1:$EMBEDDING_PORT)"
     ) in backend
 
     bin_dir = tmp_path / "bin"
@@ -2107,17 +2138,26 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
         'printf "%s\\n" "$*" >> "$HOME/curl.log"\n'
         'case " $* " in\n'
         '  *" http://127.0.0.1:8071/health "*)\n'
-        '    case " $* " in *" -D - "*)\n'
-        '      printf "HTTP/1.1 200 OK\\r\\n"\n'
-        '      printf "x-claude-smart-backend: 1\\r\\n"\n'
-        '      printf "x-claude-smart-plugin-root: %s\\r\\n" "$CLAUDE_SMART_PLUGIN_ROOT"\n'
-        "      ;;\n"
-        "    esac\n"
         "    exit 0\n"
         "    ;;\n"
         '  *" http://127.0.0.1:8072/health "*) exit 22 ;;\n'
         "esac\n"
         "exit 22\n",
+    )
+    _write_executable(
+        bin_dir / "lsof",
+        "#!/bin/sh\n"
+        'case " $* " in\n'
+        '  *" -t -i :8071 -sTCP:LISTEN "*) printf "12345\\n"; exit 0 ;;\n'
+        '  *" -t -i :8072 -sTCP:LISTEN "*) exit 0 ;;\n'
+        '  *" -a -p 12345 -d cwd -Fn "*) printf "n%s\\n" "$PWD"; exit 0 ;;\n'
+        "esac\n"
+        "exit 0\n",
+    )
+    _write_executable(
+        bin_dir / "ps",
+        "#!/bin/sh\n"
+        'printf "python -m reflexio.cli CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=%s PYTHONPATH=%s\\n" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT" "$CLAUDE_SMART_REFLEXIO_VENDOR_ROOT"\n',
     )
     _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
     env = _isolated_env(tmp_path)
@@ -2145,7 +2185,7 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     assert status.returncode == 0, status.stderr
     assert status.stdout.strip() == (
         "running on http://localhost:8071 "
-        f"(plugin {json.loads((REPO_ROOT / 'plugin' / '.codex-plugin' / 'plugin.json').read_text())['version']} at {REPO_ROOT / 'plugin'}; "
+        f"(bundled Reflexio at {REPO_ROOT / 'plugin' / 'vendor' / 'reflexio'}; "
         "embedding degraded on http://127.0.0.1:8072)"
     )
 
@@ -2165,80 +2205,244 @@ def test_backend_service_reports_local_embedding_degradation_without_cache_repai
     assert "clearing MiniLM cache" not in backend_log
     assert "restarting local services" not in backend_log
 
-    cold_home = tmp_path / "cold-start"
-    cold_plugin_root = _seed_fake_claude_cache(cold_home)
-    fake_python = (
-        cold_plugin_root
-        / ".venv"
-        / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
-    )
-    fake_python.parent.mkdir(parents=True)
-    _write_executable(
-        fake_python,
+
+def test_backend_service_restarts_stale_owned_listener_even_when_unhealthy(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 19000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    old_vendor = tmp_path / "old-plugin" / "vendor" / "reflexio"
+    (tmp_path / "stale-listener").write_text("1\n")
+    stale = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            'if [ "$1" = "-m" ]; then\n'
+            '  printf "spawned backend\\n" >> "$HOME/python.log"\n'
+            "fi\n"
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "curl",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT/health"*)\n'
+            '    if [ -f "$HOME/stale-listener" ]; then exit 22; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT"*)\n'
+            '    if [ -f "$HOME/stale-listener" ]; then exit 0; fi\n'
+            "    exit 22\n"
+            "    ;;\n"
+            "esac\n"
+            "exit 22\n",
+        )
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*)\n'
+            '    if [ -f "$HOME/stale-listener" ]; then printf "%s\\n" "$STALE_PID"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            '  *" -a -p $STALE_PID -d cwd -Fn "*) printf "n%s\\n" "$OLD_VENDOR"; exit 0 ;;\n'
+            '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*)\n'
+            '    if [ -f "$HOME/stale-listener" ]; then printf "python %s\\n" "$STALE_PID"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'if [ "${3:-}" = "$STALE_PID" ]; then\n'
+            '  printf "python -m reflexio.cli CLAUDE_SMART_REFLEXIO_VENDOR_ROOT=%s PYTHONPATH=%s\\n" "$OLD_VENDOR" "$OLD_VENDOR"\n'
+            "fi\n",
+        )
+        _write_executable(
+            bin_dir / "uv",
+            '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
+        )
+        _write_executable(
+            bin_dir / "sleep",
+            "#!/bin/sh\nrm -f \"$HOME/stale-listener\"\nexit 0\n",
+        )
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "OLD_VENDOR": str(old_vendor),
+                "REFLEXIO_URL": "",
+                "STALE_PID": str(stale.pid),
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        stale.wait(timeout=5)
+        assert "spawned backend" in (tmp_path / "python.log").read_text()
+        assert "not using bundled Reflexio" in (
+            tmp_path / ".claude-smart" / "backend.log"
+        ).read_text()
+    finally:
+        if stale.poll() is None:
+            stale.terminate()
+            stale.wait(timeout=5)
+
+
+def test_backend_service_does_not_kill_foreign_listener(tmp_path: Path) -> None:
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 20000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    foreign = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            'if [ "$1" = "-m" ]; then printf "spawned backend\\n" >> "$HOME/python.log"; fi\n'
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "curl",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT/health"*) exit 22 ;;\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT"*) exit 0 ;;\n'
+            "esac\n"
+            "exit 22\n",
+        )
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$FOREIGN_PID"; exit 0 ;;\n'
+            '  *" -a -p $FOREIGN_PID -d cwd -Fn "*) printf "n/tmp/foreign\\n"; exit 0 ;;\n'
+            '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*) printf "foreign (pid %s)\\n" "$FOREIGN_PID"; exit 0 ;;\n'
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'if [ "${3:-}" = "$FOREIGN_PID" ]; then printf "python -m other-service\\n"; fi\n',
+        )
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _isolated_env(tmp_path)
+        env.update(
+            {
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "BACKEND_TEST_PORT": str(port),
+                "CLAUDE_SMART_HOST": "codex",
+                "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
+                "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+                "FOREIGN_PID": str(foreign.pid),
+                "REFLEXIO_URL": "",
+            }
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == '{"continue":true}'
+        assert foreign.poll() is None
+        assert not (tmp_path / "python.log").exists()
+        assert "port" in result.stderr
+        assert "skipping start" in result.stderr
+    finally:
+        if foreign.poll() is None:
+            foreign.terminate()
+            foreign.wait(timeout=5)
+
+
+def test_backend_service_preflight_rejects_non_bundled_reflexio(
+    tmp_path: Path,
+) -> None:
+    port = 21000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    _write_fake_plugin_python(
+        plugin_root,
         "#!/bin/sh\n"
         'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
-        'if [ "$1" = "-m" ]; then\n'
-        '  printf "spawned backend\\n" >> "$HOME/python.log"\n'
+        'if [ "$1" = "-" ]; then\n'
+        '  case "${2:-}" in\n'
+        '    */vendor/reflexio) printf "outside bundled vendor\\n" >&2; exit 1 ;;\n'
+        "    *) exit 0 ;;\n"
+        "  esac\n"
         "fi\n"
+        'if [ "$1" = "-m" ]; then printf "spawned backend\\n" >> "$HOME/python.log"; fi\n'
         "exit 0\n",
     )
-    cold_bin_dir = cold_home / "bin"
-    cold_bin_dir.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
     _write_executable(
-        cold_bin_dir / "uv",
+        bin_dir / "curl",
+        "#!/bin/sh\nexit 22\n",
+    )
+    _write_executable(bin_dir / "lsof", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        bin_dir / "uv",
         '#!/bin/sh\nprintf "uv %s\\n" "$*" >> "$HOME/uv.log"\nexit 0\n',
     )
-    _write_executable(cold_bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
-    _write_executable(
-        cold_bin_dir / "curl",
-        "#!/bin/sh\n"
-        'printf "%s\\n" "$*" >> "$HOME/curl.log"\n'
-        'case " $* " in\n'
-        '  *" http://127.0.0.1:8071/health "*)\n'
-        '    count=$(cat "$HOME/backend-health-count" 2>/dev/null || echo 0)\n'
-        "    count=$((count + 1))\n"
-        '    printf "%s\\n" "$count" > "$HOME/backend-health-count"\n'
-        '    if [ "$count" -ge 3 ]; then\n'
-        '      case " $* " in *" -D - "*)\n'
-        '        printf "HTTP/1.1 200 OK\\r\\n"\n'
-        '        printf "x-claude-smart-backend: 1\\r\\n"\n'
-        '        printf "x-claude-smart-plugin-root: %s\\r\\n" "$CLAUDE_SMART_PLUGIN_ROOT"\n'
-        "        ;;\n"
-        "      esac\n"
-        "      exit 0\n"
-        "    fi\n"
-        "    exit 22\n"
-        "    ;;\n"
-        '  *" http://127.0.0.1:8072/health "*) exit 22 ;;\n'
-        "esac\n"
-        "exit 22\n",
-    )
-    cold_env = _isolated_env(cold_home)
-    cold_env.update(
+    _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+    env = _isolated_env(tmp_path)
+    env.update(
         {
-            "PATH": f"{cold_bin_dir}{os.pathsep}{cold_env['PATH']}",
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "BACKEND_TEST_PORT": str(port),
             "CLAUDE_SMART_HOST": "codex",
             "CLAUDE_SMART_LOGIN_PATH_TIMEOUT_SECONDS": "0",
-            "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "1",
+            "CLAUDE_SMART_USE_LOCAL_EMBEDDING": "0",
+            "REFLEXIO_URL": "",
         }
     )
 
-    cold_start = subprocess.run(
-        ["bash", str(cold_plugin_root / "scripts" / "backend-service.sh"), "start"],
-        env=cold_env,
+    result = subprocess.run(
+        ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+        env=env,
         text=True,
         capture_output=True,
         check=False,
-        timeout=25,
+        timeout=15,
     )
-    assert cold_start.returncode == 0, cold_start.stderr
-    assert cold_start.stdout.strip() == '{"continue":true}'
-    assert "spawned backend" in (cold_home / "python.log").read_text()
-    cold_backend_log = (cold_home / ".claude-smart" / "backend.log").read_text()
-    assert "Embedding service did not become healthy" in cold_backend_log
-    assert "semantic retrieval remains unavailable" in cold_backend_log
-    assert "clearing MiniLM cache" not in cold_backend_log
-    assert "restarting local services" not in cold_backend_log
+
+    assert result.returncode == 0, result.stderr
+    assert "hookSpecificOutput" in result.stdout
+    python_log = (tmp_path / "python.log").read_text()
+    assert "spawned backend" not in python_log
+    assert "bundled Reflexio import preflight failed" in (
+        tmp_path / ".claude-smart" / "backend.log"
+    ).read_text()
 
 
 def test_backend_service_full_stop_reaps_embedding_port() -> None:
@@ -2250,11 +2454,13 @@ def test_backend_service_full_stop_reaps_embedding_port() -> None:
     """
     backend = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
 
-    assert "stop_marked_backend_listener" in backend
-    assert "stop_legacy_backend_listener_if_owned" in backend
+    assert "stop_marked_backend_listener" not in backend
+    assert "stop_legacy_backend_listener_if_owned" not in backend
+    assert "stop_backend_listener_if_owned" in backend
     assert "stop_stale_embedding_listener_if_owned" in backend
-    assert "x-claude-smart-embedding" in backend
+    assert "x-claude-smart-embedding" not in backend
     assert "looks_like_claude_smart_backend_pid" in backend
+    assert "pid_uses_current_vendor_root" in backend
     assert "CLAUDE_SMART_USE_LOCAL_EMBEDDING=1" in backend
     assert (
         "reap_port_listeners \"$EMBEDDING_PORT\" '*reflexio*' '*uvicorn*'"
@@ -4253,7 +4459,7 @@ def test_codex_hook_redirects_reflexio_stray_copy_to_stable_root(
     assert result.returncode == 0, result.stderr
     assert (reflexio / "plugin-root").resolve() == stable_root
     assert json.loads(result.stdout) == {"continue": True}
-    assert not (reflexio / "plugin-root").resolve() == stray_root
+    assert (reflexio / "plugin-root").resolve() != stray_root
     assert (
         "redirecting stray plugin copy"
         in (tmp_path / ".claude-smart" / "backend.log").read_text()

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -179,6 +179,9 @@ def _seed_fake_claude_cache(tmp_path: Path) -> Path:
 
 def _seed_backend_service_test_plugin(tmp_path: Path, *, port: int) -> Path:
     plugin_root = _seed_fake_claude_cache(tmp_path)
+    vendor_package = plugin_root / "vendor" / "reflexio" / "reflexio"
+    vendor_package.mkdir(parents=True, exist_ok=True)
+    (vendor_package / "__init__.py").write_text('__version__ = "0.0.0-test"\n')
     backend_service = plugin_root / "scripts" / "backend-service.sh"
     backend_service.write_text(
         backend_service.read_text().replace("\nPORT=8071\n", f"\nPORT={port}\n")

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1285,12 +1285,25 @@ def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
     assert "backend_matches_current_root()" not in backend
     assert "CLAUDE_SMART_REFLEXIO_VENDOR_ROOT" in backend
     assert 'VENDORED_REFLEXIO="$PLUGIN_ROOT_CANONICAL/vendor/reflexio"' in backend
+    assert (
+        'VENDORED_REFLEXIO_FOR_PYTHON="$(claude_smart_to_windows_path "$VENDORED_REFLEXIO")"'
+        in backend
+    )
+    assert (
+        'export CLAUDE_SMART_REFLEXIO_VENDOR_ROOT="$VENDORED_REFLEXIO_FOR_PYTHON"'
+        in backend
+    )
     assert "verify_bundled_reflexio_import()" in backend
     assert "reflexio.__file__" in backend
     assert "module.relative_to(vendor)" in backend
     assert "reflexio import resolved outside bundled vendor" in backend
     assert "bundled Reflexio import preflight failed" in backend
     assert 'vendor_pythonpath="$VENDORED_REFLEXIO"' in backend
+    assert 'vendor_pythonpath="$VENDORED_REFLEXIO_FOR_PYTHON"' in backend
+    assert (
+        'verify_bundled_reflexio_import "$backend_python" "$backend_pythonpath" "$VENDORED_REFLEXIO_FOR_PYTHON"'
+        in backend
+    )
     assert 'PYTHONPATH="$backend_pythonpath"' in backend
     assert "pid_uses_current_vendor_root()" in backend
     assert "backend_owned_by_current_vendor()" in backend
@@ -1563,6 +1576,20 @@ def test_reflexio_vendor_release_uses_generated_bundle() -> None:
     assert "install_vendored_reflexio" in smart_install
     assert "vendor_reflexio_pyproject" in lib
     assert "/plugin/vendor/" in gitignore
+
+
+def test_integration_harness_prepares_vendored_reflexio() -> None:
+    integration = (REPO_ROOT / "tests" / "integration" / "integration.sh").read_text()
+
+    assert "prepare_vendored_reflexio()" in integration
+    assert "read_reflexio_lock_field repo" in integration
+    assert "read_reflexio_lock_field commit" in integration
+    assert 'rm -rf "$clone_dir"' in integration
+    assert 'git clone --quiet "$repo" "$clone_dir"' in integration
+    assert 'git -C "$clone_dir" checkout --quiet "$commit"' in integration
+    assert "--bundle-only" in integration
+    assert "--write" in integration
+    assert "prepare_vendored_reflexio" in integration.split("stage_setup()", 1)[1]
 
 
 def test_check_reflexio_lock_reports_invalid_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Fix stale Reflexio backend detection without adding claude-smart awareness to Reflexio itself.
- Make claude-smart accept or reap local backend listeners based on process ownership and the current npm package's bundled `plugin/vendor/reflexio` import path.
- Add dynamic script coverage for stale owned listeners, foreign listeners, and preflight import rejection.

## Changes
- Replace Reflexio health-header identity checks with claude-smart-owned process and environment inspection.
- Force bundled Reflexio first in `PYTHONPATH` and fail startup if `import reflexio` resolves outside the package vendor root.
- Reap stale claude-smart-owned backend listeners even when `/health` is unhealthy, while leaving foreign listeners alone.
- Apply the same current-vendor ownership rule to the embedding daemon.
- Keep Codex backend startup delegated to `backend-service.sh start`.

## Test Plan
- `bash -n plugin/scripts/backend-service.sh`
- `node --check plugin/scripts/codex-hook.js`
- `uv run --project plugin pytest tests/test_install_scripts.py -q --no-cov -k 'backend_service_restarts_stale_owned_listener_even_when_unhealthy or backend_service_does_not_kill_foreign_listener or backend_service_preflight_rejects_non_bundled_reflexio or backend_service_verifies_bundled_reflexio_runtime_identity or backend_service_reports_local_embedding_degradation_without_cache_repair or backend_service_full_stop_reaps_embedding_port or backend_service_uses_prepared_venv_reflexio_cli or codex_hook_recovers_missing_dependencies_without_cli_command or backend_service_configures_shared_embedding_daemon'`
- `uv run --project plugin pyright tests/test_install_scripts.py`
- `uv run --project plugin ruff check tests/test_install_scripts.py --select E9,F,SIM201`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend startup/shutdown now manages only backends and embedding listeners owned by the currently bundled Reflexio runtime.
  * Added preflight verification to block backend start when the bundled Reflexio import isn’t available.
  * Integration setup now prepares/bundles Reflexio before running installation steps.
* **Bug Fixes**
  * Improved health checks and status messaging to rely on vendor ownership rather than identity-header probing, reducing unintended service interruption.
* **Tests**
  * Expanded unit/integration coverage for stale listener recovery, safe non-killing of foreign processes, and backend start rejection for non-bundled Reflexio imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-ups
- Merge before the enterprise submodule pointer PR that consumes this runtime-isolation fix.
- Follow-up: integration setup now prepares `plugin/vendor/reflexio` from `reflexio.lock.json` when the source checkout lacks the ignored vendor bundle.
- Follow-up validation: Windows path handling remains explicit via `VENDORED_REFLEXIO_FOR_PYTHON`; `uv sync --project plugin --locked --dry-run --python 3.12 --python-platform x86_64-pc-windows-msvc` passes.
- Follow-up: backend-service unit-test fixture now seeds a minimal bundled vendor tree, so clean CI checkouts no longer depend on ignored local vendor artifacts.