### PR TITLE
Only credit the learnings the assistant says it used

### DIFF
--- a/plugin/src/claude_smart/context_format.py
+++ b/plugin/src/claude_smart/context_format.py
@@ -269,15 +269,13 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
     gate = cs_cite.WHEN_TO_CITE_COMPACT
     link_style = os.environ.get(_CITATION_LINK_STYLE_ENV, "markdown")
     if link_style == "osc8" and marker_parts:
-        marker = cs_cite.build_marker(" | ".join(marker_parts), "osc8")
-        separator_instruction = (
-            " Separate multiple linked memories with the visible ` | ` separator."
-            if len(marker_parts) > 1
-            else ""
-        )
+        example = cs_cite.build_marker(marker_parts[0], "osc8")
+        available = " · ".join(marker_parts)
         return _remoteize_citation_instruction(
-            f"{gate} If you do, copy this final marker exactly, preserving its "
-            f"hidden OSC 8 terminal link: `{marker}`.{separator_instruction}"
+            f"{gate} If you do, use this final marker format, preserving its "
+            f"hidden OSC 8 terminal link: `{example}`. Include only memories "
+            f"that materially changed the response. Available linked titles: {available}. "
+            "Separate multiple linked memories with the visible ` | ` separator."
         )
     if link_style == "osc8":
         return _remoteize_citation_instruction(
@@ -287,15 +285,12 @@ def _compact_citation_instruction(marker_parts: list[str] | None = None) -> str:
             "repo; keep the links, but do not show the URL."
         )
     if marker_parts:
