### PR TITLE
fix: attribute Cursor-hosted hooks correctly

### DIFF
--- a/plugin/dashboard/components/common/host-badge.tsx
+++ b/plugin/dashboard/components/common/host-badge.tsx
@@ -5,7 +5,8 @@ import { cn } from "@/lib/utils";
 import type { Host } from "@/lib/types";
 
 // Exact product colors from the current official app assets. Label colors meet
-// WCAG AA for the badge's small text.
+// WCAG AA for small text: Claude 5.65:1, Codex 5.39:1, Cursor 10.48:1,
+// OpenCode 18.93:1.
 const HOST_META: Record<
   Exclude<Host, "unknown">,
   { label: string; badgeClass: string; dotClass: string }

--- a/plugin/dashboard/components/common/host-badge.tsx
+++ b/plugin/dashboard/components/common/host-badge.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import type { Host } from "@/lib/types";
 
 // Exact product colors from the current official app assets. Label colors meet
-// WCAG AA for the badge's small text: Claude 5.65:1, Codex 5.39:1, OpenCode 18.93:1.
+// WCAG AA for the badge's small text.
 const HOST_META: Record<
   Exclude<Host, "unknown">,
   { label: string; badgeClass: string; dotClass: string }
@@ -19,6 +19,11 @@ const HOST_META: Record<
     label: "Codex",
     badgeClass: "border-[#0169CC] bg-[#0169CC] text-white",
     dotClass: "bg-[#0169CC]",
