### PR TITLE
test: isolate integration harness runtime

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -417,7 +417,45 @@ rm -f package.json.bak pyproject.toml.bak .claude-plugin/*.bak
 
 ## Developing locally
 
-There is one local test path: build the npm tarball from this checkout and install it. The tarball bundles the plugin plus a Reflexio source snapshot, so installing it exercises your local plugin code end-to-end on both hosts.
+There are two local validation paths. Use the isolated integration harness for
+day-to-day source debugging, and use a private tarball install when you need to
+prove the code exactly as a user would run it.
+
+### Safe source e2e
+
+Run the integration harness directly from the checkout:
+
+```bash
+bash tests/integration/integration.sh
+```
+
+The harness uses a temporary `HOME`, isolated Reflexio storage, and test-only
+ports by default:
+
+| Service | Production port | Integration port |
+| --- | ---: | ---: |
+| Backend | `8071` | `18071` |
+| Embedding daemon | `8072` | `18072` |
+| Dashboard | `3001` | `13001` |
+
+This path is for safely debugging source changes while your installed
+production claude-smart keeps running on the default ports. The harness refuses
+to use `8071`, `8072`, or `3001` unless you explicitly opt in:
+
+```bash
+CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1 \
+  BACKEND_PORT=8071 EMBEDDING_PORT=8072 DASHBOARD_PORT=3001 \
+  bash tests/integration/integration.sh
+```
+
+Do not use production ports for normal source debugging. If the goal is to
+validate the code as production, build and install a tarball instead.
+
+### Production-like tarball validation
+
+Build the npm tarball from this checkout and install it. The tarball bundles
+the plugin plus a Reflexio source snapshot, so installing it exercises your
+local plugin code end-to-end on real host paths and production ports.
 
 ```bash
 make package

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -451,6 +451,10 @@ CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1 \
 Do not use production ports for normal source debugging. If the goal is to
 validate the code as production, build and install a tarball instead.
 
+If local embedding startup is slow, set
+`EMBEDDING_HEALTH_TIMEOUT_SECONDS=<seconds>` before running the harness. The
+default is `240`.
+
 ### Production-like tarball validation
 
 Build the npm tarball from this checkout and install it. The tarball bundles

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -40,32 +40,37 @@ export BACKEND_PORT EMBEDDING_PORT DASHBOARD_PORT
 BACKEND_HEALTH_TIMEOUT_SECONDS="${BACKEND_HEALTH_TIMEOUT_SECONDS:-90}"
 EMBEDDING_HEALTH_TIMEOUT_SECONDS="${EMBEDDING_HEALTH_TIMEOUT_SECONDS:-240}"
 
-require_prod_port_opt_in() {
-  [ "${CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS:-}" = "1" ] && return 0
+validate_integration_ports() {
   for selected in \
     "BACKEND_PORT=$BACKEND_PORT" \
     "EMBEDDING_PORT=$EMBEDDING_PORT" \
     "DASHBOARD_PORT=$DASHBOARD_PORT"
   do
+    port_name="${selected%%=*}"
     port_value="${selected#*=}"
     case "$port_value" in
-      *[!0-9]*|"") ;;
+      *[!0-9]*|"")
+        printf '[integration] %s must be a numeric TCP port, got %s\n' "$port_name" "$port_value" >&2
+        exit 2
+        ;;
       *)
         while [ "${port_value#0}" != "$port_value" ] && [ "$port_value" != "0" ]; do
           port_value="${port_value#0}"
         done
         ;;
     esac
-    case "$port_value" in
-      8071|8072|3001)
-        printf '[integration] refusing to use production claude-smart port via %s\n' "$selected" >&2
-        printf '[integration] use the isolated defaults, or set CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1 to opt in\n' >&2
-        exit 2
-        ;;
-    esac
+    if [ "${CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS:-}" != "1" ]; then
+      case "$port_value" in
+        8071|8072|3001)
+          printf '[integration] refusing to use production claude-smart port via %s\n' "$selected" >&2
+          printf '[integration] use the isolated defaults, or set CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1 to opt in\n' >&2
+          exit 2
+          ;;
+      esac
+    fi
   done
 }
-require_prod_port_opt_in
+validate_integration_ports
 
 # Sandbox HOME so real ~/.reflexio, ~/.claude-smart, ~/.claude stay
 # untouched. Created once, reused across stages within a single run.
@@ -79,11 +84,15 @@ else
   mkdir -p "$INTEG_HOME"
 fi
 INTEG_HOME="$(cd "$INTEG_HOME" && pwd -P)"
-ORIGINAL_HOME_CANONICAL="$(
-  if [ -n "$ORIGINAL_HOME" ]; then
-    cd "$ORIGINAL_HOME" 2>/dev/null && pwd -P || printf '%s\n' "$ORIGINAL_HOME"
+ORIGINAL_HOME_CANONICAL=""
+if [ -n "$ORIGINAL_HOME" ]; then
+  if ORIGINAL_HOME_CANONICAL="$(cd "$ORIGINAL_HOME" 2>/dev/null && pwd -P)"; then
+    :
+  else
+    printf '[integration] warning: could not resolve HOME=%s; using raw path for safety comparison\n' "$ORIGINAL_HOME" >&2
+    ORIGINAL_HOME_CANONICAL="$ORIGINAL_HOME"
   fi
-)"
+fi
 if [ -z "$INTEG_HOME" ] || [ "$INTEG_HOME" = "/" ] || { [ -n "$ORIGINAL_HOME_CANONICAL" ] && [ "$INTEG_HOME" = "$ORIGINAL_HOME_CANONICAL" ]; }; then
   printf '[integration] refusing unsafe CLAUDE_SMART_INTEG_HOME=%s\n' "$INTEG_HOME" >&2
   printf '[integration] use a temporary integration home so production ~/.reflexio and ~/.claude-smart stay untouched\n' >&2

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -3,8 +3,7 @@
 #
 # Simulates a fresh user environment: sandboxed HOME, no prior reflexio
 # state, no prior claude-smart state. Exercises the two hook-driven
-# long-lived services (backend on :8071, embedding service on :8072, dashboard
-# on :3001) and asserts they come up healthy.
+# long-lived services on isolated test ports and asserts they come up healthy.
 #
 # Assumes a working install environment: uv, node, npm, python3 already
 # on PATH. The GitHub Actions matrix controls the node version; uv is
@@ -13,6 +12,9 @@
 #
 # Usage:
 #   bash tests/integration/integration.sh            # all stages
+#   CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1 \
+#     BACKEND_PORT=8071 EMBEDDING_PORT=8072 DASHBOARD_PORT=3001 \
+#     bash tests/integration/integration.sh          # explicit production-like ports
 #   bash tests/integration/integration.sh setup      # single stage
 #   bash tests/integration/integration.sh setup-hook
 #   bash tests/integration/integration.sh backend
@@ -27,12 +29,43 @@ set -Eeuo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 PLUGIN_ROOT="$REPO_ROOT/plugin"
+ORIGINAL_HOME="${HOME:-}"
 
-BACKEND_PORT="${BACKEND_PORT:-8071}"
-EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"
-DASHBOARD_PORT="${DASHBOARD_PORT:-3001}"
+# Use non-production defaults so a local integration run cannot stop or
+# replace the user's installed claude-smart/Reflexio services on 8071/8072/3001.
+BACKEND_PORT="${BACKEND_PORT:-18071}"
+EMBEDDING_PORT="${EMBEDDING_PORT:-18072}"
+DASHBOARD_PORT="${DASHBOARD_PORT:-13001}"
 export BACKEND_PORT EMBEDDING_PORT DASHBOARD_PORT
 BACKEND_HEALTH_TIMEOUT_SECONDS="${BACKEND_HEALTH_TIMEOUT_SECONDS:-90}"
+EMBEDDING_HEALTH_TIMEOUT_SECONDS="${EMBEDDING_HEALTH_TIMEOUT_SECONDS:-240}"
+
+require_prod_port_opt_in() {
+  [ "${CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS:-}" = "1" ] && return 0
+  for selected in \
+    "BACKEND_PORT=$BACKEND_PORT" \
+    "EMBEDDING_PORT=$EMBEDDING_PORT" \
+    "DASHBOARD_PORT=$DASHBOARD_PORT"
+  do
+    port_value="${selected#*=}"
+    case "$port_value" in
+      *[!0-9]*|"") ;;
+      *)
+        while [ "${port_value#0}" != "$port_value" ] && [ "$port_value" != "0" ]; do
+          port_value="${port_value#0}"
+        done
+        ;;
+    esac
+    case "$port_value" in
+      8071|8072|3001)
+        printf '[integration] refusing to use production claude-smart port via %s\n' "$selected" >&2
+        printf '[integration] use the isolated defaults, or set CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1 to opt in\n' >&2
+        exit 2
+        ;;
+    esac
+  done
+}
+require_prod_port_opt_in
 
 # Sandbox HOME so real ~/.reflexio, ~/.claude-smart, ~/.claude stay
 # untouched. Created once, reused across stages within a single run.
@@ -45,7 +78,48 @@ else
   # Create it before exporting so later log redirects don't fail early.
   mkdir -p "$INTEG_HOME"
 fi
+INTEG_HOME="$(cd "$INTEG_HOME" && pwd -P)"
+ORIGINAL_HOME_CANONICAL="$(
+  if [ -n "$ORIGINAL_HOME" ]; then
+    cd "$ORIGINAL_HOME" 2>/dev/null && pwd -P || printf '%s\n' "$ORIGINAL_HOME"
+  fi
+)"
+if [ -z "$INTEG_HOME" ] || [ "$INTEG_HOME" = "/" ] || { [ -n "$ORIGINAL_HOME_CANONICAL" ] && [ "$INTEG_HOME" = "$ORIGINAL_HOME_CANONICAL" ]; }; then
+  printf '[integration] refusing unsafe CLAUDE_SMART_INTEG_HOME=%s\n' "$INTEG_HOME" >&2
+  printf '[integration] use a temporary integration home so production ~/.reflexio and ~/.claude-smart stay untouched\n' >&2
+  exit 2
+fi
+export CLAUDE_SMART_INTEG_HOME="$INTEG_HOME"
 export HOME="$INTEG_HOME"
+
+# Make data/config isolation explicit even if the caller has Reflexio env vars
+# exported in their shell. The services under test use the temp HOME only.
+export LOCAL_STORAGE_PATH="$HOME/.reflexio/data"
+export REFLEXIO_LOG_DIR="$HOME"
+export REFLEXIO_ENV_FILE="$HOME/.claude-smart/.env"
+export REFLEXIO_URL="http://localhost:$BACKEND_PORT/"
+unset REFLEXIO_API_KEY REFLEXIO_USER_ID
+
+sanitize_integration_env_file() {
+  env_file="$HOME/.claude-smart/.env"
+  [ -f "$env_file" ] || return 0
+  tmp_file="$env_file.integration.$$"
+  awk '
+    /^[[:space:]]*(#|$)/ { print; next }
+    {
+      line = $0
+      sub(/^[[:space:]]*export[[:space:]]+/, "", line)
+      split(line, parts, "=")
+      key = parts[1]
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+      if (key == "REFLEXIO_URL" || key == "REFLEXIO_API_KEY" || key == "REFLEXIO_USER_ID") next
+      print
+    }
+  ' "$env_file" >"$tmp_file"
+  chmod 600 "$tmp_file" 2>/dev/null || true
+  mv "$tmp_file" "$env_file"
+}
+sanitize_integration_env_file
 
 # Let the plugin scripts resolve their own root without the hooks.json
 # env var; smart-install.sh doesn't read CLAUDE_PLUGIN_ROOT but the
@@ -97,7 +171,8 @@ poll_200() {
 
 # Poll a URL up to $1 seconds for a specific response header. Returns 0
 # when the header is present in the response. Used for the dashboard
-# marker check so a foreign listener on :3001 doesn't pass the integration.
+# marker check so a foreign listener on the selected port doesn't pass the
+# integration.
 poll_header() {
   local url="$1" header="$2" timeout="$3"
   local i=0
@@ -228,9 +303,9 @@ stage_backend() {
     fail "backend /health did not return 200 within ${BACKEND_HEALTH_TIMEOUT_SECONDS}s"
   fi
   if [ "${CLAUDE_SMART_USE_LOCAL_EMBEDDING:-1}" = "1" ]; then
-    log "backend: polling http://127.0.0.1:$EMBEDDING_PORT/health (120s)"
-    if ! poll_200 "http://127.0.0.1:$EMBEDDING_PORT/health" 120; then
-      fail "embedding service /health did not return 200 within 120s"
+    log "backend: polling http://127.0.0.1:$EMBEDDING_PORT/health (${EMBEDDING_HEALTH_TIMEOUT_SECONDS}s)"
+    if ! poll_200 "http://127.0.0.1:$EMBEDDING_PORT/health" "$EMBEDDING_HEALTH_TIMEOUT_SECONDS"; then
+      fail "embedding service /health did not return 200 within ${EMBEDDING_HEALTH_TIMEOUT_SECONDS}s"
     fi
   fi
   log "backend: ok"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1713,14 +1713,24 @@ def test_integration_harness_defaults_to_isolated_runtime() -> None:
     assert 'DASHBOARD_PORT="${DASHBOARD_PORT:-3001}"' not in integration
 
 
+@pytest.mark.parametrize(
+    ("env_key", "port"),
+    [
+        ("BACKEND_PORT", "08071"),
+        ("EMBEDDING_PORT", "08072"),
+        ("DASHBOARD_PORT", "03001"),
+    ],
+)
 def test_integration_harness_rejects_production_ports_without_opt_in(
     tmp_path: Path,
+    env_key: str,
+    port: str,
 ) -> None:
     if not shutil.which("bash"):
         pytest.skip("bash is required for integration harness smoke tests")
 
     env = _isolated_env(tmp_path)
-    env["BACKEND_PORT"] = "08071"
+    env[env_key] = port
     result = subprocess.run(
         ["bash", str(REPO_ROOT / "tests" / "integration" / "integration.sh"), "cleanup"],
         env=env,
@@ -1732,7 +1742,27 @@ def test_integration_harness_rejects_production_ports_without_opt_in(
 
     assert result.returncode == 2
     assert "refusing to use production claude-smart port" in result.stderr
+    assert f"{env_key}={port}" in result.stderr
     assert "CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1" in result.stderr
+
+
+def test_integration_harness_rejects_non_numeric_ports(tmp_path: Path) -> None:
+    if not shutil.which("bash"):
+        pytest.skip("bash is required for integration harness smoke tests")
+
+    env = _isolated_env(tmp_path)
+    env["BACKEND_PORT"] = "8071abc"
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "tests" / "integration" / "integration.sh"), "cleanup"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 2
+    assert "BACKEND_PORT must be a numeric TCP port" in result.stderr
 
 
 def test_integration_harness_sanitizes_reused_managed_env(
@@ -1748,6 +1778,8 @@ def test_integration_harness_sanitizes_reused_managed_env(
     env_file.write_text(
         "\n".join(
             [
+                "# mode: local",
+                "",
                 'REFLEXIO_URL="https://www.reflexio.ai/"',
                 'export REFLEXIO_API_KEY="secret"',
                 'REFLEXIO_USER_ID="user-1"',
@@ -1758,7 +1790,7 @@ def test_integration_harness_sanitizes_reused_managed_env(
     )
     env = _isolated_env(tmp_path / "runner-home")
     env["CLAUDE_SMART_INTEG_HOME"] = str(home)
-    env_file.chmod(0o600)
+    env_file.chmod(0o644)
     result = subprocess.run(
         ["bash", str(REPO_ROOT / "tests" / "integration" / "integration.sh"), "cleanup"],
         env=env,
@@ -1773,6 +1805,7 @@ def test_integration_harness_sanitizes_reused_managed_env(
     assert "REFLEXIO_URL" not in sanitized
     assert "REFLEXIO_API_KEY" not in sanitized
     assert "REFLEXIO_USER_ID" not in sanitized
+    assert "# mode: local" in sanitized
     assert 'CLAUDE_SMART_USE_LOCAL_CLI="1"' in sanitized
     if os.name != "nt":
         assert stat.S_IMODE(env_file.stat().st_mode) == 0o600

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1688,6 +1688,96 @@ def test_integration_harness_prepares_vendored_reflexio() -> None:
     assert "prepare_vendored_reflexio" in integration.split("stage_setup()", 1)[1]
 
 
+def test_integration_harness_defaults_to_isolated_runtime() -> None:
+    integration = (REPO_ROOT / "tests" / "integration" / "integration.sh").read_text()
+
+    assert 'BACKEND_PORT="${BACKEND_PORT:-18071}"' in integration
+    assert 'EMBEDDING_PORT="${EMBEDDING_PORT:-18072}"' in integration
+    assert 'DASHBOARD_PORT="${DASHBOARD_PORT:-13001}"' in integration
+    assert 'EMBEDDING_HEALTH_TIMEOUT_SECONDS="${EMBEDDING_HEALTH_TIMEOUT_SECONDS:-240}"' in integration
+    assert "within ${EMBEDDING_HEALTH_TIMEOUT_SECONDS}s" in integration
+    assert "CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS" in integration
+    assert "refusing to use production claude-smart port" in integration
+    assert 'export LOCAL_STORAGE_PATH="$HOME/.reflexio/data"' in integration
+    assert 'export REFLEXIO_LOG_DIR="$HOME"' in integration
+    assert 'export REFLEXIO_ENV_FILE="$HOME/.claude-smart/.env"' in integration
+    assert 'export REFLEXIO_URL="http://localhost:$BACKEND_PORT/"' in integration
+    assert "unset REFLEXIO_API_KEY REFLEXIO_USER_ID" in integration
+    assert "sanitize_integration_env_file" in integration
+    assert 'key == "REFLEXIO_URL"' in integration
+    assert 'key == "REFLEXIO_API_KEY"' in integration
+    assert 'key == "REFLEXIO_USER_ID"' in integration
+    assert "refusing unsafe CLAUDE_SMART_INTEG_HOME" in integration
+    assert 'BACKEND_PORT="${BACKEND_PORT:-8071}"' not in integration
+    assert 'EMBEDDING_PORT="${EMBEDDING_PORT:-8072}"' not in integration
+    assert 'DASHBOARD_PORT="${DASHBOARD_PORT:-3001}"' not in integration
+
+
+def test_integration_harness_rejects_production_ports_without_opt_in(
+    tmp_path: Path,
+) -> None:
+    if not shutil.which("bash"):
+        pytest.skip("bash is required for integration harness smoke tests")
+
+    env = _isolated_env(tmp_path)
+    env["BACKEND_PORT"] = "08071"
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "tests" / "integration" / "integration.sh"), "cleanup"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 2
+    assert "refusing to use production claude-smart port" in result.stderr
+    assert "CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1" in result.stderr
+
+
+def test_integration_harness_sanitizes_reused_managed_env(
+    tmp_path: Path,
+) -> None:
+    if not shutil.which("bash"):
+        pytest.skip("bash is required for integration harness smoke tests")
+
+    home = tmp_path / "integ-home"
+    env_dir = home / ".claude-smart"
+    env_dir.mkdir(parents=True)
+    env_file = env_dir / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                'REFLEXIO_URL="https://www.reflexio.ai/"',
+                'export REFLEXIO_API_KEY="secret"',
+                'REFLEXIO_USER_ID="user-1"',
+                'CLAUDE_SMART_USE_LOCAL_CLI="1"',
+            ]
+        )
+        + "\n"
+    )
+    env = _isolated_env(tmp_path / "runner-home")
+    env["CLAUDE_SMART_INTEG_HOME"] = str(home)
+    env_file.chmod(0o600)
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "tests" / "integration" / "integration.sh"), "cleanup"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    sanitized = env_file.read_text()
+    assert "REFLEXIO_URL" not in sanitized
+    assert "REFLEXIO_API_KEY" not in sanitized
+    assert "REFLEXIO_USER_ID" not in sanitized
+    assert 'CLAUDE_SMART_USE_LOCAL_CLI="1"' in sanitized
+    if os.name != "nt":
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+
+
 def test_check_reflexio_lock_reports_invalid_json(tmp_path: Path) -> None:
     scripts = tmp_path / "scripts"
     plugin = tmp_path / "plugin"


### PR DESCRIPTION
## What's broken / annoying

A developer machine can have the installed claude-smart plugin running while the same developer is also debugging this checkout.

Before this PR, the source integration test used the same default ports as the installed plugin: backend `8071`, embedding `8072`, and dashboard `3001`. The test also runs the normal start/stop scripts. That meant a local e2e run could accidentally stop, replace, or confuse the claude-smart services the developer depends on day to day.

There was also a quieter risk when reusing a test home: an old `.claude-smart/.env` could keep managed Reflexio connection keys and point the source test at hosted Reflexio instead of the local test backend.

## What's changing

- Source e2e now runs on test-only ports by default: backend `18071`, embedding `18072`, dashboard `13001`.
- The harness refuses production ports unless the developer explicitly sets `CLAUDE_SMART_INTEGRATION_ALLOW_PROD_PORTS=1`.
- The harness uses a temporary `HOME` plus explicit local Reflexio storage/config paths, so test data stays separate from the installed plugin's data.
- Reused test homes have managed Reflexio connection keys removed before services start: `REFLEXIO_URL`, `REFLEXIO_API_KEY`, and `REFLEXIO_USER_ID`.
- The sanitized test `.env` is written as private (`0600`) because it may contain local settings or secrets.
- Embedding startup wait is configurable with `EMBEDDING_HEALTH_TIMEOUT_SECONDS`; the default is now long enough for slower local model warmup.
- `DEVELOPER.md` now separates safe source e2e from production-like private tarball validation.

## Local machine flows

```mermaid
flowchart TD
  A["One developer machine"] --> P["Daily installed claude-smart"]
  P --> P1["Default ports: 8071 / 8072 / 3001"]
  P --> P2["Real local data: ~/.reflexio and ~/.claude-smart"]
  P --> P3["Used by Claude Code, Codex, and OpenCode"]

  A --> E["Source e2e from this checkout"]
  E --> E1["Test ports: 18071 / 18072 / 13001"]
  E --> E2["Temporary HOME and isolated Reflexio data"]
  E --> E3["Safe for normal source debugging"]

  A --> T["Production-like validation"]
  T --> T1["Build a private tarball"]
  T --> T2["Install through normal host paths"]
  T --> T3["Uses default ports and real local data, like a user install"]
```

## How the product behaves afterwards

Installed claude-smart behaves the same as before. The backend, embedding daemon, and dashboard still use `8071`, `8072`, and `3001`; Claude Code, Codex, and OpenCode still share the same local services and data.

Only the developer integration harness changes its defaults. Developers can now debug source changes without disturbing their daily installed plugin. When they need to test exactly like production, they should build and install a private tarball instead of running source e2e on production ports.

## How it was verified

- `bash -n tests/integration/integration.sh`
- `git diff --check`
- `uv run --project plugin --with pytest pytest tests/test_install_scripts.py::test_integration_harness_prepares_vendored_reflexio tests/test_install_scripts.py::test_integration_harness_defaults_to_isolated_runtime tests/test_install_scripts.py::test_integration_harness_rejects_production_ports_without_opt_in tests/test_install_scripts.py::test_integration_harness_rejects_non_numeric_ports tests/test_install_scripts.py::test_integration_harness_sanitizes_reused_managed_env tests/test_host_integration_e2e.py -q`
- `uv run --project plugin --with pytest pytest tests/test_install_scripts.py -q`
- `bash tests/integration/integration.sh`
- Checked production listeners before and after the full local e2e run: backend stayed on PID `56668` at `8071`, embedding stayed on PID `56666` at `8072`, and dashboard stayed on PID `82939` at `3001`.
- Checked test ports after cleanup: nothing remained listening on `18071`, `18072`, or `13001`.

## Reviewer notes

- The test changes stay in the existing install-script test module, next to the prior integration harness checks.
- The production-port rejection cases are now one parametrized test instead of three copy-pasted tests.
- The `.env` sanitizer test now proves comment preservation and the intentional `0600` privacy behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local validation guidance with two workflows: isolated integration testing and production-style tarball validation, including documented port behavior and embedding startup timeout.
* **Bug Fixes**
  * Integration now defaults to isolated non-production ports and blocks production-like ports unless explicitly opted in.
  * Improved sandbox safety by canonicalizing the sandbox HOME, setting isolated runtime locations, and sanitizing reused Reflexio environment values.
  * Embedding health checks now use `EMBEDDING_HEALTH_TIMEOUT_SECONDS`.
* **Tests**
  * Added smoke/integration-harness coverage for isolated defaults, production-port rejection, numeric port validation, and environment sanitization (including file permission checks on non-Windows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->