### PR TITLE
fix(optimizer): honor CLAUDE_SMART_CLI_PATH

### DIFF
--- a/plugin/src/claude_smart/env_config.py
+++ b/plugin/src/claude_smart/env_config.py
@@ -29,7 +29,10 @@ DEFAULT_CLAUDE_SMART_HOST = runtime.HOST_CLAUDE_CODE
 
 _LOCAL_DEFAULT_ENTRIES = (
     (
-        "# Route reflexio generation through the configured local host CLI",
+        "# Set to 1 to route reflexio generation through the active host CLI "
+        "(claude for Claude Code, the host compatibility bridge for OpenCode/Codex). "
+        "Set to 0 to disable that provider so reflexio auto-detects a cloud LLM "
+        "key (anthropic, minimax, openai, etc.) from ~/.claude-smart/.env instead.",
         CLAUDE_SMART_USE_LOCAL_CLI_ENV,
         "1",
     ),

--- a/plugin/src/claude_smart/optimizer_assistant.py
+++ b/plugin/src/claude_smart/optimizer_assistant.py
@@ -4,6 +4,13 @@ Reflexio's ``LocalScriptAssistant`` sends one JSON payload on stdin and expects
 one JSON object on stdout. This module bridges that protocol to a guarded
 local CLI subprocess so candidate playbooks can be evaluated against the active
 host without re-entering claude-smart/reflexio hooks.
+
+Host CLI resolution: when ``CLAUDE_SMART_CLI_PATH`` is set in the environment
+(``backend-service.sh`` writes it for ``opencode`` and ``codex`` hosts so
+generation routes through the host-specific compatibility bridge instead of
+the real Claude CLI), this script honours that override. Falling back to
+``shutil.which("claude")`` preserves the legacy Claude Code host behaviour
+where no override is configured.
 """
 
 from __future__ import annotations
@@ -22,6 +29,10 @@ from claude_smart import internal_call, runtime
 _CLI_TIMEOUT_SECONDS = 300
 _READ_ONLY_TOOLS = "Read,Grep,Glob,LS"
 _MUTATING_TOOLS = "Bash,Edit,Write,MultiEdit,NotebookEdit"
+# Mirrors ``reflexio.server.llm.providers.claude_code_provider._ENV_CLI_PATH``
+# so backend-service.sh can route both the reflexio Claude CLI provider and
+# this assistant script through the same host-specific bridge.
+_ENV_CLI_PATH = "CLAUDE_SMART_CLI_PATH"
 
 
 class OptimizerAssistantError(Exception):
@@ -142,8 +153,24 @@ def _run_local_cli(*, prompt: str, system_prompt: str) -> str:
     return _run_claude(prompt=prompt, system_prompt=system_prompt)
 
 
+def _resolve_claude_cli_path() -> str:
+    """Return the host CLI to invoke for evaluation rollouts.
+
+    When ``CLAUDE_SMART_CLI_PATH`` is set, prefer it so backend-service.sh can
+    route the assistant through the same bridge it uses for the reflexio
+    ``claude-code`` provider (e.g. ``opencode-claude-compat`` for the OpenCode
+    host). Falls back to ``shutil.which("claude")`` so Claude Code hosts — and
+    any environment that never set the override — continue to use the real
+    ``claude`` CLI.
+    """
+    override = os.environ.get(_ENV_CLI_PATH)
+    if override:
+        return override
+    return shutil.which("claude") or "claude"
+
+
 def _run_claude(*, prompt: str, system_prompt: str) -> str:
-    cli_path = shutil.which("claude") or "claude"
+    cli_path = _resolve_claude_cli_path()
     # This is an evaluation rollout, not a real user session: allow local
     # inspection, but prevent filesystem, shell, MCP, and session mutations.
     cmd = [

--- a/plugin/src/claude_smart/optimizer_assistant.py
+++ b/plugin/src/claude_smart/optimizer_assistant.py
@@ -33,6 +33,16 @@ _MUTATING_TOOLS = "Bash,Edit,Write,MultiEdit,NotebookEdit"
 # so backend-service.sh can route both the reflexio Claude CLI provider and
 # this assistant script through the same host-specific bridge.
 _ENV_CLI_PATH = "CLAUDE_SMART_CLI_PATH"
+_CLAUDE_SMART_COMPAT_BRIDGE_NAMES = frozenset(
+    {
+        "codex-claude-compat",
+        "codex-claude-compat.cmd",
+        "codex-claude-compat.js",
+        "opencode-claude-compat",
+        "opencode-claude-compat.cmd",
+        "opencode-claude-compat.js",
+    }
+)
 
 
 class OptimizerAssistantError(Exception):
@@ -169,26 +179,35 @@ def _resolve_claude_cli_path() -> str:
     return shutil.which("claude") or "claude"
 
 
+def _is_claude_smart_compat_bridge(cli_path: str) -> bool:
+    return Path(cli_path).name.lower() in _CLAUDE_SMART_COMPAT_BRIDGE_NAMES
+
+
 def _run_claude(*, prompt: str, system_prompt: str) -> str:
     cli_path = _resolve_claude_cli_path()
-    # This is an evaluation rollout, not a real user session: allow local
-    # inspection, but prevent filesystem, shell, MCP, and session mutations.
     cmd = [
         cli_path,
         "-p",
         "--output-format",
         "json",
-        "--permission-mode",
-        "plan",
-        "--tools",
-        _READ_ONLY_TOOLS,
-        "--disallowedTools",
-        _MUTATING_TOOLS,
-        "--no-session-persistence",
-        "--mcp-config",
-        '{"mcpServers": {}}',
-        "--strict-mcp-config",
     ]
+    if not _is_claude_smart_compat_bridge(cli_path):
+        # This is an evaluation rollout, not a real user session: allow local
+        # inspection, but prevent filesystem, shell, MCP, and session mutations.
+        cmd.extend(
+            [
+                "--permission-mode",
+                "plan",
+                "--tools",
+                _READ_ONLY_TOOLS,
+                "--disallowedTools",
+                _MUTATING_TOOLS,
+                "--no-session-persistence",
+                "--mcp-config",
+                '{"mcpServers": {}}',
+                "--strict-mcp-config",
+            ]
+        )
     if system_prompt:
         cmd.extend(["--append-system-prompt", system_prompt])
 

--- a/tests/test_optimizer_assistant.py
+++ b/tests/test_optimizer_assistant.py
@@ -210,3 +210,138 @@ def test_optimizer_assistant_returns_nonzero_on_timeout(monkeypatch) -> None:
     assert rc == 1
     assert stdout == ""
     assert "claude CLI timed out after 300s" in stderr
+
+
+def test_optimizer_assistant_prefers_claude_smart_cli_path(monkeypatch) -> None:
+    """When ``CLAUDE_SMART_CLI_PATH`` is set, the optimizer assistant must
+    invoke the override (e.g. ``opencode-claude-compat``) instead of the real
+    ``claude`` binary. backend-service.sh writes this override for the
+    OpenCode and Codex hosts so generation routes through the same host-aware
+    bridge the reflexio ``claude-code`` provider uses.
+    """
+    seen_cmds = []
+
+    def fake_run(cmd, **kwargs):
+        seen_cmds.append(cmd[0])
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"result": "router reply"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which", lambda _: "/bin/claude"
+    )
+    monkeypatch.setattr("claude_smart.optimizer_assistant.subprocess.run", fake_run)
+    monkeypatch.setenv("CLAUDE_SMART_CLI_PATH", "/opt/router")
+
+    rc, stdout, _stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "seen"},
+                {"role": "user", "content": "answer now"},
+            ],
+            "playbooks": [
+                {"id": 1, "content": "Be concise.", "trigger": "summaries"}
+            ],
+        },
+    )
+
+    assert rc == 0
+    assert json.loads(stdout) == {"content": "router reply"}
+    # shutil.which was registered but the override path must be the one
+    # actually spawned, because the override is an explicit operator signal.
+    assert seen_cmds == ["/opt/router"]
+    assert "/bin/claude" not in seen_cmds
+
+
+def test_optimizer_assistant_override_missing_path_fails_loud(
+    monkeypatch, tmp_path
+) -> None:
+    """An override path that doesn't exist must surface a clear ``FileNotFoundError``
+    rather than silently fall back to ``shutil.which("claude")`` (which would
+    re-introduce the original CC-quota bug for misconfigured bridges). The
+    ``OptimizerAssistantError`` wrapper reports this as
+    ``"claude CLI not found on PATH"`` so misconfiguration is diagnosable from
+    reflexio's optimizer error surface.
+    """
+    missing = tmp_path / "does-not-exist.sh"
+    monkeypatch.setenv("CLAUDE_SMART_CLI_PATH", str(missing))
+
+    def fake_run(cmd, **_kwargs):
+        raise FileNotFoundError(2, "No such file", str(missing))
+
+    monkeypatch.setattr("claude_smart.optimizer_assistant.subprocess.run", fake_run)
+
+    rc, stdout, stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": None}],
+        },
+    )
+
+    assert rc == 1
+    assert stdout == ""
+    assert "claude CLI not found on PATH" in stderr
+
+
+def test_optimizer_assistant_falls_back_to_shutil_which_without_override(
+    monkeypatch,
+) -> None:
+    """Without ``CLAUDE_SMART_CLI_PATH``, the legacy Claude Code host path
+    continues to use ``shutil.which("claude")`` so non-OpenCode installs keep
+    working.
+    """
+    seen = []
+
+    def fake_run(cmd, **_kwargs):
+        seen.append(cmd[0])
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"result": "ok"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which", lambda _: "/usr/bin/claude"
+    )
+    monkeypatch.setattr("claude_smart.optimizer_assistant.subprocess.run", fake_run)
+    monkeypatch.delenv("CLAUDE_SMART_CLI_PATH", raising=False)
+
+    rc, stdout, _stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": None}],
+        },
+    )
+
+    assert rc == 0
+    assert json.loads(stdout) == {"content": "ok"}
+    assert seen == ["/usr/bin/claude"]
+
+
+def test_optimizer_assistant_resolve_helpers(monkeypatch) -> None:
+    """The resolver ignores empty overrides and falls through to shutil."""
+    monkeypatch.setattr(
+        "claude_smart.optimizer_assistant.shutil.which",
+        lambda _: "/usr/local/bin/claude",
+    )
+
+    monkeypatch.delenv("CLAUDE_SMART_CLI_PATH", raising=False)
+    assert (
+        optimizer_assistant._resolve_claude_cli_path() == "/usr/local/bin/claude"
+    )
+
+    monkeypatch.setenv("CLAUDE_SMART_CLI_PATH", "")
+    assert (
+        optimizer_assistant._resolve_claude_cli_path() == "/usr/local/bin/claude"
+    )
+
+    monkeypatch.setenv("CLAUDE_SMART_CLI_PATH", "/bridge/claude")
+    assert (
+        optimizer_assistant._resolve_claude_cli_path() == "/bridge/claude"
+    )

--- a/tests/test_optimizer_assistant.py
+++ b/tests/test_optimizer_assistant.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
+from pathlib import Path
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -96,6 +98,7 @@ def test_optimizer_assistant_invokes_codex_for_codex_host(
         lambda name: "/bin/codex" if name == "codex" else None,
     )
     monkeypatch.setattr("claude_smart.optimizer_assistant.subprocess.run", fake_run)
+    monkeypatch.setenv("CLAUDE_SMART_CLI_PATH", "/ignored/codex-claude-compat")
 
     rc, stdout, stderr = _run_main(
         monkeypatch,
@@ -114,6 +117,7 @@ def test_optimizer_assistant_invokes_codex_for_codex_host(
     assert json.loads(stdout) == {"content": "codex reply"}
     cmd, kwargs = calls[0]
     assert cmd[:2] == ["/bin/codex", "exec"]
+    assert "/ignored/codex-claude-compat" not in cmd
     assert "--output-last-message" in cmd
     assert cmd[cmd.index("--sandbox") + 1] == "read-only"
     assert "--ask-for-approval" not in cmd
@@ -255,6 +259,44 @@ def test_optimizer_assistant_prefers_claude_smart_cli_path(monkeypatch) -> None:
     # actually spawned, because the override is an explicit operator signal.
     assert seen_cmds == ["/opt/router"]
     assert "/bin/claude" not in seen_cmds
+
+
+def test_optimizer_assistant_opencode_bridge_accepts_optimizer_args(
+    monkeypatch, tmp_path
+) -> None:
+    """Run through the real OpenCode bridge parser so optimizer-only Claude flags
+    cannot be reintroduced for host compatibility bridges.
+    """
+    if os.name == "nt":
+        pytest.skip("POSIX bridge wrapper exercised on non-Windows hosts")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    bridge = repo_root / "plugin" / "scripts" / "opencode-claude-compat"
+    fake_opencode = tmp_path / "opencode"
+    fake_opencode.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' '{\"type\":\"result\",\"result\":\"bridge reply\"}'\n"
+    )
+    fake_opencode.chmod(0o755)
+
+    runtime.set_host(runtime.HOST_OPENCODE)
+    monkeypatch.setenv("CLAUDE_SMART_CLI_PATH", str(bridge))
+    monkeypatch.setenv("CLAUDE_SMART_OPENCODE_PATH", str(fake_opencode))
+
+    rc, stdout, stderr = _run_main(
+        monkeypatch,
+        {
+            "messages": [
+                {"role": "system", "content": "System note."},
+                {"role": "user", "content": "hello"},
+            ],
+            "playbooks": [{"id": 1, "content": "Be concise.", "trigger": None}],
+        },
+    )
+
+    assert rc == 0, stderr
+    assert stderr == ""
+    assert json.loads(stdout) == {"content": "bridge reply"}
 
 
 def test_optimizer_assistant_override_missing_path_fails_loud(


### PR DESCRIPTION
## What's broken / annoying

When claude-smart runs under OpenCode, the backend already knows which local bridge should handle Claude-style AI calls:

- OpenCode should go through `opencode-claude-compat`
- Claude Code can keep using the normal `claude` CLI
- Codex uses the optimizer assistant's native `codex exec` path, not the Claude-compat bridge

Most Reflexio calls already follow their host-specific path. But the optimizer assistant had one old path that still looked up `claude` directly on non-Codex hosts.

The first version of this PR fixed that lookup, but it sent full Claude Code safety flags to the OpenCode compatibility bridge. That bridge intentionally accepts only a small Claude-provider argument surface, so the optimizer would fail on OpenCode instead of routing correctly.

## What's changing

- The optimizer assistant still checks `CLAUDE_SMART_CLI_PATH` before falling back to the normal `claude` CLI.
- When the resolved executable is a claude-smart compatibility bridge, the optimizer sends only the bridge-supported arguments.
- When the resolved executable is the real Claude CLI, the optimizer keeps the existing guarded flags: plan mode, read-only tools, mutating tools disabled, no MCP, and no session persistence.
- Codex behavior is kept explicit: Codex host runs through `_run_codex()` and ignores `CLAUDE_SMART_CLI_PATH` for optimizer rollouts.
- Tests now exercise the real OpenCode bridge parser with a fake OpenCode binary, so unsupported optimizer-only Claude flags cannot silently return.

```mermaid
flowchart TD
    A[Optimizer needs an AI response] --> B{Which host is running?}

    B -->|Claude Code| C[Resolve normal claude CLI]
    C --> D[Use guarded Claude flags]
    D --> E[Same Claude Code behavior as before]

    B -->|OpenCode before fix| F[Resolve opencode-claude-compat]
    F --> G[Send unsupported Claude Code flags]
    G --> H[Bridge rejects the call]

    B -->|OpenCode after fix| I[Resolve opencode-claude-compat]
    I --> J[Send bridge-supported args only]
    J --> K[Request runs through OpenCode bridge]

    B -->|Codex| L[Use native codex exec optimizer path]
    L --> M[Same Codex behavior as before]

    classDef broken fill:#ffe5e5,stroke:#c62828,color:#111;
    classDef changed fill:#e8f5e9,stroke:#2e7d32,color:#111;
    classDef same fill:#eef3ff,stroke:#315fbd,color:#111;

    class F,G,H broken;
    class I,J,K changed;
    class C,D,E,L,M same;
```

## How the product behaves afterwards

- OpenCode installs route optimizer calls through the OpenCode bridge without rejected arguments.
- Claude Code installs keep the same guarded Claude CLI behavior as before.
- Codex installs keep the same native Codex optimizer behavior as before.
- A bad explicit bridge path still fails loudly instead of silently falling back to `claude`, because silent fallback would recreate the quota/routing bug.

## Validation

- `uvx ruff check plugin/src/claude_smart/optimizer_assistant.py plugin/src/claude_smart/env_config.py tests/test_optimizer_assistant.py` -> passed
- `uv run --project plugin pytest tests/test_optimizer_assistant.py tests/test_opencode_support.py::test_opencode_backend_service_uses_bridge_without_opencode_path_probe tests/test_codex_support.py::test_codex_hooks_use_expected_events_and_marketplace_fallback` -> 14 passed
- `npm ci` -> installed locked Node dev dependencies needed by packaging/TypeScript checks
- `uv run --project plugin pytest` -> 642 passed
- Live OpenCode smoke: `CLAUDE_SMART_HOST=opencode` with real `opencode-claude-compat` and local `opencode 1.17.12` returned `{"content":"OK"}`
- Live Codex smoke: `CLAUDE_SMART_HOST=codex` with local `codex-cli 0.142.5` returned `{"content":"OK"}`

## Risks / follow-ups

- This does not add executable-bit validation before spawning the bridge. Today that remains a loud subprocess failure, which is safer than silently falling back to the wrong CLI.
- A future cleanup could centralize CLI path resolution across the optimizer assistant, install checks, and the vendored Reflexio Claude provider.

## Why this is needed

This closes the gap where OpenCode optimizer rollouts could either bypass the host bridge or, after the initial PR version, fail because the bridge received unsupported Claude Code-only flags.

## Why this is net-positive

Developers get predictable local routing and clearer failure behavior. OpenCode gets the bridge path it expects, Claude Code keeps its guarded CLI behavior, and Codex keeps its existing native optimizer path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing a specific Claude CLI executable via an environment override, with automatic fallback to the installed command when not set.
  * Improved handling for compatibility bridges so they can route requests without extra rollout-specific restrictions.

* **Bug Fixes**
  * Clarified local configuration guidance for how Claude Smart routes to host or cloud providers.
  * Improved error handling when the configured CLI path cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->