-        marker = cs_cite.build_marker(" | ".join(marker_parts), "markdown")
-        separator_instruction = (
-            " Separate multiple linked memories with the visible ` | ` separator."
-            if len(marker_parts) > 1
-            else ""
-        )
+        example = cs_cite.build_marker(marker_parts[0], "markdown")
         return _remoteize_citation_instruction(
-            f"{gate} If you do, copy this final marker exactly with markdown "
-            f"links: `{marker}`.{separator_instruction}"
+            f"{gate} If you do, use this final marker format with markdown "
+            f"links: `{example}`. Include only memories that materially changed "
+            "the response. "
+            "Separate multiple linked memories with the visible ` | ` separator."
         )
     return _remoteize_citation_instruction(
         f"{gate} If you do, end with one final marker like "
@@ -337,11 +332,14 @@ def _exact_osc8_marker_instruction(entries: list[dict[str, Any]]) -> str:
     if not marker_parts:
         return ""
 
-    marker = cs_cite.build_marker(" | ".join(marker_parts), "osc8")
+    example = cs_cite.build_marker(marker_parts[0], "osc8")
+    available = " · ".join(marker_parts)
     return (
-        "If any listed memory above was used, copy this exact final marker, "
-        f"preserving its hidden OSC 8 terminal links: `{marker}`. "
-        "Do not rename, summarize, or regroup the linked titles."
+        "If any listed memory above was used, use this final marker format, "
+        f"preserving its hidden OSC 8 terminal link: `{example}`. Include only "
+        f"memories that materially changed the response. Available linked titles: "
+        f"{available}. "
+        "Separate multiple linked memories with the visible ` | ` separator."
     )
 
 

--- a/tests/test_context_format.py
+++ b/tests/test_context_format.py
@@ -232,17 +232,18 @@ def test_render_inline_with_registry_can_inject_osc8_instruction(monkeypatch) ->
     assert "OSC 8 terminal" in md
     assert "\x1b]8;;http://localhost:3001/rules/s1-123\x1b\\" in md
     assert "✨ claude-smart rule applied: [verify process state]" not in md
-    assert "copy this exact final marker" in md
-    assert "Do not rename, summarize, or regroup the linked titles." in md
+    assert "Include only memories that materially changed the response." in md
+    assert "Available linked titles:" in md
     assert (
         "✨ claude-smart rule applied: "
         "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\"
         "Use uv sync after pyproject edits"
-        "\x1b]8;;\x1b\\ | "
-        "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\"
-        "prefers concise answers"
         "\x1b]8;;\x1b\\"
     ) in md
+    assert (
+        "Use uv sync after pyproject edits\x1b]8;;\x1b\\ | "
+        "\x1b]8;;http://localhost:3001/rules/p1-pref"
+    ) not in md
     # Reflexio attribution rides along as an OSC 8 terminal link to the repo.
     assert (
         " · \x1b]8;;https://github.com/ReflexioAI/reflexio\x1b\\⚡Reflexio\x1b]8;;\x1b\\"
@@ -283,12 +284,15 @@ def test_render_inline_compact_with_registry_is_one_logical_line(
     assert "prefers concise answers" in md
     assert "✨ claude-smart rule applied:" in md
     assert md.count("✨ claude-smart rule applied:") == 1
-    assert "copy this final marker exactly with markdown links" in md
+    assert "Include only memories that materially changed the response." in md
     assert (
         "✨ claude-smart rule applied: "
+        "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1-17)"
+    ) in md
+    assert (
         "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1-17) | "
         "[prefers concise answers](http://localhost:3001/rules/p1-pref)"
-    ) in md
+    ) not in md
     assert "visible ` | ` separator" in md
     assert "\x1b]8;;" not in md
     assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
@@ -315,7 +319,12 @@ def test_render_inline_compact_with_registry_can_emit_osc8_when_requested(
 
     assert "\x1b]8;;http://localhost:3001/rules/s1-17\x1b\\" in md
     assert "\x1b]8;;http://localhost:3001/rules/p1-pref\x1b\\" in md
-    assert "preserving its hidden OSC 8 terminal link" in md
+    assert "Available linked titles:" in md
+    assert "Include only memories that materially changed the response." in md
+    assert (
+        "Run uv sync after pyproject edits\x1b]8;;\x1b\\ | "
+        "\x1b]8;;http://localhost:3001/rules/p1-pref"
+    ) not in md
     assert "open: http://localhost:3001/rules/s1-17" not in md
     assert {entry["id"] for entry in registry} == {"s1-17", "p1-pref"}
 
@@ -418,12 +427,10 @@ def test_render_inline_compact_uses_remote_reflexio_item_pages(monkeypatch) -> N
         "[use shared flow](https://www.reflexio.ai/playbooks?agent_playbook_id=42)"
     ) in md
     assert (
-        "[use safe git flow](https://www.reflexio.ai/playbooks?"
-        "resource=user_playbook&user_playbook_id=17)"
+        "open: https://www.reflexio.ai/playbooks?"
+        "resource=user_playbook&user_playbook_id=17"
     ) in md
-    assert (
-        "[prefers concise answers](https://www.reflexio.ai/profiles?profile_id=pref%2Fone)"
-    ) in md
+    assert "open: https://www.reflexio.ai/profiles?profile_id=pref%2Fone" in md
     assert "http://localhost:3001/rules/" not in md
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1084,11 +1084,12 @@ def test_user_prompt_injects_compact_context_for_codex(
     assert "Run uv sync after pyproject edits: Run uv sync" not in markdown
     assert "prefers anyio over asyncio" in markdown
     assert "✨ claude-smart rule applied:" in markdown
-    assert "copy this final marker exactly with markdown links" in markdown
+    assert (
+        "Include only memories that materially changed the response." in markdown
+    )
     assert (
         "✨ claude-smart rule applied: "
-        "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1) | "
-        "[prefers anyio over asyncio](http://localhost:3001/rules/p1)"
+        "[Run uv sync after pyproject edits](http://localhost:3001/rules/s1)"
     ) in markdown
     assert "\x1b]8;;" not in markdown
 


### PR DESCRIPTION
## Customer impact

When several learnings are available, claude-smart no longer gives the assistant an **Applied** footer prefilled with all of them. The assistant now sees a one-learning format example and is told to include only the learnings that materially changed its response.

This removes prompt pressure to credit unrelated learnings while keeping the existing **Learning applied** wording, clickable links, and dashboard behavior.

## Before

If learnings A, B, and C were retrieved and only A helped, the prompt still told the assistant to copy a footer containing A, B, and C.

## After

The prompt shows A as the format example, keeps B and C available to link, and tells the assistant to add only the learnings that materially changed the response. Legitimate multi-learning attribution remains supported.

## Scope

- No dashboard or UI changes
- No terminology, parser, resolver, schema, or counting changes
- No screenshots because no visual surface changed

## Validation

- Full Python suite: 694 passed, 1 skipped
- Focused renderer and Codex integration tests: 104 passed
- Diff check passed
- Independent standards and customer-value reviews found no issues

Supersedes #140.
