### PR TITLE
fix: make citation labels more precise and observable

### DIFF
--- a/plugin/dashboard/app/dashboard/page.tsx
+++ b/plugin/dashboard/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
   ExternalLink,
   Users,
 } from "lucide-react";
+import { InjectedBadge } from "@/components/common/injected-badge";
 import { LearningsBadge } from "@/components/common/learnings-badge";
 import { HostBadge } from "@/components/common/host-badge";
 import { PageHeader } from "@/components/common/page-header";
@@ -218,6 +219,10 @@ export default function DashboardPage() {
                       <code className="font-mono text-xs truncate">
                         {truncateId(s.session_id, 10, 6)}
                       </code>
+                      <InjectedBadge
+                        count={s.injected_learning_count}
+                        size="sm"
+                      />
                       <LearningsBadge
                         count={s.learning_interaction_count}
                         size="sm"

--- a/plugin/dashboard/app/sessions/[sessionId]/page.tsx
+++ b/plugin/dashboard/app/sessions/[sessionId]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { PageHeader } from "@/components/common/page-header";
 import { HostBadge } from "@/components/common/host-badge";
+import { InjectedBadge } from "@/components/common/injected-badge";
 import { LearningsBadge } from "@/components/common/learnings-badge";
 import { EmptyState } from "@/components/common/empty-state";
 import { Badge } from "@/components/ui/badge";
@@ -82,6 +83,10 @@ export default function InteractionDetailPage({
             <span>{sessionId}</span>
             {detail && (
               <>
+                <InjectedBadge
+                  count={detail.injected_learning_count}
+                  size="sm"
+                />
                 <LearningsBadge
                   count={detail.learning_interaction_count}
                   size="sm"
@@ -232,6 +237,12 @@ export default function InteractionDetailPage({
                   {turn.cited_items && turn.cited_items.length > 0 && (
                     <CitedItemsRow items={turn.cited_items} />
                   )}
+                  {turn.unresolved_citations &&
+                    turn.unresolved_citations.length > 0 && (
+                      <UnresolvedCitationsRow
+                        ids={turn.unresolved_citations}
+                      />
+                    )}
                   <TurnMeta ts={turn.ts} userId={turn.user_id} />
                 </article>
               );
@@ -308,6 +319,31 @@ function CitedItemsRow({ items }: { items: CitedItem[] }) {
             </Link>
           );
         })}
+      </div>
+    </div>
+  );
+}
+
+function UnresolvedCitationsRow({ ids }: { ids: string[] }) {
+  return (
+    <div className="mt-2 flex items-start gap-2 text-[11px]">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 text-muted-foreground shrink-0" />
+      <div className="flex items-center gap-1 flex-wrap">
+        <span
+          className="text-muted-foreground"
+          title="Marker ids that could not be matched to this session's injection registry. Not counted as applied."
+        >
+          Unresolved marker
+        </span>
+        {ids.map((id) => (
+          <Badge
+            key={id}
+            variant="outline"
+            className="h-5 gap-1 text-[10px] text-muted-foreground"
+          >
+            {id}
+          </Badge>
+        ))}
       </div>
     </div>
   );

--- a/plugin/dashboard/app/sessions/page.tsx
+++ b/plugin/dashboard/app/sessions/page.tsx
@@ -6,6 +6,7 @@ import { MessageSquare, Search } from "lucide-react";
 import { PageHeader } from "@/components/common/page-header";
 import { EmptyState } from "@/components/common/empty-state";
 import { DeleteAllButton } from "@/components/common/delete-all-button";
+import { InjectedBadge } from "@/components/common/injected-badge";
 import { LearningsBadge } from "@/components/common/learnings-badge";
 import { HostBadge } from "@/components/common/host-badge";
 import { Input } from "@/components/ui/input";
@@ -150,6 +151,10 @@ export default function SessionsPage() {
                               </span>
                             )}
                           </p>
+                          <InjectedBadge
+                            count={s.injected_learning_count}
+                            size="sm"
+                          />
                           <LearningsBadge
                             count={s.learning_interaction_count}
                             size="sm"

--- a/plugin/dashboard/components/common/injected-badge.tsx
+++ b/plugin/dashboard/components/common/injected-badge.tsx
@@ -1,0 +1,35 @@
+import { Inbox } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export function InjectedBadge({
+  count,
+  size = "md",
+  className,
+}: {
+  count: number;
+  size?: "md" | "sm";
+  className?: string;
+}) {
+  if (count <= 0) return null;
+  const isSmall = size === "sm";
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-border bg-muted/40 text-muted-foreground gap-1",
+        isSmall ? "h-4 px-1.5 text-[10px] shrink-0" : "h-5",
+        className,
+      )}
+      title="Unique learnings injected into this session's context registry (not the same as applied)."
+    >
+      <Inbox
+        className={cn(
+          "text-muted-foreground",
+          isSmall ? "h-2.5 w-2.5" : "h-3 w-3",
+        )}
+      />
+      {count} injected
+    </Badge>
+  );
+}

