### PR TITLE
fix(install): close the GitHub-marketplace broken-install path

### DIFF
--- a/.claude-plugin/marketplace.template.json
+++ b/.claude-plugin/marketplace.template.json
@@ -9,7 +9,6 @@
   "plugins": [
     {
       "name": "claude-smart",
-      "version": "0.2.49",
       "source": "./plugin",
       "description": "Turns corrections into Preferences, Project-specific skills, and Shared skills — uses Claude Code, Codex, or OpenCode as the LLM backend (no external API key required)"
     }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,6 +53,20 @@ jobs:
       - name: Install test dependencies
         run: uv sync --project plugin --group dev --python 3.12 --locked
 
+      # plugin/vendor/reflexio is a pack-time artifact and is gitignored, so a
+      # fresh checkout has none. The install-flow tests need it: a tarball
+      # without the vendored runtime installs a plugin whose backend cannot
+      # start, which Setup now correctly rejects. Vendor the locked commit so
+      # those tests exercise what users actually receive.
+      - name: Vendor locked Reflexio (install-flow tests need the release bundle)
+        run: |
+          repo=$(python3 -c "import json;print(json.load(open('reflexio.lock.json'))['repo'])")
+          commit=$(python3 -c "import json;print(json.load(open('reflexio.lock.json'))['commit'])")
+          git clone --quiet "$repo" "$RUNNER_TEMP/reflexio-src"
+          git -C "$RUNNER_TEMP/reflexio-src" checkout --quiet "$commit"
+          python3 scripts/vendor-reflexio.py \
+            --reflexio-path "$RUNNER_TEMP/reflexio-src" --bundle-only --write
+
       - name: Run pytest suite
         run: uv --project plugin run pytest tests -q
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,13 @@ benchmarks/memory_comparison/results
 # Generated release vendor bundle
 /plugin/vendor/
 
+# Generated at pack time from .claude-plugin/marketplace.template.json.
+# Deliberately not committed: it is what makes this repo installable as a Claude
+# Code marketplace, and the plugin it advertises has no vendored Reflexio
+# runtime in git. Keeping it out means `claude plugin marketplace add
+# ReflexioAI/claude-smart` fails fast instead of installing a broken plugin.
+/.claude-plugin/marketplace.json
+
 # Scheduled tasks lock
 .claude/scheduled_tasks.lock
 .coverage

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -13,7 +13,9 @@ Internal notes for maintainers of `claude-smart`. End-user install instructions 
 | `bin/claude-smart.js` | Node wrapper so `npx claude-smart install` works |
 | `package.json` | npm manifest — ships `bin/`, marketplace metadata, `plugin/`, `README.md`, and `LICENSE` |
 | `plugin/.claude-plugin/plugin.json` | Plugin metadata read by Claude Code |
-| `.claude-plugin/marketplace.json` | Marketplace entry — `claude plugin marketplace add` reads this |
+| `.claude-plugin/marketplace.template.json` | Source of the marketplace entry, minus the version |
+| `.claude-plugin/marketplace.json` | Marketplace entry `claude plugin marketplace add` reads — **generated at pack time, gitignored** (see below) |
+| `scripts/generate-marketplace.js` | Builds the marketplace entry from the template + `package.json` version; runs via npm's `prepack` |
 | `reflexio.lock.json` | Reflexio provenance — records the PyPI baseline or generated vendor bundle commit |
 | `plugin/vendor/reflexio/` | Generated release-only Reflexio bundle for npm artifacts; gitignored, not committed |
 | `plugin/dashboard/` | Next.js management UI for interactions, preferences, skills, configuration |
@@ -99,14 +101,21 @@ Condensed install/uninstall commands live in the [README Quick Start](./README.m
 
 ### Claude Code
 
-`npx claude-smart install` registers the bundled package as a marketplace and installs the plugin. The manual marketplace equivalent:
+`npx claude-smart install` registers the bundled npm package as a local
+marketplace and installs the plugin.
 
-```bash
-claude plugin marketplace add ReflexioAI/claude-smart
-claude plugin install claude-smart@reflexioai
-```
+`ReflexioAI/claude-smart` cannot be installed as a GitHub marketplace: the
+generated `plugin/vendor/reflexio` runtime is gitignored and exists only in
+packaged npm artifacts, so the marketplace manifest is generated at pack time
+rather than committed (see [Versioning](#versioning)). `claude plugin
+marketplace add ReflexioAI/claude-smart` therefore fails with `Marketplace file
+not found` instead of installing a plugin whose backend can never start.
 
-If installed via the marketplace, uninstall with `claude plugin uninstall claude-smart@reflexioai` instead of `npx claude-smart uninstall`.
+For anyone already in that state from an earlier release, the npm installer
+repairs it: it detects a Claude cache for the version it is installing that is
+missing the vendor bundle and replaces it before preparing or restarting
+services. It only ever inspects the cache directory matching its own version —
+other cached versions vendor a different Reflexio and are left alone.
 
 ### Codex
 
@@ -187,12 +196,36 @@ mismatches in `claude plugin list` vs. `npm view claude-smart version`.
 | `plugin/pyproject.toml` | `project.version` |
 | `plugin/.claude-plugin/plugin.json` | `.version` |
 | `plugin/.codex-plugin/plugin.json` | `.version` |
-| `.claude-plugin/marketplace.json` | `.plugins[0].version` |
 | `package-lock.json` | root package version |
 | `plugin/uv.lock` | `claude-smart` package version |
 | `README.md` | version badge |
 
 Don't edit these by hand — use `make bump`.
+
+`.claude-plugin/marketplace.json` is deliberately absent from this table: it does
+not exist in the repo. It is generated at pack time by
+`scripts/generate-marketplace.js` (npm's `prepack` hook), which stamps it with
+`package.json`'s version — so it cannot drift, and there is nothing to bump.
+
+### Why the marketplace entry is generated, not committed
+
+The manifest is what makes a directory installable as a Claude Code marketplace.
+The plugin it advertises is **incomplete in git**: `plugin/vendor/reflexio` is
+generated at pack time and gitignored. If the manifest were committed,
+`claude plugin marketplace add ReflexioAI/claude-smart` would install a plugin
+with no Reflexio runtime — one that can never start its backend.
+
+With the manifest absent from the repo, that command fails immediately
+(`Marketplace file not found`), and the only way in is the npm package, which
+carries both the manifest and the vendor bundle. `npx claude-smart install`
+registers the npm package root as the marketplace, so the supported path is
+unaffected. As a backstop, `smart-install.sh` fails Setup outright if a host
+plugin cache (`*/plugins/cache/*`) is missing the vendor bundle, since that can
+only mean a GitHub-marketplace install.
+
+Local development is unaffected: the integration harness runs from the checkout
+without registering a marketplace, and a tarball install goes through
+`make package`, which generates both artifacts.
 
 ## Release flow
 
@@ -339,13 +372,17 @@ make publish-dry
 
 ### How users pick up the new release
 
-Once published, end users update to the latest version with either:
+Once published, end users update to the latest version with:
 
 ```bash
 npx claude-smart update
 ```
 
-Both wrap `claude plugin update claude-smart@reflexioai`. Users restart Claude Code to apply. Codex users rerun `npx claude-smart install --host codex`, then restart Codex after `/plugins` has upgraded the installed plugin.
+The command re-registers the bundled npm package, repairs an incomplete Claude
+cache for that version when necessary, and reinstalls the plugin. Users
+restart Claude Code to apply. Codex users rerun
+`npx claude-smart install --host codex`, then restart Codex after `/plugins` has
+upgraded the installed plugin.
 
 ## Pre-release checklist
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -223,9 +223,15 @@ unaffected. As a backstop, `smart-install.sh` fails Setup outright if a host
 plugin cache (`*/plugins/cache/*`) is missing the vendor bundle, since that can
 only mean a GitHub-marketplace install.
 
-Local development is unaffected: the integration harness runs from the checkout
-without registering a marketplace, and a tarball install goes through
-`make package`, which generates both artifacts.
+Anything that installs **the checkout itself** as a marketplace must generate the
+manifest first — exactly as it already generates `plugin/vendor/reflexio`. Both
+artifacts are pack-time products, and neither is in git:
+
+- `make package` / `npm pack` / `npm publish` — the `prepack` hook handles it.
+- `tests/integration/integration.sh` — `prepare_marketplace_manifest` handles it,
+  alongside `prepare_vendored_reflexio`.
+
+To generate it by hand: `npm run gen:marketplace`.
 
 ## Release flow
 

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,12 @@
         check-vendor-reflexio \
         check-locked-project-version check-standalone-lock relock unskip-worktree
 
+# .claude-plugin/marketplace.json is intentionally absent: it is generated at
+# pack time from package.json's version by scripts/generate-marketplace.js (via
+# npm's prepack hook), so there is nothing here to bump.
 VERSION_FILES := package.json plugin/pyproject.toml \
                  plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json \
-                 .claude-plugin/marketplace.json README.md
+                 README.md
 LOCK_FILES    := package-lock.json plugin/uv.lock reflexio.lock.json
 PYPROJECT     := plugin/pyproject.toml
 
@@ -100,14 +103,13 @@ relock: unskip-worktree ## Regenerate plugin/uv.lock as a standalone lockfile (r
 bump: check-version unskip-worktree ## Rewrite version in all release manifests
 	@echo "→ bumping to $(VERSION)"
 	@sed -i.bak -E 's/"version": "[^"]+"/"version": "$(VERSION)"/' \
-	    package.json plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json \
-	    .claude-plugin/marketplace.json
+	    package.json plugin/.claude-plugin/plugin.json plugin/.codex-plugin/plugin.json
 	@sed -i.bak -E 's/^version = "[^"]+"/version = "$(VERSION)"/' plugin/pyproject.toml
 	@python3 -c 'import json, pathlib; p=pathlib.Path("package-lock.json"); data=json.loads(p.read_text()); data["version"]="$(VERSION)"; data["packages"][""]["version"]="$(VERSION)"; p.write_text(json.dumps(data, indent=2) + "\n")'
 	@sed -i.bak -E 's|badge/version-[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?-green\.svg|badge/version-$(VERSION)-green.svg|' README.md
 	@rm -f package.json.bak plugin/pyproject.toml.bak \
 	       plugin/.claude-plugin/plugin.json.bak plugin/.codex-plugin/plugin.json.bak \
-	       .claude-plugin/marketplace.json.bak README.md.bak
+	       README.md.bak
 	@echo "→ regenerating standalone plugin/uv.lock (resolves reflexio-ai from PyPI)"
 	@# plugin/ is a member of the enterprise uv workspace, so `uv lock --project
 	@# plugin` writes the PARENT lockfile and leaves plugin/uv.lock's dependency

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npx claude-smart uninstall --host opencode    # OpenCode
 
 Restart the host afterward. Learned data under `~/.reflexio/` and `~/.claude-smart/` is preserved and shared across hosts, so you can uninstall or switch hosts without losing skills or preferences.
 
-For per-host details — the Claude Code plugin-marketplace alternative, what the installers and uninstallers touch, OpenCode config resolution and model/env overrides, and Windows notes — see [Host install notes](./DEVELOPER.md#host-install-notes) in DEVELOPER.md. Developing the plugin itself? See [Developing locally](./DEVELOPER.md#developing-locally).
+For per-host details — what the installers and uninstallers touch, OpenCode config resolution and model/env overrides, and Windows notes — see [Host install notes](./DEVELOPER.md#host-install-notes) in DEVELOPER.md. Developing the plugin itself? See [Developing locally](./DEVELOPER.md#developing-locally).
 
 > **Not supported:** Claude Code Cowork, claude.ai/code web, or remote Codex environments without local plugin hooks — they run outside your local machine, so the local backend/dashboard and `~/.reflexio/` aren't reachable.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -24,6 +24,26 @@ The default local semantic search uses `onnxruntime`, which loads Microsoft nati
 **Install reports `install-failed`.**
 `~/.claude-smart/install-failed` is reserved for core setup failures such as `uv` installation or `uv sync --locked --python 3.12`. Fix the reported issue, delete the marker, then restart Claude Code so Setup can retry. Dashboard-only issues should appear in `~/.claude-smart/dashboard-unavailable` instead.
 
+**Backend log repeats `bundled Reflexio import preflight failed`.**
+This means claude-smart was installed from the GitHub marketplace, whose
+checkout intentionally excludes the generated Reflexio runtime bundle. Current
+releases make that install impossible (`claude plugin marketplace add
+ReflexioAI/claude-smart` now fails with `Marketplace file not found`), but an
+install from an older release can still be in this state. Repair the cache from
+the packaged npm artifact:
+
+```bash
+npx claude-smart update
+```
+
+The installer replaces an incomplete cache for the version it is installing.
+Restart Claude Code afterward. Do not use `claude plugin marketplace add
+ReflexioAI/claude-smart`; use the npm command for installation and updates.
+
+`/claude-smart:restart` cannot repair this — it preflights the same missing
+bundle and deliberately leaves your running services alone rather than stopping
+a backend it cannot replace. Use `npx claude-smart update`.
+
 **Where are private install tools stored?**
 `uv` is installed into the standard Astral locations (`~/.local/bin` or `~/.cargo/bin`). The private dashboard runtime is at `~/.claude-smart/node/current`. Set `CLAUDE_SMART_NODE_LTS_MAJOR=22` to choose the Node LTS major used by the private bootstrap.
 

--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -816,6 +816,66 @@ function fileSha256(path) {
   return crypto.createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
+function claudeCodeCacheRoot() {
+  return join(homedir(), ".claude", "plugins", "cache", CODEX_MARKETPLACE_NAME, "claude-smart");
+}
+
+// Version of the plugin this npm package ships. The Claude Code cache is keyed
+// by this version, and each version vendors a different Reflexio — so the
+// vendor payload may only ever be compared against the cache dir for *this*
+// version. Comparing against some other version's cache reports a spurious
+// mismatch (its vendor legitimately differs) and would force a pointless
+// reinstall.
+function claudeCodePackageVersion(sourceRoot = join(PACKAGE_ROOT, "plugin")) {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(sourceRoot, ".claude-plugin", "plugin.json"), "utf8"),
+    );
+    if (typeof manifest.version === "string" && manifest.version) return manifest.version;
+  } catch {
+    // Fall through to pyproject.toml.
+  }
+  try {
+    const match = readFileSync(join(sourceRoot, "pyproject.toml"), "utf8").match(
+      /^version\s*=\s*"([^"]+)"/m,
+    );
+    if (match) return match[1];
+  } catch {
+    // No readable version.
+  }
+  return null;
+}
+
+function claudeCodeVendorPayloadMismatch(
+  pluginRoot,
+  sourceRoot = join(PACKAGE_ROOT, "plugin"),
+) {
+  // A sentinel pair, not a full tree hash: it catches the failure this exists
+  // for (a cache with no vendor bundle at all, or one from a different build),
+  // not a vendor tree that is individually corrupt past these two files.
+  const vendorFiles = [
+    "vendor/reflexio/pyproject.toml",
+    "vendor/reflexio/reflexio/__init__.py",
+  ];
+  // A git checkout gitignores the generated vendor bundle, so a source tree
+  // without one is a dev install, not a broken cache. Nothing to compare.
+  const sourceHasVendor = vendorFiles.some((rel) =>
+    existsSync(join(sourceRoot, rel)),
+  );
+  if (!sourceHasVendor) return null;
+
+  for (const rel of vendorFiles) {
+    const source = join(sourceRoot, rel);
+    const cached = join(pluginRoot, rel);
+    if (!existsSync(source)) {
+      throw new Error(`installed claude-smart package is missing ${rel}`);
+    }
+    if (!existsSync(cached)) return rel;
+    if (fileSha256(source) !== fileSha256(cached)) return rel;
+  }
+  return null;
+}
+
 function verifyOpenCodePluginPackage(packageRoot) {
   const sourceScript = join(PACKAGE_ROOT, "plugin", "scripts", "smart-install.sh");
   const copiedScript = join(packageRoot, "plugin", "scripts", "smart-install.sh");
@@ -948,6 +1008,48 @@ async function bootstrapClaudeCodeInstall() {
     throw new Error(`smart-install.sh failed in ${pluginRoot}`);
   }
   throwIfInstallFailureMarker();
+  return pluginRoot;
+}
+
+async function refreshClaudeCodeCacheIfVendorMissing() {
+  const version = claudeCodePackageVersion();
+  if (!version) return null;
+  // Only ever inspect and repair the cache dir for the version we are
+  // installing. Other version dirs coexist in the cache and are not ours to
+  // judge — `findClaudeCodePluginRoot()` returns the highest one, which is a
+  // different plugin build whenever this package is a downgrade.
+  const pluginRoot = join(claudeCodeCacheRoot(), version);
+  if (!existsSync(pluginRoot)) return null;
+
+  const mismatch = claudeCodeVendorPayloadMismatch(pluginRoot);
+  if (!mismatch) return pluginRoot;
+
+  process.stderr.write(
+    `warning: cached claude-smart plugin is missing or has stale ${mismatch}; reinstalling from the bundled npm package.\n`,
+  );
+  let code = await runClaude(["plugin", "uninstall", PLUGIN_SPEC], {
+    spinnerLabel: "Removing stale claude-smart cache…",
+  });
+  if (code !== 0) {
+    throw new Error(`could not remove stale ${PLUGIN_SPEC} cache (exit ${code})`);
+  }
+  code = await runClaude(["plugin", "install", PLUGIN_SPEC], {
+    spinnerLabel: "Refreshing claude-smart cache…",
+  });
+  if (code !== 0) {
+    throw new Error(`could not reinstall ${PLUGIN_SPEC} from the bundled package (exit ${code})`);
+  }
+
+  if (!existsSync(pluginRoot)) {
+    throw new Error(`Claude Code did not recreate the claude-smart plugin cache at ${pluginRoot}`);
+  }
+  const remainingMismatch = claudeCodeVendorPayloadMismatch(pluginRoot);
+  if (remainingMismatch) {
+    throw new Error(
+      `refreshed claude-smart cache still does not match the bundled npm package: ${remainingMismatch}`,
+    );
+  }
+  process.stdout.write("Refreshed stale claude-smart plugin cache from the bundled npm package.\n");
   return pluginRoot;
 }
 
@@ -2181,6 +2283,7 @@ async function runInstall(args, options = {}) {
   }
 
   try {
+    await refreshClaudeCodeCacheIfVendorMissing();
     const pluginRoot = await bootstrapClaudeCodeInstall();
     restorePublishHooksFromSource(pluginRoot);
     if (readOnly) {
@@ -2492,6 +2595,8 @@ if (require.main === module) {
 module.exports = {
   assertSupportedRuntimePlatform,
   bootstrapPluginRuntime,
+  claudeCodePackageVersion,
+  claudeCodeVendorPayloadMismatch,
   codexMarketplacePluginRoot,
   copyCodexMarketplace,
   ensurePrivateNode,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "scripts": {
     "build:opencode": "tsc -p plugin/opencode/tsconfig.json",
-    "prepack": "npm run build:opencode"
+    "prepack": "npm run gen:marketplace && npm run build:opencode",
+    "gen:marketplace": "node scripts/generate-marketplace.js"
   },
   "bin": {
     "claude-smart": "bin/claude-smart.js"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,13 +9,14 @@ This directory is the Claude Code/Codex/OpenCode plugin payload shipped through 
 ### Claude Code
 
 ```bash
-claude plugin marketplace add ReflexioAI/claude-smart
-claude plugin install claude-smart@reflexioai
+npx claude-smart install
 ```
 
 The Setup hook bootstraps `uv`, Python 3.12, and a private Node.js/npm runtime
 under `~/.claude-smart/` when they are missing. If Node.js is already installed,
-`npx claude-smart install` is equivalent.
+the npm installer also supplies the generated Reflexio runtime bundle that is
+not committed to the GitHub repository. Installing this repository directly as
+a Claude Code marketplace is therefore unsupported.
 
 Add `--read-only` to either install command to skip hooks that publish
 interactions for learning.

--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -4,6 +4,8 @@
 # so the SessionStart hook doesn't block the session.
 #
 # Subcommands:
+#   preflight     verify that this plugin can import its bundled Reflexio
+#                 runtime without changing any running service.
 #   start         probe /health; if nothing we recognize is on the port,
 #                 spawn the prepared venv's `reflexio services start --only
 #                 backend --no-reload` detached. Polls /health briefly so first
@@ -136,14 +138,19 @@ claude_smart_trim_log_file "$LOG_FILE" "$LOG_MAX_BYTES"
 
 emit_ok() { claude_smart_emit_continue; }
 
+# Reason string for a failed bundled-Reflexio preflight. Shared by every site
+# that reports it so the remedy text in emit_start_failure stays in sync.
+VENDOR_PREFLIGHT_FAILURE="bundled Reflexio import preflight failed"
+
 emit_start_failure() {
   reason="$1"
   if py=$(claude_smart_resolve_python 2>/dev/null); then
-    "$py" - "$reason" <<'PY'
+    "$py" - "$reason" "$VENDOR_PREFLIGHT_FAILURE" <<'PY'
 import json
 import sys
 
 reason = sys.argv[1].strip()
+vendor_preflight_failure = sys.argv[2]
 message = (
     "> **claude-smart learning backend is not running.** "
     "Interactions are being buffered locally, but learning will not publish "
@@ -151,11 +158,19 @@ message = (
 )
 if reason:
     message += f">\n> Last startup error: `{reason}`\n"
-message += (
-    ">\n> Make sure the local model provider is available: Claude Code needs "
-    "`claude`, Codex needs `codex`, and OpenCode needs `opencode`. "
-    "Then run `/claude-smart:restart`."
-)
+if reason == vendor_preflight_failure:
+    # /claude-smart:restart cannot repair this: the bundled Reflexio runtime
+    # only ships in the npm artifact, so the cache has to be replaced.
+    message += (
+        ">\n> The bundled Reflexio runtime is missing or unusable. Repair it "
+        "with `npx claude-smart update`, then restart Claude Code."
+    )
+else:
+    message += (
+        ">\n> Make sure the local model provider is available: Claude Code needs "
+        "`claude`, Codex needs `codex`, and OpenCode needs `opencode`. "
+        "Then run `/claude-smart:restart`."
+    )
 print(json.dumps({
     "hookSpecificOutput": {
         "hookEventName": "SessionStart",
@@ -562,6 +577,31 @@ except ValueError:
 PY
 }
 
+prepare_backend_import_context() {
+  backend_pythonpath="${PYTHONPATH:-}"
+  if [ -d "$VENDORED_REFLEXIO/reflexio" ]; then
+    vendor_pythonpath="$VENDORED_REFLEXIO"
+    pythonpath_sep=":"
+    if claude_smart_is_windows; then
+      # Native Windows Python expects ;-separated Windows-style paths in
+      # PYTHONPATH; MSYS does not auto-convert arbitrary env vars.
+      pythonpath_sep=";"
+      vendor_pythonpath="$VENDORED_REFLEXIO_FOR_PYTHON"
+    fi
+    backend_pythonpath="$vendor_pythonpath${backend_pythonpath:+$pythonpath_sep$backend_pythonpath}"
+  fi
+  backend_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"
+}
+
+# Repair the vendored install if its version drifted, then prove this plugin
+# can import its own bundled Reflexio. Callers run this before any action that
+# would stop or replace a running service.
+preflight_bundled_reflexio_runtime() {
+  ensure_vendored_reflexio_active || return 1
+  prepare_backend_import_context
+  verify_bundled_reflexio_import "$backend_python" "$backend_pythonpath" "$VENDORED_REFLEXIO_FOR_PYTHON"
+}
+
 # True only if the recorded PID is alive, /health responds, and the listener
 # process is using this package's bundled Reflexio import path.
 is_our_backend_running() {
@@ -778,6 +818,19 @@ full_stop() {
 }
 
 case "$CMD" in
+  preflight)
+    if claude_smart_reflexio_url_is_remote \
+      || [ "${CLAUDE_SMART_BACKEND_AUTOSTART:-1}" = "0" ]; then
+      exit 0
+    fi
+    if ! preflight_bundled_reflexio_runtime; then
+      echo "claude-smart backend preflight failed ($VENDOR_PREFLIGHT_FAILURE);" \
+        "existing services were not changed" >&2
+      echo "Repair the bundled runtime with: npx claude-smart update" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
   start)
     if claude_smart_is_internal_invocation_env; then
       emit_ok; exit 0
@@ -828,6 +881,28 @@ case "$CMD" in
         "[claude-smart] backend: recorded backend process is still running but not healthy yet; skipping duplicate start"
       emit_ok; exit 0
     fi
+    # Everything above only accepts an existing healthy backend; everything
+    # below stops or replaces one. The bundled-runtime checks sit on that
+    # boundary: if this plugin cannot run its own backend, report that without
+    # tearing down a backend that is currently serving.
+    if ! command -v uv >/dev/null 2>&1; then
+      if [ "${CLAUDE_SMART_BOOTSTRAPPING:-}" != "1" ] && [ -x "$PLUGIN_ROOT/scripts/smart-install.sh" ]; then
+        claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: uv not on PATH; starting installer in background"
+        CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
+          bash "$PLUGIN_ROOT/scripts/smart-install.sh" \
+          >>"$STATE_DIR/install.log" 2>&1 || true
+      fi
+      if ! command -v uv >/dev/null 2>&1; then
+        claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: uv not on PATH; installer recovery scheduled; skipping"
+        emit_ok; exit 0
+      fi
+    fi
+    if ! preflight_bundled_reflexio_runtime; then
+      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
+        "[claude-smart] backend: $VENDOR_PREFLIGHT_FAILURE; existing services were not changed"
+      emit_start_failure "$VENDOR_PREFLIGHT_FAILURE"
+      exit 0
+    fi
     if recorded_backend_pid_alive; then
       claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" \
         "[claude-smart] backend: recorded backend process exceeded startup grace without health; restarting"
@@ -850,20 +925,7 @@ case "$CMD" in
       echo "Free port $PORT (or stop the process above) and run /claude-smart:restart again." >&2
       emit_ok; exit 0
     fi
-    if ! command -v uv >/dev/null 2>&1; then
-      if [ "${CLAUDE_SMART_BOOTSTRAPPING:-}" != "1" ] && [ -x "$PLUGIN_ROOT/scripts/smart-install.sh" ]; then
-        claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: uv not on PATH; starting installer in background"
-        CLAUDE_SMART_SPAWN_KEEP_OUTPUT=1 claude_smart_spawn_detached env CLAUDE_SMART_BOOTSTRAPPING=1 \
-          bash "$PLUGIN_ROOT/scripts/smart-install.sh" \
-          >>"$STATE_DIR/install.log" 2>&1 || true
-      fi
-      if ! command -v uv >/dev/null 2>&1; then
-        claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: uv not on PATH; installer recovery scheduled; skipping"
-        emit_ok; exit 0
-      fi
-    fi
     cd "$PLUGIN_ROOT"
-    ensure_vendored_reflexio_active
 
     # Cap local interaction history to keep the SQLite store small for
     # claude-smart users. Reflexio's library defaults are much higher
@@ -887,19 +949,6 @@ case "$CMD" in
     # without touching the file on disk.
     export REFLEXIO_STORAGE="sqlite"
 
-    backend_pythonpath="${PYTHONPATH:-}"
-    if [ -d "$VENDORED_REFLEXIO/reflexio" ]; then
-      vendor_pythonpath="$VENDORED_REFLEXIO"
-      pythonpath_sep=":"
-      if claude_smart_is_windows; then
-        # Native Windows Python expects ;-separated Windows-style paths in
-        # PYTHONPATH; MSYS does not auto-convert arbitrary env vars.
-        pythonpath_sep=";"
-        vendor_pythonpath="$VENDORED_REFLEXIO_FOR_PYTHON"
-      fi
-      backend_pythonpath="$vendor_pythonpath${backend_pythonpath:+$pythonpath_sep$backend_pythonpath}"
-    fi
-
     # (nohup; no process groups). backend-log-runner.sh owns stdout/stderr
     # capture so process output cannot grow backend.log past its cap.
     #
@@ -911,13 +960,10 @@ case "$CMD" in
     # CLAUDE_SMART_BACKEND_WORKERS for power users running concurrent
     # Claude Code sessions or wanting zero-downtime recycling.
     workers="${CLAUDE_SMART_BACKEND_WORKERS:-1}"
-    backend_python="$(claude_smart_plugin_python "$PLUGIN_ROOT")"
-    if ! verify_bundled_reflexio_import "$backend_python" "$backend_pythonpath" "$VENDORED_REFLEXIO_FOR_PYTHON"; then
-      reason="bundled Reflexio import preflight failed"
-      claude_smart_append_capped_log "$LOG_FILE" "$LOG_MAX_BYTES" "[claude-smart] backend: $reason"
-      emit_start_failure "$reason"
-      exit 0
-    fi
+    # Sets backend_python / backend_pythonpath for the spawn below. Already run
+    # by the preflight above; repeated here so the spawn does not depend on a
+    # side effect of an earlier, reorderable step.
+    prepare_backend_import_context
     # Record the spawned pid, not a pgid sampled with ps. On POSIX,
     # setsid/python os.setsid make this pid the new process group leader;
     # sampling immediately can race and capture the caller's pgid instead.

--- a/plugin/scripts/smart-install.sh
+++ b/plugin/scripts/smart-install.sh
@@ -149,7 +149,21 @@ install_vendored_reflexio() {
   local VENDORED_REFLEXIO PLUGIN_PYTHON
 
   VENDORED_REFLEXIO="$PLUGIN_ROOT/vendor/reflexio"
-  [ -f "$VENDORED_REFLEXIO/pyproject.toml" ] || return 0
+  if [ ! -f "$VENDORED_REFLEXIO/pyproject.toml" ]; then
+    # A host plugin cache (~/.claude/plugins/cache/..., ~/.codex/plugins/cache/...)
+    # is only ever populated from the npm package, which always carries the
+    # vendored runtime. Missing it there means the plugin was installed straight
+    # from the GitHub marketplace, where the bundle is gitignored — the backend
+    # could never start. Fail here, at Setup, rather than at first session.
+    case "$PLUGIN_ROOT" in
+      */plugins/cache/*)
+        write_failure "bundled Reflexio runtime is missing from $VENDORED_REFLEXIO. This happens when claude-smart is installed from the GitHub marketplace, which does not carry the generated runtime. Install with: npx claude-smart install"
+        ;;
+    esac
+    # A source checkout legitimately has no vendor bundle (it is generated at
+    # pack time); reflexio comes from the plugin venv instead.
+    return 0
+  fi
 
   if claude_smart_is_windows; then
     PLUGIN_PYTHON="$PLUGIN_ROOT/.venv/Scripts/python.exe"

--- a/plugin/src/claude_smart/cli.py
+++ b/plugin/src/claude_smart/cli.py
@@ -2185,6 +2185,20 @@ def cmd_restart(args: argparse.Namespace) -> int:
         return 0
 
     if do_backend:
+        # Preparing the replacement can reinstall the vendored Reflexio if its
+        # version drifted, so this both validates and repairs. It must succeed
+        # before we stop anything: a backend we cannot replace is better left
+        # running.
+        sys.stdout.write("Preparing reflexio backend replacement…\n")
+        preflight_rc = _run_service(_BACKEND_SCRIPT, "preflight")
+        if preflight_rc != 0:
+            sys.stderr.write(
+                "error: reflexio backend replacement failed preflight; "
+                "existing services were not changed.\n"
+                "Repair the bundled runtime with: npx claude-smart update\n"
+            )
+            return preflight_rc
+
         sys.stdout.write("Stopping reflexio backend…\n")
         _run_service(_BACKEND_SCRIPT, "stop")
     if do_dashboard:

--- a/scripts/generate-marketplace.js
+++ b/scripts/generate-marketplace.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Generate .claude-plugin/marketplace.json from the committed template.
+//
+// The manifest is deliberately NOT committed. It is the file that makes a
+// directory installable as a Claude Code marketplace, and the plugin payload it
+// advertises is incomplete in git: plugin/vendor/reflexio is generated at pack
+// time and gitignored. Committing the manifest would let
+// `claude plugin marketplace add ReflexioAI/claude-smart` install a plugin with
+// no Reflexio runtime. With the manifest absent from the repo, that command
+// fails immediately ("Marketplace file not found") instead of producing a
+// plugin that cannot start.
+//
+// npm's prepack hook runs this, so every `npm pack` / `npm publish` — and the
+// Makefile targets that wrap them — ships a manifest whose version matches
+// package.json by construction.
+
+const { readFileSync, writeFileSync } = require("node:fs");
+const { join, dirname } = require("node:path");
+
+const REPO_ROOT = dirname(__dirname);
+const TEMPLATE = join(REPO_ROOT, ".claude-plugin", "marketplace.template.json");
+const OUTPUT = join(REPO_ROOT, ".claude-plugin", "marketplace.json");
+
+function main() {
+  const { version } = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8"));
+  if (!version) {
+    throw new Error("package.json has no version");
+  }
+
+  const manifest = JSON.parse(readFileSync(TEMPLATE, "utf8"));
+  if (!Array.isArray(manifest.plugins) || manifest.plugins.length === 0) {
+    throw new Error(`${TEMPLATE} declares no plugins`);
+  }
+  // package.json is the single source of version truth; `make bump` no longer
+  // rewrites this manifest because it does not exist until pack time.
+  for (const plugin of manifest.plugins) {
+    plugin.version = version;
+  }
+
+  writeFileSync(OUTPUT, `${JSON.stringify(manifest, null, 2)}\n`);
+  // stderr, not stdout: this runs as npm's prepack hook, and `npm pack` prints
+  // the tarball path on stdout. Callers read that path (`npm pack | tail -1` in
+  // the Makefile), so anything else on stdout corrupts it.
+  process.stderr.write(`generated .claude-plugin/marketplace.json (version ${version})\n`);
+}
+
+main();

--- a/tests/integration/integration.sh
+++ b/tests/integration/integration.sh
@@ -236,6 +236,21 @@ prepare_vendored_reflexio() {
     --write
 }
 
+# The Claude marketplace manifest is generated at pack time (npm prepack) and is
+# not committed, so that the GitHub repo cannot be installed as a marketplace
+# with no Reflexio runtime. This harness installs the checkout as a marketplace,
+# so it must generate the manifest itself — same as it does for the vendor
+# bundle above.
+prepare_marketplace_manifest() {
+  log "setup: generating .claude-plugin/marketplace.json"
+  if ! command -v node >/dev/null 2>&1; then
+    fail "node not on PATH — required to generate the marketplace manifest"
+  fi
+  if ! node "$REPO_ROOT/scripts/generate-marketplace.js"; then
+    fail "could not generate .claude-plugin/marketplace.json"
+  fi
+}
+
 stage_setup() {
   log "setup: sandbox HOME=$HOME"
   if ! command -v claude >/dev/null 2>&1; then
@@ -246,6 +261,7 @@ stage_setup() {
   export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-dummy-for-plugin-install}"
 
   prepare_vendored_reflexio
+  prepare_marketplace_manifest
 
   log "setup: claude plugin marketplace add $REPO_ROOT"
   if ! claude plugin marketplace add "$REPO_ROOT" >"$HOME/marketplace-add.log" 2>&1; then

--- a/tests/test_cli_restart.py
+++ b/tests/test_cli_restart.py
@@ -149,7 +149,7 @@ def test_restart_skips_rebuild_when_npm_missing(
     # stop backend, stop dashboard, start backend, start dashboard
     # (trailing status calls for the status-line are not part of the contract).
     lifecycle = [sub for _name, sub in service_calls if sub != "status"]
-    assert lifecycle == ["stop", "stop", "start", "start"]
+    assert lifecycle == ["preflight", "stop", "stop", "start", "start"]
     err = capsys.readouterr().err
     assert "npm not on PATH" in err
 
@@ -191,7 +191,7 @@ def test_restart_starts_backend_even_when_dashboard_build_fails(
         for name, sub in service_calls
         if name == "dashboard-service.sh" and sub != "status"
     ]
-    assert subs == ["stop", "start"]
+    assert subs == ["preflight", "stop", "start"]
     assert dash_subs == ["stop"]
     out = capsys.readouterr()
     assert "dashboard build failed" in out.err
@@ -233,7 +233,7 @@ def test_restart_starts_backend_when_dashboard_build_launch_fails(
         for name, sub in service_calls
         if name == "dashboard-service.sh" and sub != "status"
     ]
-    assert subs == ["stop", "start"]
+    assert subs == ["preflight", "stop", "start"]
     assert dash_subs == ["stop"]
     out = capsys.readouterr()
     assert "dashboard build failed" in out.err
@@ -245,6 +245,30 @@ def test_restart_no_rebuild_flag_skips_npm(fake_services) -> None:
     rc = cli.cmd_restart(_make_args(no_rebuild=True))
     assert rc == 0
     assert build_calls == []
+
+
+def test_restart_failed_backend_preflight_preserves_services(
+    fake_services, monkeypatch, capsys
+) -> None:
+    service_calls, build_calls = fake_services
+
+    def fake_run(cmd, cwd=None, check=False, capture_output=False, text=False):
+        argv = [str(c) for c in cmd]
+        if argv[-1] == "preflight":
+            service_calls.append(("backend-service.sh", "preflight"))
+            raise subprocess.CalledProcessError(1, argv)
+        raise AssertionError(f"unexpected command after failed preflight: {argv}")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    rc = cli.cmd_restart(_make_args())
+
+    assert rc == 1
+    assert service_calls == [("backend-service.sh", "preflight")]
+    assert build_calls == []
+    output = capsys.readouterr()
+    assert "existing services were not changed" in output.err
+    assert "Stopping" not in output.out
 
 
 def test_restart_uses_npm_ci_when_lockfile_exists(fake_services) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1076,6 +1076,7 @@ def test_node_install_reads_managed_env_and_bootstraps_latest_cache(
 
     old_root = cache_root / "0.2.31"
     new_root = cache_root / "0.2.32"
+    shutil.copytree(REPO_ROOT / "plugin" / "vendor", new_root / "vendor")
     old_mtime = new_root.stat().st_mtime + 100
     os.utime(old_root, (old_mtime, old_mtime))
 
@@ -1139,6 +1140,7 @@ def test_npx_install_reads_managed_env(tmp_path: Path) -> None:
         '[ "$REFLEXIO_API_KEY" = "rflx-test-secret" ] || exit 42\n'
     )
     install.chmod(install.stat().st_mode | stat.S_IXUSR)
+    shutil.copytree(REPO_ROOT / "plugin" / "vendor", cache_root / "vendor")
 
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
@@ -1289,6 +1291,221 @@ def test_node_update_retries_install_after_uninstall(tmp_path: Path) -> None:
     ]
 
 
+def test_node_install_refreshes_same_version_cache_missing_vendor(
+    tmp_path: Path,
+) -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for Node installer test")
+
+    package_root = tmp_path / "package"
+    plugin_source = package_root / "plugin"
+    scripts = plugin_source / "scripts"
+    vendor = plugin_source / "vendor" / "reflexio"
+    (package_root / "bin").mkdir(parents=True)
+    scripts.mkdir(parents=True)
+    (vendor / "reflexio").mkdir(parents=True)
+    shutil.copy2(NODE_INSTALLER, package_root / "bin" / "claude-smart.js")
+    (plugin_source / "pyproject.toml").write_text(
+        '[project]\nname = "claude-smart"\nversion = "0.2.49"\n'
+    )
+    _write_executable(scripts / "smart-install.sh", "#!/bin/sh\nexit 0\n")
+    (vendor / "pyproject.toml").write_text(
+        '[project]\nname = "reflexio-ai"\nversion = "0.2.28"\n'
+    )
+    (vendor / "reflexio" / "__init__.py").write_text(
+        '__version__ = "0.2.28"\n'
+    )
+
+    cache = (
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "reflexioai"
+        / "claude-smart"
+        / "0.2.49"
+    )
+    (cache / "scripts").mkdir(parents=True)
+    shutil.copy2(plugin_source / "pyproject.toml", cache / "pyproject.toml")
+    shutil.copy2(scripts / "smart-install.sh", cache / "scripts" / "smart-install.sh")
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "claude",
+        "#!/bin/sh\n"
+        'printf \'claude %s\\n\' "$*" >> "$HOME/claude.log"\n'
+        'dest="$HOME/.claude/plugins/cache/reflexioai/claude-smart/0.2.49"\n'
+        'if [ "$1 $2" = "plugin uninstall" ]; then rm -rf "$dest"; exit 0; fi\n'
+        'if [ "$1 $2" = "plugin install" ] && [ ! -d "$dest" ]; then\n'
+        '  mkdir -p "$(dirname "$dest")"\n'
+        f"  cp -R {shlex.quote(str(plugin_source))} \"$dest\"\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    _write_executable(fake_bin / "bash", "#!/bin/sh\nexit 0\n")
+    env = _isolated_env(tmp_path)
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
+            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
+        }
+    )
+
+    result = subprocess.run(
+        [node, str(package_root / "bin" / "claude-smart.js"), "install"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "missing or has stale vendor/reflexio/pyproject.toml" in result.stderr
+    assert "Refreshed stale claude-smart plugin cache" in result.stdout
+    assert (cache / "vendor" / "reflexio" / "pyproject.toml").is_file()
+    assert (cache / "vendor" / "reflexio" / "reflexio" / "__init__.py").is_file()
+    assert (tmp_path / "claude.log").read_text().splitlines() == [
+        f"claude plugin marketplace add {package_root}",
+        "claude plugin install claude-smart@reflexioai",
+        "claude plugin uninstall claude-smart@reflexioai",
+        "claude plugin install claude-smart@reflexioai",
+    ]
+
+
+def test_node_install_ignores_cache_version_other_than_package_version(
+    tmp_path: Path,
+) -> None:
+    """A newer cache dir must not be judged against this package's vendor.
+
+    Each plugin version vendors a different Reflexio, so their vendor payloads
+    legitimately differ. Comparing against the highest cached version (rather
+    than our own) reports a spurious mismatch on any downgrade install and then
+    fails the install outright when the repair cannot converge.
+    """
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for Node installer test")
+
+    # The package being installed is an intentional downgrade: 0.2.48.
+    package_root = tmp_path / "package"
+    plugin_source = package_root / "plugin"
+    scripts = plugin_source / "scripts"
+    vendor = plugin_source / "vendor" / "reflexio"
+    (package_root / "bin").mkdir(parents=True)
+    scripts.mkdir(parents=True)
+    (vendor / "reflexio").mkdir(parents=True)
+    shutil.copy2(NODE_INSTALLER, package_root / "bin" / "claude-smart.js")
+    (plugin_source / "pyproject.toml").write_text(
+        '[project]\nname = "claude-smart"\nversion = "0.2.48"\n'
+    )
+    _write_executable(scripts / "smart-install.sh", "#!/bin/sh\nexit 0\n")
+    (vendor / "pyproject.toml").write_text(
+        '[project]\nname = "reflexio-ai"\nversion = "0.2.27"\n'
+    )
+    (vendor / "reflexio" / "__init__.py").write_text('__version__ = "0.2.27"\n')
+
+    # A newer 0.2.49 is already cached and perfectly healthy — it has its own
+    # (different) vendor bundle. Old version dirs persist in the real cache.
+    cache_root = tmp_path / ".claude" / "plugins" / "cache" / "reflexioai" / "claude-smart"
+    newer = cache_root / "0.2.49"
+    (newer / "scripts").mkdir(parents=True)
+    (newer / "pyproject.toml").write_text(
+        '[project]\nname = "claude-smart"\nversion = "0.2.49"\n'
+    )
+    _write_executable(newer / "scripts" / "smart-install.sh", "#!/bin/sh\nexit 0\n")
+    newer_vendor = newer / "vendor" / "reflexio"
+    (newer_vendor / "reflexio").mkdir(parents=True)
+    (newer_vendor / "pyproject.toml").write_text(
+        '[project]\nname = "reflexio-ai"\nversion = "0.2.28"\n'
+    )
+    (newer_vendor / "reflexio" / "__init__.py").write_text('__version__ = "0.2.28"\n')
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "claude",
+        "#!/bin/sh\n"
+        "printf 'claude %s\\n' \"$*\" >> \"$HOME/claude.log\"\n"
+        'dest="$HOME/.claude/plugins/cache/reflexioai/claude-smart/0.2.48"\n'
+        'if [ "$1 $2" = "plugin uninstall" ]; then rm -rf "$dest"; exit 0; fi\n'
+        'if [ "$1 $2" = "plugin install" ] && [ ! -d "$dest" ]; then\n'
+        '  mkdir -p "$(dirname "$dest")"\n'
+        f"  cp -R {shlex.quote(str(plugin_source))} \"$dest\"\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    _write_executable(fake_bin / "bash", "#!/bin/sh\nexit 0\n")
+    env = _isolated_env(tmp_path)
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "CLAUDE_SMART_BACKEND_AUTOSTART": "0",
+            "CLAUDE_SMART_DASHBOARD_AUTOSTART": "0",
+        }
+    )
+
+    result = subprocess.run(
+        [node, str(package_root / "bin" / "claude-smart.js"), "install"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "stale" not in result.stderr
+    assert "Refreshed stale" not in result.stdout
+    # The healthy newer cache is left untouched, and no repair cycle is run.
+    assert (newer_vendor / "pyproject.toml").read_text() == (
+        '[project]\nname = "reflexio-ai"\nversion = "0.2.28"\n'
+    )
+    assert (tmp_path / "claude.log").read_text().splitlines() == [
+        f"claude plugin marketplace add {package_root}",
+        "claude plugin install claude-smart@reflexioai",
+    ]
+
+
+def test_vendor_payload_mismatch_is_skipped_for_source_without_vendor(
+    tmp_path: Path,
+) -> None:
+    """A git checkout gitignores the vendor bundle — that is a dev install.
+
+    This guard is the only thing keeping local development from being treated
+    as a broken cache and force-reinstalled.
+    """
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for Node installer test")
+
+    source_root = tmp_path / "checkout" / "plugin"
+    source_root.mkdir(parents=True)
+    plugin_root = tmp_path / "cache" / "0.2.49"
+    plugin_root.mkdir(parents=True)
+
+    result = subprocess.run(
+        [
+            node,
+            "-e",
+            "const m = require(process.argv[1]);"
+            "console.log(JSON.stringify("
+            "m.claudeCodeVendorPayloadMismatch(process.argv[2], process.argv[3])"
+            "));",
+            str(NODE_INSTALLER),
+            str(plugin_root),
+            str(source_root),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "null"
+
+
 def test_dashboard_service_loads_reflexio_env_for_managed_proxy() -> None:
     dashboard = (REPO_ROOT / "plugin" / "scripts" / "dashboard-service.sh").read_text()
 
@@ -1331,6 +1548,8 @@ def test_backend_service_verifies_bundled_reflexio_runtime_identity() -> None:
         in backend
     )
     assert "verify_bundled_reflexio_import()" in backend
+    assert "preflight_bundled_reflexio_runtime()" in backend
+    assert "existing services were not changed" in backend
     assert "reflexio.__file__" in backend
     assert "module.relative_to(vendor)" in backend
     assert "reflexio import resolved outside bundled vendor" in backend
@@ -1956,9 +2175,9 @@ def test_smart_install_installs_vendored_reflexio(tmp_path: Path) -> None:
 
 
 def _prepare_smart_install_sync_fixture(
-    tmp_path: Path, *, mode: str
+    tmp_path: Path, *, mode: str, plugin_root: Path | None = None
 ) -> tuple[Path, Path, dict[str, str]]:
-    plugin_root = tmp_path / "plugin"
+    plugin_root = plugin_root or (tmp_path / "plugin")
     scripts = plugin_root / "scripts"
     fake_bin = tmp_path / "bin"
     scripts.mkdir(parents=True)
@@ -2093,6 +2312,58 @@ def test_smart_install_rerun_preserves_existing_host(tmp_path: Path) -> None:
     assert (tmp_path / "uv.log").read_text().count(
         "sync --locked --python 3.12 --quiet"
     ) == 1
+
+
+def test_smart_install_fails_loudly_when_host_cache_has_no_vendor(
+    tmp_path: Path,
+) -> None:
+    """A host plugin cache without a vendor bundle is a GitHub-marketplace install.
+
+    The cache is only ever populated from the npm package, which always carries
+    the vendored runtime, so its absence means the backend can never start.
+    Setup must say so — and name the command that repairs it — instead of
+    succeeding and leaving the failure to the first session start.
+    """
+    cache_root = (
+        tmp_path / ".claude" / "plugins" / "cache" / "reflexioai" / "claude-smart" / "0.2.49"
+    )
+    _plugin_root, smart_install, env = _prepare_smart_install_sync_fixture(
+        tmp_path, mode="fresh", plugin_root=cache_root
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(smart_install)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    marker = tmp_path / ".claude-smart" / "install-failed"
+    assert result.returncode == 0
+    assert marker.exists()
+    marker_text = marker.read_text()
+    assert "bundled Reflexio runtime is missing" in marker_text
+    assert "npx claude-smart install" in marker_text
+
+
+def test_smart_install_allows_source_checkout_without_vendor(tmp_path: Path) -> None:
+    """A source checkout legitimately has no vendor bundle — it is generated at
+    pack time. Setup must not treat local development as a broken install."""
+    _plugin_root, smart_install, env = _prepare_smart_install_sync_fixture(
+        tmp_path, mode="fresh"
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", str(smart_install)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / ".claude-smart" / "install-failed").exists()
 
 
 def test_smart_install_non_lock_sync_failure_stays_strict(tmp_path: Path) -> None:
@@ -2808,7 +3079,10 @@ def test_backend_start_accepts_unknown_version_legacy_peer(
         assert result.stdout.strip() == '{"continue":true}'
         assert peer.poll() is None
         assert peer_runner.poll() is None
-        assert not (tmp_path / "python.log").exists()
+        python_log = tmp_path / "python.log"
+        assert "spawned backend" not in (
+            python_log.read_text() if python_log.exists() else ""
+        )
     finally:
         if peer.poll() is None:
             peer.terminate()
@@ -2912,7 +3186,10 @@ def test_backend_start_accepts_compatible_other_root_without_downgrade(
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == '{"continue":true}'
         assert peer.poll() is None
-        assert not (tmp_path / "python.log").exists()
+        python_log = tmp_path / "python.log"
+        assert "spawned backend" not in (
+            python_log.read_text() if python_log.exists() else ""
+        )
     finally:
         if peer.poll() is None:
             peer.terminate()
@@ -3116,7 +3393,10 @@ def test_backend_start_waits_for_existing_service_lock_without_spawn(
 
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == '{"continue":true}'
-        assert not (tmp_path / "python.log").exists()
+        python_log = tmp_path / "python.log"
+        assert "spawned backend" not in (
+            python_log.read_text() if python_log.exists() else ""
+        )
     finally:
         if locker.poll() is None:
             locker.terminate()
@@ -3175,7 +3455,10 @@ def test_backend_start_honors_startup_grace_for_recorded_pid(
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == '{"continue":true}'
         assert warming.poll() is None
-        assert not (tmp_path / "python.log").exists()
+        python_log = tmp_path / "python.log"
+        assert "spawned backend" not in (
+            python_log.read_text() if python_log.exists() else ""
+        )
         assert "recorded backend process is still running but not healthy yet" in (
             state_dir / "backend.log"
         ).read_text()
@@ -3283,7 +3566,10 @@ def test_backend_service_does_not_kill_foreign_listener(tmp_path: Path) -> None:
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == '{"continue":true}'
         assert foreign.poll() is None
-        assert not (tmp_path / "python.log").exists()
+        python_log = tmp_path / "python.log"
+        assert "spawned backend" not in (
+            python_log.read_text() if python_log.exists() else ""
+        )
         assert "port" in result.stderr
         assert "skipping start" in result.stderr
     finally:
@@ -3350,6 +3636,190 @@ def test_backend_service_preflight_rejects_non_bundled_reflexio(
     assert "bundled Reflexio import preflight failed" in (
         tmp_path / ".claude-smart" / "backend.log"
     ).read_text()
+
+
+def test_backend_service_preflight_missing_vendor_preserves_services(
+    tmp_path: Path,
+) -> None:
+    port = 22000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    shutil.rmtree(plugin_root / "vendor")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    env = _backend_service_env(tmp_path, bin_dir, port)
+
+    result = subprocess.run(
+        ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "preflight"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=15,
+    )
+
+    assert result.returncode == 1
+    assert "bundled Reflexio package not found" in result.stderr
+    assert "existing services were not changed" in result.stderr
+
+
+def test_backend_start_missing_vendor_does_not_stop_or_spawn(
+    tmp_path: Path,
+) -> None:
+    """A broken bundle reports failure without stopping or spawning anything.
+
+    Read-only inspection of the port (lsof) is expected and harmless — the
+    guarantee is that nothing is torn down and no backend is spawned.
+    """
+    port = 23000 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    shutil.rmtree(plugin_root / "vendor")
+    _write_fake_plugin_python(
+        plugin_root,
+        "#!/bin/sh\n"
+        'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+        'case "$1" in *backend-python-runner.py) printf "spawned backend\\n" >> "$HOME/python.log" ;; esac\n'
+        "exit 0\n",
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "uv", "#!/bin/sh\nexit 0\n")
+    env = _backend_service_env(tmp_path, bin_dir, port)
+
+    result = subprocess.run(
+        ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "hookSpecificOutput" in result.stdout
+    assert "bundled Reflexio import preflight failed" in result.stdout
+    # The remedy must be the one that can actually repair a missing bundle;
+    # /claude-smart:restart cannot, since it preflights the same bundle.
+    assert "npx claude-smart update" in result.stdout
+    python_log = tmp_path / "python.log"
+    assert "spawned backend" not in (
+        python_log.read_text() if python_log.exists() else ""
+    )
+    backend_log = (tmp_path / ".claude-smart" / "backend.log").read_text()
+    assert "existing services were not changed" in backend_log
+    assert "restarting" not in backend_log
+
+
+def test_backend_start_missing_vendor_still_accepts_healthy_other_root(
+    tmp_path: Path,
+) -> None:
+    """A broken bundle must not report "backend is not running" over a live one.
+
+    Another plugin root can be serving a healthy, compatible backend on the
+    port. Preflighting *this* root's bundle before that acceptance check would
+    tell the user their backend is down while it is happily serving.
+    """
+    if os.name == "nt":
+        pytest.skip("process termination fixture is POSIX-only")
+    port = 23600 + (abs(hash(tmp_path.name)) % 1000)
+    plugin_root = _seed_backend_service_test_plugin(tmp_path, port=port)
+    peer_version = json.loads(
+        (plugin_root / ".codex-plugin" / "plugin.json").read_text()
+    )["version"]
+    # This root's bundle is unusable — the exact GitHub-marketplace failure.
+    shutil.rmtree(plugin_root / "vendor")
+
+    peer_root = tmp_path / "peer-plugin"
+    peer_vendor = peer_root / "vendor" / "reflexio"
+    (peer_root / ".codex-plugin").mkdir(parents=True)
+    peer_vendor.mkdir(parents=True)
+    (peer_root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": peer_version})
+    )
+    peer = subprocess.Popen(["/bin/sleep", "60"])
+    peer_runner = subprocess.Popen(["/bin/sleep", "60"])
+    try:
+        _write_fake_plugin_python(
+            plugin_root,
+            "#!/bin/sh\n"
+            'printf "python %s\\n" "$*" >> "$HOME/python.log"\n'
+            'if [ "$1" = "-" ]; then exit 0; fi\n'
+            'case "$1" in *backend-python-runner.py) printf "spawned backend\\n" >> "$HOME/python.log" ;; esac\n'
+            "exit 0\n",
+        )
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_executable(
+            bin_dir / "curl",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT/health"*) exit 0 ;;\n'
+            '  *"http://127.0.0.1:$BACKEND_TEST_PORT"*) exit 0 ;;\n'
+            "esac\n"
+            "exit 22\n",
+        )
+        _write_executable(
+            bin_dir / "lsof",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -t -i :$BACKEND_TEST_PORT -sTCP:LISTEN "*|*" -tiTCP:$BACKEND_TEST_PORT -sTCP:LISTEN "*) printf "%s\\n" "$PEER_PID"; exit 0 ;;\n'
+            '  *" -a -p $PEER_PID -d cwd -Fn "*) printf "n%s\\n" "$PEER_ROOT"; exit 0 ;;\n'
+            '  *" -i:$BACKEND_TEST_PORT -sTCP:LISTEN -P -n "*) printf "python (pid %s)\\n" "$PEER_PID"; exit 0 ;;\n'
+            "esac\n"
+            "exit 0\n",
+        )
+        _write_executable(
+            bin_dir / "ps",
+            "#!/bin/sh\n"
+            'case " $* " in\n'
+            '  *" -o ppid= "*)\n'
+            '    if [ "${2:-}" = "$PEER_PID" ]; then printf "%s\\n" "$PEER_RUNNER_PID"; else printf "0\\n"; fi\n'
+            "    exit 0\n"
+            "    ;;\n"
+            "esac\n"
+            'if [ "${3:-}" = "$PEER_PID" ]; then\n'
+            '  printf "python -m reflexio.server --port %s\\n" "$BACKEND_TEST_PORT"\n'
+            'elif [ "${3:-}" = "$PEER_RUNNER_PID" ]; then\n'
+            '  printf "python backend-python-runner.py --claude-smart-backend=1 --claude-smart-plugin-root=%s --claude-smart-version=%s --claude-smart-reflexio-vendor-root=%s -- services start\\n" "$PEER_ROOT" "$PEER_VERSION" "$PEER_VENDOR"\n'
+            "fi\n",
+        )
+        _write_executable(bin_dir / "uv", "#!/bin/sh\nexit 0\n")
+        _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+        env = _backend_service_env(
+            tmp_path,
+            bin_dir,
+            port,
+            PEER_PID=str(peer.pid),
+            PEER_ROOT=str(peer_root),
+            PEER_RUNNER_PID=str(peer_runner.pid),
+            PEER_VENDOR=str(peer_vendor),
+            PEER_VERSION=peer_version,
+        )
+
+        result = subprocess.run(
+            ["bash", str(plugin_root / "scripts" / "backend-service.sh"), "start"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        # Plain continue: no "backend is not running" panel over a live backend.
+        assert result.stdout.strip() == '{"continue":true}'
+        assert "preflight failed" not in result.stdout
+        assert peer.poll() is None
+        python_log = tmp_path / "python.log"
+        assert "spawned backend" not in (
+            python_log.read_text() if python_log.exists() else ""
+        )
+    finally:
+        if peer.poll() is None:
+            peer.terminate()
+            peer.wait(timeout=5)
+        if peer_runner.poll() is None:
+            peer_runner.terminate()
+            peer_runner.wait(timeout=5)
 
 
 def test_backend_service_full_stop_reaps_embedding_port() -> None:
@@ -4369,6 +4839,75 @@ def test_codex_fresh_tarball_install_prepares_cache_and_trusts_hooks(
     assert "codex plugin marketplace add" in codex_log
     assert "codex features enable hooks" in codex_log
     assert "codex features enable plugin_hooks" in codex_log
+
+
+def test_claude_marketplace_manifest_is_not_committed() -> None:
+    """The Claude marketplace manifest must stay out of git.
+
+    It is what makes a directory installable as a Claude Code marketplace, and
+    the plugin it advertises has no vendored Reflexio runtime in the repo
+    (plugin/vendor/ is generated at pack time and gitignored). Committing it
+    lets `claude plugin marketplace add ReflexioAI/claude-smart` install a
+    plugin that can never start. Absent, that command fails immediately.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files", ".claude-plugin/marketplace.json"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+    assert tracked == "", (
+        ".claude-plugin/marketplace.json is tracked by git; it must be generated "
+        "at pack time so the GitHub repo is not installable as a marketplace"
+    )
+
+    # The template it is generated from must be committed.
+    template = subprocess.run(
+        ["git", "ls-files", ".claude-plugin/marketplace.template.json"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+    assert template == ".claude-plugin/marketplace.template.json"
+
+
+def test_package_tarball_ships_generated_marketplace_manifest(tmp_path: Path) -> None:
+    """A real pack (prepack hook active) must ship a version-correct manifest.
+
+    The npm path depends on it: `npx claude-smart install` runs
+    `claude plugin marketplace add <package root>`, which fails without it.
+    Packs with --ignore-scripts skip prepack, so this must not use that flag.
+    """
+    npm = shutil.which("npm")
+    if not npm:
+        pytest.skip("npm is required for package smoke tests")
+
+    pack_dir = tmp_path / "pack"
+    pack_dir.mkdir()
+    result = subprocess.run(
+        [npm, "pack", "--pack-destination", str(pack_dir), str(REPO_ROOT)],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr
+    tarball = next(pack_dir.glob("*.tgz"))
+
+    extract_dir = tmp_path / "extract"
+    extract_dir.mkdir()
+    with tarfile.open(tarball) as archive:
+        archive.extractall(extract_dir)
+
+    manifest_path = extract_dir / "package" / ".claude-plugin" / "marketplace.json"
+    assert manifest_path.is_file(), "npm tarball is missing the Claude marketplace manifest"
+
+    manifest = json.loads(manifest_path.read_text())
+    expected = json.loads((REPO_ROOT / "package.json").read_text())["version"]
+    assert [plugin["version"] for plugin in manifest["plugins"]] == [expected]
+    assert manifest["plugins"][0]["source"] == "./plugin"
 
 
 def test_package_tarball_ships_fresh_uv_lock(tmp_path: Path) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1076,7 +1076,8 @@ def test_node_install_reads_managed_env_and_bootstraps_latest_cache(
 
     old_root = cache_root / "0.2.31"
     new_root = cache_root / "0.2.32"
-    shutil.copytree(REPO_ROOT / "plugin" / "vendor", new_root / "vendor")
+    # No vendor payload needed: neither cached version matches this package's
+    # version, and the cache repair only ever inspects its own version's dir.
     old_mtime = new_root.stat().st_mtime + 100
     os.utime(old_root, (old_mtime, old_mtime))
 
@@ -1140,7 +1141,14 @@ def test_npx_install_reads_managed_env(tmp_path: Path) -> None:
         '[ "$REFLEXIO_API_KEY" = "rflx-test-secret" ] || exit 42\n'
     )
     install.chmod(install.stat().st_mode | stat.S_IXUSR)
-    shutil.copytree(REPO_ROOT / "plugin" / "vendor", cache_root / "vendor")
+    # This cache dir matches the package version, so the repair inspects it.
+    # Give it the same vendor payload the source has, so it is seen as healthy
+    # and no reinstall is triggered. plugin/vendor is a pack-time artifact: when
+    # the checkout has none, the repair is skipped anyway and there is nothing
+    # to mirror.
+    repo_vendor = REPO_ROOT / "plugin" / "vendor"
+    if repo_vendor.is_dir():
+        shutil.copytree(repo_vendor, cache_root / "vendor")
 
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
@@ -4672,6 +4680,12 @@ def test_claude_code_fresh_tarball_install_prepares_matching_cache(
     node = shutil.which("node")
     if not node or not shutil.which("npm"):
         pytest.skip("node and npm are required for package install smoke tests")
+    if not (REPO_ROOT / "plugin" / "vendor" / "reflexio").is_dir():
+        # A tarball packed from an unvendored checkout is not a release
+        # artifact: it installs a plugin with no Reflexio runtime, whose backend
+        # cannot start, and Setup rejects it by design. Vendor first (CI does;
+        # locally run `make package`) to smoke-test what users actually install.
+        pytest.skip("plugin/vendor/reflexio is required; run `make package` first")
 
     tarball = _pack_claude_smart_tarball(tmp_path)
     home = tmp_path / "home"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -4873,6 +4873,27 @@ def test_claude_marketplace_manifest_is_not_committed() -> None:
     assert template == ".claude-plugin/marketplace.template.json"
 
 
+def test_integration_harness_generates_marketplace_manifest_before_installing() -> None:
+    """Anything installing the checkout as a marketplace must generate the manifest.
+
+    The manifest is a pack-time artifact and is not committed, so the harness —
+    which registers REPO_ROOT as a marketplace — has to generate it itself, the
+    same way it already generates the vendor bundle. Without this it fails at
+    `claude plugin marketplace add` with "Marketplace file not found".
+    """
+    harness = (REPO_ROOT / "tests" / "integration" / "integration.sh").read_text()
+    assert "prepare_marketplace_manifest" in harness
+    assert "scripts/generate-marketplace.js" in harness
+
+    generate_at = harness.index("prepare_marketplace_manifest()")
+    call_at = harness.index("prepare_marketplace_manifest\n", generate_at)
+    add_at = harness.index("claude plugin marketplace add")
+    assert call_at < add_at, (
+        "the harness must generate the marketplace manifest before registering "
+        "the checkout as a marketplace"
+    )
+
+
 def test_package_tarball_ships_generated_marketplace_manifest(tmp_path: Path) -> None:
     """A real pack (prepack hook active) must ship a version-correct manifest.
 


### PR DESCRIPTION
## Problem

Installing via `claude plugin marketplace add ReflexioAI/claude-smart` produces a plugin whose backend can **never start**. `plugin/vendor/reflexio` is generated at pack time and gitignored, so the GitHub tree carries no Reflexio runtime. Users only find out later, from a backend log repeating `bundled Reflexio import preflight failed`.

## What changed

**Close the door at the front.** `.claude-plugin/marketplace.json` is now generated at pack time from a committed template (via npm's `prepack`) instead of being committed. That manifest is what makes a directory installable as a Claude Code marketplace — with it absent from git, `claude plugin marketplace add ReflexioAI/claude-smart` fails immediately with `Marketplace file not found` instead of installing a plugin that cannot run. The supported path is untouched: `npx claude-smart install` registers the npm package root, which ships both the manifest and the vendor bundle. Version can't drift either — the generator stamps it from `package.json`, so `make bump` has nothing to bump.

**Repair anyone already stuck**, scoped to the cache dir matching the package's own version. The first cut compared against the *highest-versioned* cache dir; since each plugin version vendors a different Reflexio, their vendor payloads legitimately differ, so any **downgrade install** was diagnosed as "stale", force-reinstalled, and then failed outright (`exit 1`) when the repair couldn't converge. Reproduced, then fixed.

**Preflight the bundled runtime before stopping or replacing a backend** — in both the SessionStart hook and `/claude-smart:restart`. The check sits exactly on the boundary between *accepting* a healthy backend and *tearing one down*. This matters: a broken bundle in one plugin root no longer reports "backend is not running" over a live, compatible backend served by another root (a case the code explicitly supports).

**Point users at the command that can actually fix it.** The failure message said to run `/claude-smart:restart`, which preflights the same missing bundle and refuses — a dead end. It now says `npx claude-smart update`.

**Fail Setup loudly** when a host plugin cache (`*/plugins/cache/*`) has no vendor bundle. That can only mean a GitHub-marketplace install; `smart-install.sh` previously skipped silently. A source checkout legitimately has no bundle and is left alone.

## Verification

Full end-to-end against a real `make package` tarball, installed into an isolated `HOME` on harness ports (production backend on 8071 untouched throughout):

| Scenario | Result |
| --- | --- |
| Clean install from tarball | Backend boots healthy, serving from the vendored runtime |
| GitHub tree → `marketplace add` | Refused: `Marketplace file not found` |
| npm package → `marketplace add` | Succeeds |
| Bundle deleted, backend still serving | Plain `{"continue":true}` — no false "backend is not running", backend survives |
| Bundle deleted, no backend | Reports failure with the `npx claude-smart update` remedy |
| `/claude-smart:restart`, bundle deleted | Aborts `rc=1`; **same pid still serving 200** — nothing stopped |
| `npx claude-smart update` | Restores the bundle; backend healthy; preflight passes |

Tests: 202 passing across `test_install_scripts.py`, `test_cli_restart.py`, `test_codex_support.py` (7 new: manifest stays untracked, real pack ships a version-correct manifest, downgrade install doesn't touch a newer cache, dev-checkout exemption, Setup cache guard, multi-root acceptance, restart-preserves-services). Biome clean; `bash -n` clean.

## Note for release notes

Anyone who previously added the GitHub marketplace will find `claude plugin update` stops working once this ships. That's intended — it pushes them onto `npx claude-smart update`, the only thing that can repair them — but it's a visible break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Install and update flows now detect and repair incomplete or stale Claude Code plugin caches automatically (including missing bundled runtime payloads).
  * Backend startup and restart now run a preflight check for the required bundled runtime and won’t disrupt existing services if it’s missing.
  * Clear, actionable repair guidance is shown when the bundled runtime isn’t present.

* **Documentation**
  * Updated installation, update/uninstall, and troubleshooting instructions to reflect the new `npx claude-smart install` flow and repair steps.

* **Packaging**
  * Marketplace metadata is generated automatically during package creation and the generated manifest is no longer committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->