### PR TITLE
feat: emit explicit playbook citation provenance

### DIFF
--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -167,7 +167,7 @@ export interface ReflexioConfig {
 export interface PlaybookApplicationStat {
   real_id: string;
   citation_id?: string;
-  kind: "playbook" | "profile";
+  kind: "playbook" | "profile" | "user_playbook" | "agent_playbook";
   source_kind?: "user_playbook" | "agent_playbook" | "profile";
   title: string;
   href?: string;

--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -19,8 +19,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 try:
     import fcntl  # POSIX only — Windows hooks fall back to append-without-lock.
@@ -34,7 +35,9 @@ _DEFAULT_STATE_DIR = Path.home() / ".claude-smart" / "sessions"
 
 _TOOL_DATA_FIELD_MAX_LEN = 256
 
-_VALID_CITATION_KINDS = frozenset({"playbook", "profile"})
+_VALID_CITATION_KINDS = frozenset(
+    {"playbook", "profile", "user_playbook", "agent_playbook"}
+)
 
 
 def _truncate_tool_data_field(value: Any) -> Any:
@@ -206,13 +209,18 @@ def _to_wire_citations(cited_items: Any) -> list[dict[str, str]]:
         kind = item.get("kind")
         if not isinstance(real_id, str) or not real_id:
             continue
-        if kind not in _VALID_CITATION_KINDS:
+        wire_kind = kind
+        if kind == "playbook":
+            source_kind = item.get("source_kind")
+            if source_kind in {"user_playbook", "agent_playbook"}:
+                wire_kind = source_kind
+        if wire_kind not in _VALID_CITATION_KINDS:
             continue
         tag = item.get("id")
         title = item.get("title")
         out.append(
             {
-                "kind": kind,
+                "kind": wire_kind,
                 "real_id": real_id,
                 "tag": tag if isinstance(tag, str) else "",
                 "title": title if isinstance(title, str) else "",

--- a/tests/host_learning_harness.py
+++ b/tests/host_learning_harness.py
@@ -261,7 +261,7 @@ def run_host_learning_happy_path(
         ]
         assert interactions[1]["citations"] == [
             {
-                "kind": "playbook",
+                "kind": "user_playbook",
                 "real_id": f"user-{host}",
                 "tag": "s2-user",
                 "title": f"{host} project skill",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -360,12 +360,46 @@ def test_to_wire_citations_filters_invalid_kinds() -> None:
     """Items with unknown ``kind`` are dropped (server has a Literal there)."""
     items = [
         {"id": "s1-ab12", "kind": "playbook", "title": "ok", "real_id": "pb_1"},
-        {"id": "x1-0001", "kind": "agent_playbook", "title": "junk", "real_id": "ap_1"},
+        {
+            "id": "x1-0001",
+            "kind": "agent_playbook",
+            "title": "explicit",
+            "real_id": "ap_1",
+        },
         {"id": "y1-0002", "kind": "", "title": "junk2", "real_id": "z_1"},
     ]
     result = state._to_wire_citations(items)
-    assert [c["kind"] for c in result] == ["playbook"]
+    assert [c["kind"] for c in result] == ["playbook", "agent_playbook"]
     assert result[0]["real_id"] == "pb_1"
+    assert result[1]["real_id"] == "ap_1"
+
+
+def test_to_wire_citations_preserves_explicit_playbook_source_kind() -> None:
+    wire = state._to_wire_citations(
+        [
+            {
+                "id": "s1-1",
+                "kind": "playbook",
+                "source_kind": "agent_playbook",
+                "real_id": "20",
+                "title": "Agent",
+            },
+            {
+                "id": "s2-1",
+                "kind": "playbook",
+                "source_kind": "user_playbook",
+                "real_id": "101",
+                "title": "User",
+            },
+            {"id": "p1-1", "kind": "profile", "real_id": "p1", "title": "Profile"},
+        ]
+    )
+
+    assert [item["kind"] for item in wire] == [
+        "agent_playbook",
+        "user_playbook",
+        "profile",
+    ]
 
 
 def test_to_wire_citations_drops_unresolved_real_id() -> None:


### PR DESCRIPTION
## Summary
- Emit explicit playbook citation provenance from claude-smart/OpenClaw state so downstream Reflexio pipelines can distinguish playbook target kinds.
- Keep existing dashboard/type contracts aligned with the explicit citation fields.

## Changes
- Plugin state: citation emission now carries explicit playbook identifiers and kind metadata.
- Dashboard/types: updated citation shape for compatibility with the enterprise citation contract.
- Tests: updated state coverage for explicit citation output.

## Test Plan
- `uv run pytest --no-cov tests/test_state.py -q`
- Enterprise integration gates were run from the parent PR with `REFLEXIO_GOVERNANCE_REF_SECRET=test-governance-ref-secret`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard playbook statistics now include additional categories for user and agent playbooks.

* **Bug Fixes**
  * Citations now preserve and emit the correct playbook type (including user/agent variants) when publishing assistant turns.
  * Invalid citation kinds are still filtered out, while valid playbook and profile citations are retained consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->