--- a/plugin/dashboard/lib/session-reader.ts
+++ b/plugin/dashboard/lib/session-reader.ts
@@ -64,6 +64,7 @@ type RawRecord = {
   user_action?: UserActionType;
   user_action_description?: string;
   cited_items?: CitedItem[];
+  unresolved_citations?: string[];
   published_up_to?: number;
 };
 
@@ -375,6 +376,15 @@ function foldTurns(records: RawRecord[]): {
       turn.cited_items = rec.cited_items;
     }
     if (
+      role === "Assistant" &&
+      Array.isArray(rec.unresolved_citations) &&
+      rec.unresolved_citations.length > 0
+    ) {
+      turn.unresolved_citations = rec.unresolved_citations.filter(
+        (id): id is string => typeof id === "string" && id.length > 0,
+      );
+    }
+    if (
       preview === null &&
       role === "User" &&
       typeof turn.content === "string" &&
@@ -397,6 +407,19 @@ function foldTurns(records: RawRecord[]): {
   };
 }
 
+async function countUniqueInjected(sessionId: string): Promise<number> {
+  const records = await readInjectedJsonl(
+    path.join(stateDir(), `${sessionId}.injected.jsonl`),
+  ).catch(() => []);
+  const ids = new Set<string>();
+  for (const entry of records) {
+    if (typeof entry.id === "string" && entry.id.length > 0) {
+      ids.add(entry.id);
+    }
+  }
+  return ids.size;
+}
+
 export async function listSessions(): Promise<SessionSummary[]> {
   const dir = stateDir();
   let entries: string[];
@@ -411,6 +434,7 @@ export async function listSessions(): Promise<SessionSummary[]> {
     if (!entry.endsWith(".jsonl")) continue;
     if (entry.endsWith(".injected.jsonl")) continue;
     const fullPath = path.join(dir, entry);
+    const sessionId = entry.replace(/\.jsonl$/, "");
     const records = await readJsonl(fullPath).catch(() => []);
     const {
       turns,
@@ -422,10 +446,12 @@ export async function listSessions(): Promise<SessionSummary[]> {
       host,
       requestIds,
     } = foldTurns(records);
+    const injectedLearningCount = await countUniqueInjected(sessionId);
     summaries.push({
-      session_id: entry.replace(/\.jsonl$/, ""),
+      session_id: sessionId,
       turn_count: turns.length,
       learning_interaction_count: learningInteractionCount,
+      injected_learning_count: injectedLearningCount,
       last_activity: lastTs,
       first_activity: firstTs,
       published_up_to: publishedUpTo,
@@ -490,10 +516,12 @@ export async function readSession(
   }
   const { turns, publishedUpTo, learningInteractionCount, host } =
     foldTurns(records);
+  const injectedLearningCount = await countUniqueInjected(sessionId);
   return {
     session_id: sessionId,
     turns,
     learning_interaction_count: learningInteractionCount,
+    injected_learning_count: injectedLearningCount,
     published_up_to: publishedUpTo,
     host,
   };

--- a/plugin/dashboard/lib/types.ts
+++ b/plugin/dashboard/lib/types.ts
@@ -92,6 +92,7 @@ export interface SessionTurn {
   user_id?: string;
   tools_used?: ToolUsed[];
   cited_items?: CitedItem[];
+  unresolved_citations?: string[];
   user_action?: UserActionType;
   user_action_description?: string;
 }
@@ -100,6 +101,8 @@ export interface SessionSummary {
   session_id: string;
   turn_count: number;
   learning_interaction_count: number;
+  /** Unique learning ids recorded in the session injection registry. */
+  injected_learning_count: number;
   last_activity: number | null;
   first_activity: number | null;
   published_up_to: number;
@@ -113,6 +116,8 @@ export interface SessionDetail {
   session_id: string;
   turns: SessionTurn[];
   learning_interaction_count: number;
+  /** Unique learning ids recorded in the session injection registry. */
+  injected_learning_count: number;
   published_up_to: number;
   host: Host | null;
 }

--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -267,38 +267,46 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
     if os.environ.get("CLAUDE_SMART_CITATIONS", "on") == "off":
         return ""
     gate = cs_cite.WHEN_TO_CITE_COMPACT
+    only_used = (
+        "Include only memories that met that bar; omit the rest. "
+        "Do not cite every listed memory by default."
+    )
     link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
     if link_style == "osc8" and marker_parts:
-        marker = cs_cite.build_marker(" | ".join(marker_parts), "osc8")
-        separator_instruction = (
-            " Separate multiple linked memories with the visible ` | ` separator."
+        example = cs_cite.build_marker(marker_parts[0], "osc8")
+        multi = (
+            " For multiple qualifying items, join their linked titles with the "
+            "visible ` | ` separator."
             if len(marker_parts) > 1
             else ""
         )
         return _remoteize_citation_instruction(
-            f"{gate} If you do, copy this final marker exactly, preserving its "
-            f"hidden OSC 8 terminal link: `{marker}`.{separator_instruction}"
+            f"{gate} {only_used} If you do, end with one final marker in this "
+            f"format, preserving hidden OSC 8 terminal links: `{example}`."
+            f"{multi}"
         )
     if link_style == "osc8":
         return _remoteize_citation_instruction(
-            f"{gate} If you do, end with `{cs_cite.MARKER_PREFIX}` "
-            "followed by the same linked memory text, then "
+            f"{gate} {only_used} If you do, end with `{cs_cite.MARKER_PREFIX}` "
+            "followed by the linked memory text for only the qualifying items, "
+            "then "
             f"`{cs_cite.marker_attribution('osc8')}` linking to the reflexio "
             "repo; keep the links, but do not show the URL."
         )
     if marker_parts:
-        marker = cs_cite.build_marker(" | ".join(marker_parts), "markdown")
-        separator_instruction = (
-            " Separate multiple linked memories with the visible ` | ` separator."
+        example = cs_cite.build_marker(marker_parts[0], "markdown")
+        multi = (
+            " For multiple qualifying items, join their markdown links with the "
+            "visible ` | ` separator."
             if len(marker_parts) > 1
             else ""
         )
         return _remoteize_citation_instruction(
-            f"{gate} If you do, copy this final marker exactly with markdown "
-            f"links: `{marker}`.{separator_instruction}"
+            f"{gate} {only_used} If you do, end with one final marker like "
+            f"`{example}` using each item's shown rule URL.{multi}"
         )
     return _remoteize_citation_instruction(
-        f"{gate} If you do, end with one final marker like "
+        f"{gate} {only_used} If you do, end with one final marker like "
         f"`{cs_cite.MARKDOWN_EXAMPLE_ONE}` using the shown rule URL."
     )
 
@@ -337,11 +345,26 @@ def _exact_osc8_marker_instruction(entries: list[dict[str, Any]]) -> str:
     if not marker_parts:
         return ""
 
-    marker = cs_cite.build_marker(" | ".join(marker_parts), "osc8")
+    example = cs_cite.build_marker(marker_parts[0], "osc8")
+    if len(marker_parts) == 1:
+        available = ""
+        multi = ""
+    else:
+        available = (
+            " Qualifying linked titles: "
+            + " · ".join(marker_parts)
+            + "."
+        )
+        multi = (
+            " For multiple qualifying items, join only those linked titles with "
+            "the visible ` | ` separator."
+        )
     return (
-        "If any listed memory above was used, copy this exact final marker, "
-        f"preserving its hidden OSC 8 terminal links: `{marker}`. "
-        "Do not rename, summarize, or regroup the linked titles."
+        "If a listed memory above materially changed your response, end with one "
+        "final marker in this OSC 8 format (include only qualifying items; omit "
+        f"the rest): `{example}`.{available}{multi} Preserve hidden OSC 8 "
+        "terminal links and use each item's linked title as shown — do not invent "
+        "URLs."
     )
 
 

--- a/plugin/src/claude_smart/events/stop.py
+++ b/plugin/src/claude_smart/events/stop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -282,26 +283,30 @@ def _has_unpublished_user_turn(session_id: str) -> bool:
     return any(item.get("role") == "User" for item in interactions)
 
 
-def _resolve_cited_items(session_id: str, cited_ids: list[str]) -> list[dict[str, Any]]:
-    """Map citation ids to ``{id, kind, title}`` entries via the session registry.
+def _resolve_cited_items(
+    session_id: str, cited_ids: list[str]
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Map citation ids to registry entries; return unresolved tokens separately.
 
-    Unknown ids (Claude hallucinations, or items injected in a newer
-    session than this hook can see) are dropped. Duplicate ids within
-    one turn collapse to a single entry — the user-facing badge row
-    doesn't need the multiplicity.
+    Duplicate ids within one turn collapse to a single entry — the
+    user-facing badge row doesn't need the multiplicity. Unknown ids are
+    not promoted to ``cited_items``; callers may persist them as
+    ``unresolved_citations`` for local diagnostics.
     """
     if not cited_ids:
-        return []
+        return [], []
     registry = state.read_injected(session_id)
     seen: set[str] = set()
     resolved: list[dict[str, Any]] = []
+    unresolved: list[str] = []
     for cid in cited_ids:
         if cid in seen:
             continue
+        seen.add(cid)
         entry = _registry_entry_for_citation(registry, cid)
         if not entry:
+            unresolved.append(cid)
             continue
-        seen.add(cid)
         item: dict[str, Any] = {
             "id": entry.get("id", cid),
             "kind": entry.get("kind", ""),
@@ -314,15 +319,42 @@ def _resolve_cited_items(session_id: str, cited_ids: list[str]) -> list[dict[str
         if isinstance(source_kind, str) and source_kind:
             item["source_kind"] = source_kind
         resolved.append(item)
-    return resolved
+    return resolved, unresolved
+
+
+_RANK_ID_RE = re.compile(r"^(?P<rank>[ps]\d+)(?:-(?P<fp>[a-z0-9]{1,8}))?$", re.I)
 
 
 def _registry_entry_for_citation(
     registry: dict[str, dict[str, Any]], citation: str
 ) -> dict[str, Any] | None:
-    """Resolve a legacy rank id or a dashboard-route citation token."""
+    """Resolve a legacy rank id or a dashboard-route citation token.
+
+    Rank ids may drift fingerprints across re-injections (``s4-1068`` vs
+    ``s4-1006``). When the exact id is missing, accept a unique match on
+    the rank prefix alone; ambiguous or empty matches stay unresolved so
+    we never invent credit.
+    """
     if not citation.startswith("route:"):
-        return registry.get(citation)
+        entry = registry.get(citation)
+        if entry is not None:
+            return entry
+        lowered = {key.lower(): value for key, value in registry.items()}
+        entry = lowered.get(citation.lower())
+        if entry is not None:
+            return entry
+        match = _RANK_ID_RE.fullmatch(citation.strip())
+        if not match:
+            return None
+        rank = match.group("rank").lower()
+        candidates = [
+            value
+            for key, value in registry.items()
+            if key.lower() == rank or key.lower().startswith(f"{rank}-")
+        ]
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
     try:
         _, kind, source_kind, real_id = citation.split(":", 3)
     except ValueError:
@@ -395,7 +427,9 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
     if os.environ.get("CLAUDE_SMART_CITATIONS", "on") == "off":
         assistant_text = cs_cite.strip_marker_lines(assistant_text)
     text_cited_ids = cs_cite.parse_text_citations(assistant_text)
-    cited_items = _resolve_cited_items(session_id, text_cited_ids)
+    cited_items, unresolved_citations = _resolve_cited_items(
+        session_id, text_cited_ids
+    )
     plan_decisions = _scan_transcript_for_plan_decisions(entries)
 
     now = int(time.time())
@@ -432,6 +466,8 @@ def handle(payload: dict[str, Any]) -> tuple[publish.PublishStatus, int] | None:
     }
     if cited_items:
         record["cited_items"] = cited_items
+    if unresolved_citations:
+        record["unresolved_citations"] = unresolved_citations
     state.append(session_id, record)
     if env_config.env_truthy(env_config.CLAUDE_SMART_READ_ONLY_ENV):
         state.mark_all_published(session_id)

--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -407,7 +407,13 @@ def unpublished_slice(
         turn = {
             key: value
             for key, value in record.items()
-            if key not in {"role", "ts", "cited_items", "host"}
+            if key not in {
+                "role",
+                "ts",
+                "cited_items",
+                "unresolved_citations",
+                "host",
+            }
         }
         turn["role"] = role
         if role == "Assistant":

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -232,8 +232,14 @@ def test_render_inline_with_registry_can_inject_osc8_instruction(monkeypatch) ->
     assert "OSC 8 terminal" in md
     assert "\x1b]8;;http://localhost:3001/rules/s1-123\x1b\\" in md
     assert "✨ claude-smart rule applied: [verify process state]" not in md
-    assert "copy this exact final marker" in md
-    assert "Do not rename, summarize, or regroup the linked titles." in md
+    assert "include only qualifying items" in md
+    # Format example uses the first item only — not a prebuilt multi-item marker.
+    assert (
+        "✨ claude-smart rule applied: "
+        "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\"
+        "Use uv sync after pyproject edits"
+        "\x1b]8;;\x1b\\"
+    ) in md
     assert (
         "✨ claude-smart rule applied: "
         "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\"
@@ -242,7 +248,7 @@ def test_render_inline_with_registry_can_inject_osc8_instruction(monkeypatch) ->
         "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\"
         "prefers concise answers"
         "\x1b]8;;\x1b\\"
-    ) in md
+    ) not in md
     # Reflexio attribution rides along as an OSC 8 terminal link to the repo.
     assert (
         " · \x1b]8;;https://github.com/ReflexioAI/reflexio\x1b\\⚡Reflexio\x1b]8;;\x1b\\"
@@ -283,12 +289,17 @@ def test_render_inline_compact_with_registry_is_one_logical_line(
     assert "prefers concise answers" in md
     assert "✨ claude-smart rule applied:" in md
     assert md.count("✨ claude-smart rule applied:") == 1
-    assert "copy this final marker exactly with markdown links" in md
+    assert "Do not cite every listed memory by default." in md
+    assert "end with one final marker like" in md
+    assert (
+        "✨ claude-smart rule applied: "
+        "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1-17)"
+    ) in md
     assert (
         "✨ claude-smart rule applied: "
         "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1-17) | "
         "[prefers concise answers](http://localhost:3001/rules/p1-pref)"
-    ) in md
+    ) not in md
     assert "visible ` | ` separator" in md
     assert "\x1b]8;;" not in md
     assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
@@ -315,7 +326,8 @@ def test_render_inline_compact_with_registry_can_emit_osc8_when_requested(
 
     assert "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\" in md
     assert "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in md
-    assert "preserving its hidden OSC 8 terminal link" in md
+    assert "preserving hidden OSC 8 terminal links" in md
+    assert "Do not cite every listed memory by default." in md
     assert "open: http://localhost:3001/rules/s1-17" not in md
     assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
 
@@ -415,15 +427,23 @@ def test_render_inline_compact_uses_remote_reflexio_item_pages(monkeypatch) -> N
     )
 
     assert (
+        "open: https://www.reflexio.ai/playbooks?agent_playbook_id=42"
+    ) in md
+    assert (
+        "open: https://www.reflexio.ai/playbooks?"
+        "resource=user_playbook&user_playbook_id=17"
+    ) in md
+    assert (
+        "open: https://www.reflexio.ai/profiles?profile_id=pref%2Fone"
+    ) in md
+    # Marker example uses the first item only (no prebuilt multi-cite line).
+    assert (
         "[use shared flow](https://www.reflexio.ai/playbooks?agent_playbook_id=42)"
     ) in md
     assert (
-        "[use safe git flow](https://www.reflexio.ai/playbooks?"
-        "resource=user_playbook&user_playbook_id=17)"
-    ) in md
-    assert (
-        "[prefers concise answers](https://www.reflexio.ai/profiles?profile_id=pref%2Fone)"
-    ) in md
+        "[use shared flow](https://www.reflexio.ai/playbooks?agent_playbook_id=42) | "
+        "[use safe git flow]"
+    ) not in md
     assert "http://localhost:3001/rules/" not in md
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1084,12 +1084,17 @@ def test_user_prompt_injects_compact_context_for_codex(
     assert "Run uv sync after pyproject edits: Run uv sync" not in markdown
     assert "prefers anyio over asyncio" in markdown
     assert "✨ claude-smart rule applied:" in markdown
-    assert "copy this final marker exactly with markdown links" in markdown
+    assert "Do not cite every listed memory by default." in markdown
+    assert "end with one final marker like" in markdown
+    assert (
+        "✨ claude-smart rule applied: "
+        "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1)"
+    ) in markdown
     assert (
         "✨ claude-smart rule applied: "
         "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1) | "
         "[prefers anyio over asyncio](http://localhost:3001/rules/p1)"
-    ) in markdown
+    ) not in markdown
     assert "\x1b]8;;" not in markdown
 
 
@@ -1363,7 +1368,7 @@ def test_stop_omits_cited_items_when_no_citation_marker(
 def test_stop_drops_unknown_text_citation_ids(
     session_dir, tmp_path, monkeypatch
 ) -> None:
-    """Ids not present in the session registry are silently dropped."""
+    """Ids not present in the session registry are not counted as applied."""
     _prime_injected_registry("s1")
     transcript = _write_transcript(
         tmp_path,
@@ -1394,6 +1399,116 @@ def test_stop_drops_unknown_text_citation_ids(
     assert cited == [
         {"id": "s1-42", "kind": "playbook", "title": "use pathlib", "real_id": "42"},
     ]
+    assert records[-1].get("unresolved_citations") == ["s9-ffff"]
+
+
+def test_stop_resolves_unique_rank_fingerprint_drift(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    """Stale rank fingerprints still resolve when the rank prefix is unique."""
+    state.append_injected(
+        "s1",
+        [
+            {
+                "id": "s4-1006",
+                "kind": "playbook",
+                "title": "snapshot safety",
+                "content": "snapshot safety",
+                "real_id": "1006",
+                "ts": 0,
+            }
+        ],
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {"type": "user", "message": {"content": "hi"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "Done.\n\n"
+                                "✨ claude-smart rule applied: "
+                                "[snapshot safety](http://localhost:3001/rules/s4-1068)"
+                            ),
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
+    )
+    stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
+    records = state.read_all("s1")
+    assert records[-1].get("cited_items") == [
+        {
+            "id": "s4-1006",
+            "kind": "playbook",
+            "title": "snapshot safety",
+            "real_id": "1006",
+        }
+    ]
+    assert "unresolved_citations" not in records[-1]
+
+
+def test_stop_keeps_ambiguous_rank_ids_unresolved(
+    session_dir, tmp_path, monkeypatch
+) -> None:
+    """Ambiguous rank prefixes must not invent applied credit."""
+    state.append_injected(
+        "s1",
+        [
+            {
+                "id": "s4-1006",
+                "kind": "playbook",
+                "title": "one",
+                "content": "one",
+                "real_id": "1006",
+                "ts": 0,
+            },
+            {
+                "id": "s4-aaaa",
+                "kind": "playbook",
+                "title": "two",
+                "content": "two",
+                "real_id": "aaaa",
+                "ts": 0,
+            },
+        ],
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            {"type": "user", "message": {"content": "hi"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "Done.\n\n"
+                                "✨ claude-smart rule applied: "
+                                "[mystery](http://localhost:3001/rules/s4-zzzz)"
+                            ),
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "claude_smart.publish.publish_unpublished", lambda **_: ("nothing", 0)
+    )
+    stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
+    records = state.read_all("s1")
+    assert "cited_items" not in records[-1]
+    assert records[-1].get("unresolved_citations") == ["s4-zzzz"]
 
 
 def test_stop_handles_missing_transcript_file(session_dir, monkeypatch) -> None:
@@ -1437,6 +1552,7 @@ def test_stop_citation_without_prior_registry_drops_all_ids(
     stop.handle({"session_id": "s1", "transcript_path": str(transcript)})
     records = state.read_all("s1")
     assert "cited_items" not in records[-1]
+    assert records[-1].get("unresolved_citations") == ["s1-42"]
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stop pre-building multi-item "copy all injected memories" citation markers (reduces over-cite false positives).
- Resolve unique rank fingerprint drift so true markers still count as applied.
- Persist unresolved marker ids locally for diagnostics (not on the publish wire).
- Dashboard shows **injected** vs **applied** counts so low application badges are interpretable.

## Context
FP (over-cite) is worse than FN. These changes improve label precision and observability without loosening the material-change cite bar or inventing applied credit.

## Test plan
- [x] `pytest tests/test_context_format.py tests/test_events.py tests/test_cs_cite.py tests/test_state.py tests/test_codex_support.py`
- [x] Dashboard `tsc --noEmit`
- [ ] Manual: open `/sessions` and confirm injected badge appears on sessions with registry files; open a turn with a bad marker id and confirm unresolved row (after install from this branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added injected-learning counts to session lists, recent sessions, and session details.
  * Added visibility for unresolved citation markers within session transcripts.
  * Improved citation matching, including case-insensitive and unique rank-based matching.

* **Improvements**
  * Unresolved citations are now recorded instead of silently omitted.
  * Updated citation guidance for clearer, more precise linked references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->