+  },
+  cursor: {
+    label: "Cursor",
+    badgeClass: "border-[#72716D] bg-[#D6D5D2] text-[#26251E]",
+    dotClass: "bg-[#72716D]",
   },
   opencode: {
     label: "OpenCode",

--- a/plugin/dashboard/lib/session-reader.ts
+++ b/plugin/dashboard/lib/session-reader.ts
@@ -22,6 +22,7 @@ import type {
 const VALID_HOSTS: ReadonlySet<Host> = new Set([
   "claude-code",
   "codex",
+  "cursor",
   "opencode",
   "unknown",
 ]);

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -41,7 +41,7 @@ export interface Interaction {
   tools_used: ToolUsed[];
 }
 
-export type Host = "claude-code" | "codex" | "opencode" | "unknown";
+export type Host = "claude-code" | "codex" | "cursor" | "opencode" | "unknown";
 
 export interface UserPlaybook {
   user_playbook_id: number;

--- a/plugin/src/claude_smart/hook.py
+++ b/plugin/src/claude_smart/hook.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from collections.abc import Callable
 from contextlib import redirect_stdout
@@ -111,15 +112,22 @@ def _parse_args(argv: list[str]) -> tuple[str, str]:
 def main(argv: list[str] | None = None) -> int:
     """Entry point used by ``python -m claude_smart.hook`` and the console script."""
     argv = argv if argv is not None else sys.argv[1:]
-    host, event = _parse_args(argv)
-    runtime.set_host(host)
-    env_config.load_reflexio_env()
+    declared_host, event = _parse_args(argv)
     if not event:
+        runtime.set_host(declared_host)
+        env_config.load_reflexio_env()
         _LOGGER.warning("hook dispatcher called with no event name")
         emit_continue()
         return 0
 
     payload = _read_stdin_json()
+    host = runtime.resolve_hook_host(declared_host, payload)
+    runtime.set_host(host)
+    if host == runtime.HOST_CURSOR and not payload.get("cwd"):
+        cursor_project_dir = os.environ.get("CURSOR_PROJECT_DIR")
+        if cursor_project_dir:
+            payload["cwd"] = cursor_project_dir
+    env_config.load_reflexio_env()
 
     # Self-feedback guard: when this hook fires inside reflexio's own
     # `claude -p` subprocess (the claude-code LLM provider), skip all

--- a/plugin/src/claude_smart/runtime.py
+++ b/plugin/src/claude_smart/runtime.py
@@ -1,22 +1,28 @@
 """Host/runtime state shared by claude-smart entrypoints.
 
-The plugin can be loaded by Claude Code or Codex, but v1 intentionally keeps
-one memory namespace. The host value is for payload quirks and install UX; the
-Reflexio agent version remains shared so both hosts see the same learned rules.
+The plugin intentionally keeps one memory namespace across supported hosts.
+The host value is for payload quirks, attribution, and install UX; the Reflexio
+agent version remains shared so every host sees the same learned rules.
 """
 
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
 
 HOST_ENV = "CLAUDE_SMART_HOST"
 INTERNAL_ENV = "CLAUDE_SMART_INTERNAL"
 
 HOST_CLAUDE_CODE = "claude-code"
 HOST_CODEX = "codex"
+HOST_CURSOR = "cursor"
 HOST_OPENCODE = "opencode"
 HOST_UNKNOWN = "unknown"
-VALID_HOSTS = frozenset({HOST_CLAUDE_CODE, HOST_CODEX, HOST_OPENCODE})
+VALID_HOSTS = frozenset(
+    {HOST_CLAUDE_CODE, HOST_CODEX, HOST_CURSOR, HOST_OPENCODE}
+)
 
 _SHARED_AGENT_VERSION = "claude-code"
 _current_host: str | None = None
@@ -24,6 +30,43 @@ _current_host: str | None = None
 
 def _resolve_host(value: str | None, fallback: str) -> str:
     return value if value in VALID_HOSTS else fallback
+
+
+def resolve_hook_host(
+    declared_host: str, payload: Mapping[str, Any]
+) -> str:
+    """Resolve the actual host behind a normalized hook invocation.
+
+    Cursor loads the Claude Code plugin directly, so its hook command declares
+    ``claude-code`` even though Cursor launched the subprocess. Positive Cursor
+    signals may refine that declaration. Explicit Codex/OpenCode invocations
+    and real Claude Code entrypoints always retain their declared host.
+
+    Args:
+        declared_host (str): Host selected by the hook command arguments.
+        payload (Mapping[str, Any]): Normalized hook payload.
+
+    Returns:
+        str: The effective host used for local attribution and hook telemetry.
+    """
+    if declared_host != HOST_CLAUDE_CODE:
+        return declared_host
+    if os.environ.get("CLAUDE_CODE_ENTRYPOINT"):
+        return declared_host
+    if os.environ.get("CURSOR_TRANSCRIPT_PATH"):
+        return HOST_CURSOR
+    if os.environ.get("CURSOR_VERSION") and os.environ.get("CURSOR_PROJECT_DIR"):
+        return HOST_CURSOR
+
+    transcript_path = payload.get("transcript_path")
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return declared_host
+    try:
+        cursor_root = (Path.home() / ".cursor").resolve()
+        Path(transcript_path).expanduser().resolve().relative_to(cursor_root)
+    except (OSError, RuntimeError, ValueError):
+        return declared_host
+    return HOST_CURSOR
 
 
 def set_host(value: str | None) -> str:

--- a/tests/test_cursor_support.py
+++ b/tests/test_cursor_support.py
@@ -1,0 +1,157 @@
+"""Regression coverage for Cursor host attribution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from claude_smart import hook, hook_log, runtime, state
+
+
+@pytest.fixture(autouse=True)
+def _clear_cursor_detection_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep Cursor host signals local to each test."""
+    for name in (
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CURSOR_PROJECT_DIR",
+        "CURSOR_TRANSCRIPT_PATH",
+        "CURSOR_USER_EMAIL",
+        "CURSOR_VERSION",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def cursor_hook_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect hook telemetry away from the user's real state."""
+    path = tmp_path / "hook.log"
+    monkeypatch.setattr(hook_log, "_LOG_PATH", path)
+    monkeypatch.delenv("CLAUDE_SMART_HOOK_LOG", raising=False)
+    return path
+
+
+def _log_records(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def test_cursor_hook_records_cursor_in_session_and_hook_log(
+    session_dir: Path,
+    cursor_hook_log: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Cursor-fired Claude Code plugin hook keeps Cursor provenance."""
+    monkeypatch.setenv("CURSOR_VERSION", "3.11.0")
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        hook,
+        "_read_stdin_json",
+        lambda: {
+            "session_id": "cursor-session",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/example.py"},
+            "tool_response": {"ok": True},
+        },
+    )
+
+    assert hook.main(["claude-code", "post-tool"]) == 0
+
+    assert state.read_all("cursor-session")[0]["host"] == "cursor"
+    log_record = _log_records(cursor_hook_log)[0]
+    assert log_record["host"] == "cursor"
+    assert log_record["cwd"] == str(tmp_path)
+    assert log_record["project_id"] == tmp_path.name
+
+
+def test_claude_code_entrypoint_wins_over_cursor_environment(
+    session_dir: Path,
+    cursor_hook_log: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claude Code launched inside Cursor stays attributed to Claude Code."""
+    monkeypatch.setenv("CURSOR_VERSION", "3.11.0")
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+    monkeypatch.setattr(
+        hook,
+        "_read_stdin_json",
+        lambda: {
+            "session_id": "claude-session",
+            "cwd": str(tmp_path),
+            "tool_name": "Read",
+            "tool_response": {"ok": True},
+        },
+    )
+
+    assert hook.main(["claude-code", "post-tool"]) == 0
+
+    assert state.read_all("claude-session")[0]["host"] == "claude-code"
+    assert _log_records(cursor_hook_log)[0]["host"] == "claude-code"
+
+
+@pytest.mark.parametrize(
+    ("env", "payload", "expected"),
+    [
+        ({"CURSOR_TRANSCRIPT_PATH": "/tmp/cursor.jsonl"}, {}, "cursor"),
+        (
+            {"CURSOR_VERSION": "3.11", "CURSOR_PROJECT_DIR": "/tmp/project"},
+            {},
+            "cursor",
+        ),
+        ({"CURSOR_VERSION": "3.11"}, {}, "claude-code"),
+        (
+            {
+                "CURSOR_TRANSCRIPT_PATH": "/tmp/cursor.jsonl",
+                "CLAUDE_CODE_ENTRYPOINT": "cli",
+            },
+            {},
+            "claude-code",
+        ),
+        (
+            {},
+            {
+                "transcript_path": str(
+                    Path.home() / ".cursor" / "projects" / "session.jsonl"
+                )
+            },
+            "cursor",
+        ),
+        (
+            {},
+            {
+                "transcript_path": str(
+                    Path.home() / ".claude" / "projects" / "session.jsonl"
+                )
+            },
+            "claude-code",
+        ),
+    ],
+)
+def test_resolve_hook_host_uses_layered_cursor_signals(
+    env: dict[str, str],
+    payload: dict[str, str],
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    assert runtime.resolve_hook_host("claude-code", payload) == expected
+
+
+def test_explicit_non_claude_host_is_not_reclassified_as_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CURSOR_TRANSCRIPT_PATH", "/tmp/cursor.jsonl")
+
+    assert runtime.resolve_hook_host("opencode", {}) == "opencode"
+
+
+def test_cursor_shares_learnings_without_losing_attribution() -> None:
+    assert runtime.set_host("cursor") == "cursor"
+    assert runtime.host() == "cursor"
+    assert runtime.attribution_host() == "cursor"
+    assert runtime.agent_version() == "claude-code"

--- a/tests/test_cursor_support.py
+++ b/tests/test_cursor_support.py
@@ -142,13 +142,16 @@ def test_resolve_hook_host_uses_layered_cursor_signals(
     assert runtime.resolve_hook_host("claude-code", payload) == expected
 
 
-def test_explicit_non_claude_host_is_not_reclassified_as_cursor(
+@pytest.mark.parametrize("host", ["codex", "opencode"])
+def test_explicit_non_claude_hosts_are_not_reclassified_as_cursor(
+    host: str,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Explicit non-Claude hosts remain authoritative under Cursor signals."""
-    monkeypatch.setenv("CURSOR_TRANSCRIPT_PATH", "/tmp/cursor.jsonl")
+    monkeypatch.setenv("CURSOR_TRANSCRIPT_PATH", str(tmp_path / "cursor.jsonl"))
 
-    assert runtime.resolve_hook_host("opencode", {}) == "opencode"
+    assert runtime.resolve_hook_host(host, {}) == host
 
 
 def test_cursor_shares_learnings_without_losing_attribution() -> None:

--- a/tests/test_cursor_support.py
+++ b/tests/test_cursor_support.py
@@ -17,7 +17,6 @@ def _clear_cursor_detection_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "CLAUDE_CODE_ENTRYPOINT",
         "CURSOR_PROJECT_DIR",
         "CURSOR_TRANSCRIPT_PATH",
-        "CURSOR_USER_EMAIL",
         "CURSOR_VERSION",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -136,6 +135,7 @@ def test_resolve_hook_host_uses_layered_cursor_signals(
     expected: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Layered Cursor signals refine only ambiguous Claude Code hooks."""
     for name, value in env.items():
         monkeypatch.setenv(name, value)
 
@@ -145,12 +145,14 @@ def test_resolve_hook_host_uses_layered_cursor_signals(
 def test_explicit_non_claude_host_is_not_reclassified_as_cursor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Explicit non-Claude hosts remain authoritative under Cursor signals."""
     monkeypatch.setenv("CURSOR_TRANSCRIPT_PATH", "/tmp/cursor.jsonl")
 
     assert runtime.resolve_hook_host("opencode", {}) == "opencode"
 
 
 def test_cursor_shares_learnings_without_losing_attribution() -> None:
+    """Cursor keeps local attribution while sharing the learning namespace."""
     assert runtime.set_host("cursor") == "cursor"
     assert runtime.host() == "cursor"
     assert runtime.attribution_host() == "cursor"


### PR DESCRIPTION
## What's broken / annoying

Cursor loads the Claude Code plugin directly, so claude-smart currently receives a hook command that says `claude-code` even when Cursor launched it. New local session rows and hook telemetry are therefore mislabeled, and project-scoped learnings can fall back to a plugin-version project ID when Cursor omits `cwd`.

## What's changing

- Refine a declared `claude-code` hook to `cursor` only when positive Cursor signals are present and Claude Code's own entrypoint is absent.
- Fill a missing Cursor `cwd` from `CURSOR_PROJECT_DIR` before resolving project identity.
- Treat `cursor` as a supported local host in session JSONL and dashboard parsing.
- Reuse the existing request-ID join so project-specific skills and preferences show `Generated via Cursor`.
- Add a Cursor badge using the warm-neutral palette from the [official Cursor brand assets](https://cursor.com/en-US/brand), distinct from OpenCode's black badge.

```text
Cursor fires Claude Code plugin hook
              |
              v
    one dispatcher detection
              |
              +--> session JSONL: host = cursor
              +--> hook.log: host = cursor
              +--> request ID join
                         |
                         +--> project skill origin
                         +--> preference origin
```

## How the product behaves afterwards

| Before | Changed | After |
| --- | --- | --- |
| Cursor sessions appeared as Claude Code. | The dispatcher checks layered Cursor signals once. | New Cursor session/tool rows and hook telemetry say `cursor`. |
| Missing Cursor `cwd` could create a junk project scope. | `CURSOR_PROJECT_DIR` supplies the missing working directory. | Project identity follows the active Cursor workspace. |
| Cursor was unknown to the dashboard. | The existing host type, parser, and shared badge catalog include Cursor. | Cursor appears on dashboard/session views and as project-skill/preference provenance. |
| OpenCode used its own black treatment. | Cursor gets its official warm-gray treatment. | Cursor and OpenCode remain visually distinct. |

Real Claude Code remains Claude Code when `CLAUDE_CODE_ENTRYPOINT` is present. Explicit Codex and OpenCode hooks are never reclassified. Host metadata stays local and is still removed before interactions are published to Reflexio; the shared learning namespace is unchanged. Existing records are not rewritten, and shared skills remain host-free because they can aggregate multiple sessions.

## Verification

- `693 passed, 1 skipped` in the full Python suite.
- New red/green coverage proves Cursor JSONL + hook-log attribution, missing-`cwd` recovery, layered detection, explicit-host protection, and Claude Code precedence.
- Ruff passed for all touched Python files.
- Dashboard ESLint, TypeScript, and production build passed.
- Sanitized browser fixtures validated dashboard recents, session list/detail, project-skill list/detail, and preference list/detail.
- Rendered colors were checked directly: Cursor `rgb(214, 213, 210)` / `rgb(38, 37, 30)`; OpenCode `rgb(19, 16, 16)` / white.

A sanitized browser screenshot is attached in the PR conversation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cursor as a recognized host and expanded host/runtime resolution.
  * Cursor badge/provenance now reflects the new host.
  * Cursor sessions include project directory context when available.
  * Cursor can share learnings while preserving correct attribution.
  * Explicit Claude Code configuration takes precedence over Cursor signals.

* **Bug Fixes**
  * Improved recorded-host parsing and attribution consistency across Cursor and Claude Code workflows.

* **Tests**
  * Added regression coverage for Cursor/Claude Code attribution, precedence rules, and telemetry logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->