### PR TITLE
feat(hooks): send session_id on hook searches for server-side injection dedup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ Next user prompt / tool call → query-aware search for project-specific skills,
 | --- | --- |
 | `user_id` | `project_id` (git-toplevel basename) — scopes preferences to the current project |
 | `agent_version` | `claude-code` for shared skills; project-specific skills also carry project provenance |
-| `session_id` | Claude Code `session_id` — for reflexio's deferred success evaluation |
+| `session_id` | Claude Code `session_id` — for reflexio's deferred success evaluation, and sent on every hook search so the server dedups injections per session |
 
 `plugin/src/claude_smart/reflexio_adapter.py` keeps user-facing behavior scoped clearly:
 
@@ -50,6 +50,18 @@ Next user prompt / tool call → query-aware search for project-specific skills,
 - **Shared skills** are retrieved across projects and filtered to auto-generated or persisted statuses; rejected shared skills are not injected.
 
 The adapter method names still mirror Reflexio's wire fields (`user_profiles`, `user_playbooks`, `agent_playbooks`) because those are backend API names, not user-facing terminology.
+
+### Per-session injection dedup
+
+Hook searches (UserPromptSubmit and PreToolUse) fire many times per session, so
+`search_all` passes the Claude Code `session_id` to reflexio's `/api/search`.
+The server remembers which rules it already returned to that session and skips
+them on later searches, backfilling next-best matches instead — a turn with ten
+tool calls injects each rule once, not ten times. The seen-state lives
+in-memory on the backend (lost on restart, which only means an occasional
+re-injection). Known limitation: after Claude Code compacts a conversation, the
+`session_id` stays the same, so rules that fell out of the model's context are
+not re-injected for the remainder of that session.
 
 ## Extraction signals
 

--- a/plugin/src/claude_smart/context_inject.py
+++ b/plugin/src/claude_smart/context_inject.py
@@ -59,6 +59,9 @@ def emit_context(
         project_id=project_id,
         query=query,
         top_k=top_k,
+        # Scopes server-side dedup: rules already injected into this session
+        # are not returned again; next-best matches backfill instead.
+        session_id=session_id or None,
     )
     renderer = (
         context_format.render_inline_compact_with_registry

--- a/plugin/src/claude_smart/reflexio_adapter.py
+++ b/plugin/src/claude_smart/reflexio_adapter.py
@@ -340,7 +340,12 @@ class Adapter:
     # -----------------------------------------------------------------
 
     def search_all(
-        self, *, project_id: str, query: str, top_k: int = 5
+        self,
+        *,
+        project_id: str,
+        query: str,
+        top_k: int = 5,
+        session_id: str | None = None,
     ) -> tuple[list[Any], list[Any], list[Any]]:
         """Unified hybrid search → ``(user_playbooks, agent_playbooks, preferences)``.
 
@@ -354,6 +359,10 @@ class Adapter:
             project_id (str): reflexio ``user_id`` for this repo.
             query (str): Free-text query routed through BM25 + vector RRF.
             top_k (int): Cap on results per entity type.
+            session_id (str | None): Claude Code session id. When set, the
+                server skips results it already returned to this session
+                and backfills next-best matches, so repeated hook searches
+                within one session stop re-injecting the same rules.
 
         Returns:
             tuple[list[Any], list[Any], list[Any]]: ``(user_playbooks,
@@ -374,6 +383,7 @@ class Adapter:
                 enable_agent_answer=False,
                 top_k=top_k,
                 search_mode=_SEARCH_MODE_HYBRID,
+                session_id=session_id,
             )
         except Exception as exc:  # noqa: BLE001
             self._record_read_error("unified search", exc)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -422,6 +422,25 @@ def test_search_all_makes_one_client_call() -> None:
     assert client.search_call_count == 1
 
 
+def test_search_all_passes_session_id_for_server_side_dedup() -> None:
+    """session_id scopes the server's per-session result dedup."""
+    client = _RecordingClient(
+        unified_resp=SimpleNamespace(user_playbooks=[], agent_playbooks=[], profiles=[])
+    )
+    a = _adapter_with(client)
+    a.search_all(project_id="p", query="q", session_id="sess-1")
+    assert client.search_kwargs["session_id"] == "sess-1"
+
+
+def test_search_all_session_id_defaults_to_none() -> None:
+    client = _RecordingClient(
+        unified_resp=SimpleNamespace(user_playbooks=[], agent_playbooks=[], profiles=[])
+    )
+    a = _adapter_with(client)
+    a.search_all(project_id="p", query="q")
+    assert client.search_kwargs["session_id"] is None
+
+
 def test_search_all_returns_three_empty_lists_on_error() -> None:
     class BrokenSearch:
         def search(self, **_kw):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1007,6 +1007,8 @@ def test_user_prompt_injects_context_when_hits_present(
     # Prompt text is passed verbatim as the search query.
     assert calls[0]["project_id"] == "demo"
     assert calls[0]["query"] == "edit pyproject.toml"
+    # Session id scopes server-side injection dedup.
+    assert calls[0]["session_id"] == "s1"
     # The prompt is still buffered for downstream extraction.
     records = state.read_all("s1")
     assert records[-1]["role"] == "User"
@@ -1820,6 +1822,8 @@ def test_pre_tool_injects_context_when_hits_present(session_dir, monkeypatch) ->
     # Composed query must reach the adapter scoped to the project.
     assert calls[0]["project_id"] == "demo"
     assert "pyproject.toml" in calls[0]["query"]
+    # Session id scopes server-side injection dedup.
+    assert calls[0]["session_id"] == "s1"
 
 
 def test_pre_tool_emits_continue_when_search_empty(session_dir, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Hook searches now pass the Claude Code `session_id` to reflexio's unified `/api/search`, opting into the backend's session-scoped result dedup (ReflexioAI/reflexio#310): the server skips rules it already returned to this session and backfills next-best matches. A turn with ten tool calls injects each rule once instead of ten times, cutting repeated context injection without any client-side state.

Works with any backend: older reflexio versions simply ignore the field (today it is metering-only metadata), so this can merge and ship independently — dedup activates once the backend side is deployed/vendored.

## Changes

- `reflexio_adapter.py` — `search_all` accepts `session_id` (default `None`) and forwards it on `client.search(...)`.
- `context_inject.py` — `emit_context` passes the hook payload's session id into `search_all`, covering both UserPromptSubmit and PreToolUse injection paths.
- `ARCHITECTURE.md` — documents the per-session injection dedup and the post-compaction limitation (same `session_id` after compaction means rules that fell out of context are not re-injected for the rest of that session).

No vendored-client change needed — `client.search` already accepts and forwards `session_id`. No client-side filtering; the server owns dedup, and `{session_id}.injected.jsonl` remains citation-resolution-only.

## Test Plan

- [x] Adapter tests: `session_id` forwarded when provided, defaults to `None` when omitted
- [x] Hook tests: both UserPromptSubmit and PreToolUse injection paths send the payload's `session_id` to `search_all`
- [x] Full suite: 115 tests in `tests/test_adapter.py` + `tests/test_events.py` pass; ruff clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context injection now tracks sessions to avoid repeating the same rules during repeated hook searches.
  * When results are already shown in a session, the next best matches are returned instead.

* **Bug Fixes**
  * Improved behavior when no session ID is available by handling it consistently.
  * After conversation compaction, previously injected rules may not be re-added for the rest of that session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->