### PR TITLE
fix: allow backend fallback when vendor Reflexio is missing (#130)

### DIFF
--- a/plugin/scripts/backend-service.sh
+++ b/plugin/scripts/backend-service.sh
@@ -535,10 +535,18 @@ verify_bundled_reflexio_import() {
   python_bin="$1"
   pythonpath="$2"
   vendor_root_for_python="$3"
-  [ -d "$VENDORED_REFLEXIO/reflexio" ] || {
-    echo "bundled Reflexio package not found at $VENDORED_REFLEXIO" >&2
-    return 1
-  }
+  if [ ! -d "$VENDORED_REFLEXIO/reflexio" ]; then
+    PYTHONPATH="$pythonpath" "$python_bin" - <<'PY'
+import sys
+
+try:
+    import reflexio
+except Exception as exc:
+    print(f"failed to import installed reflexio: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+    return $?
+  fi
   PYTHONPATH="$pythonpath" "$python_bin" - "$vendor_root_for_python" <<'PY'
 from pathlib import Path
 import sys

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -478,6 +478,46 @@ def test_backend_service_pins_reflexio_home_to_user_home() -> None:
     assert 'export REFLEXIO_LOG_DIR="${REFLEXIO_LOG_DIR:-$HOME}"' in service
 
 
+def test_backend_reflexio_preflight_accepts_venv_install_when_vendor_missing(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    site_packages = plugin_root / ".venv" / "lib" / "python3.12" / "site-packages"
+    reflexio_pkg = site_packages / "reflexio"
+    reflexio_pkg.mkdir(parents=True)
+    (reflexio_pkg / "__init__.py").write_text("__version__ = '0.2.28'\n")
+
+    service = (REPO_ROOT / "plugin" / "scripts" / "backend-service.sh").read_text()
+    match = re.search(
+        r"verify_bundled_reflexio_import\(\) \{.*?^\}",
+        service,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+
+    probe = tmp_path / "probe.sh"
+    probe.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -eu\n"
+        f"VENDORED_REFLEXIO={shlex.quote(str(plugin_root / 'vendor' / 'reflexio'))}\n"
+        f"{match.group(0)}\n"
+        "verify_bundled_reflexio_import "
+        f"{shlex.quote(sys.executable)} "
+        f"{shlex.quote(str(site_packages))} "
+        f"{shlex.quote(str(plugin_root / 'vendor' / 'reflexio'))}\n"
+    )
+    probe.chmod(0o755)
+
+    result = subprocess.run(
+        ["/bin/bash", str(probe)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_windows_detached_spawn_closes_hook_output_pipes() -> None:
     lib = LIB.read_text()
 


### PR DESCRIPTION
## Summary
- Allow backend Reflexio preflight to fall back to the plugin venv's installed `reflexio` package when `vendor/reflexio` is absent.
- Preserve the stricter bundled-vendor path validation when the vendored package exists.
- Add a regression test covering the missing-vendor/site-packages fallback path.

## Test Plan
- `uv run --project plugin pytest tests/test_install_scripts.py::test_backend_reflexio_preflight_accepts_venv_install_when_vendor_missing -q`
- `uv run --project plugin pytest tests/test_install_scripts.py::test_backend_service_uses_prepared_venv_reflexio_cli tests/test_install_scripts.py::test_backend_reflexio_preflight_accepts_venv_install_when_vendor_missing -q`
- `git diff --check`
- `uv run --project plugin pytest tests/test_install_scripts.py -q` (141 passed; 1 pre-existing/environment failure in `test_npx_install_reads_managed_env` because local `npm pack` exits 127)

Fixes #130


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend startup validation to recognize Reflexio installations available in the plugin environment when bundled files are absent.
  * Startup errors now provide the underlying import details, making installation issues easier to diagnose.

* **Tests**
  * Added regression coverage for successful startup with a virtual-environment installation and no bundled package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->