### PR TITLE
fix: load dashboard playbooks by exact ID

### DIFF
--- a/plugin/dashboard/app/skills/project/[id]/page.tsx
+++ b/plugin/dashboard/app/skills/project/[id]/page.tsx
@@ -55,6 +55,8 @@ export default function ProjectSkillDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
+  const userPlaybookId = Number(id);
+  const invalidId = !Number.isSafeInteger(userPlaybookId) || userPlaybookId <= 0;
 
   const [playbook, setPlaybook] = useState<UserPlaybook | null>(null);
   const [notFound, setNotFound] = useState(false);
@@ -71,13 +73,12 @@ export default function ProjectSkillDetailPage({
 
   useEffect(() => {
     let cancelled = false;
+    if (invalidId) return;
     reflexio
-      .getUserPlaybooks({})
+      .getUserPlaybooks({ userPlaybookId, limit: 1 })
       .then((res) => {
         if (cancelled) return;
-        const found = (res.user_playbooks ?? []).find(
-          (p) => String(p.user_playbook_id) === id,
-        );
+        const found = res.user_playbooks?.[0];
         if (!found) {
           setNotFound(true);
           return;
@@ -91,7 +92,7 @@ export default function ProjectSkillDetailPage({
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [invalidId, userPlaybookId]);
 
   const dirty = useMemo(() => {
     if (!playbook) return false;
@@ -147,7 +148,7 @@ export default function ProjectSkillDetailPage({
     setEditing(false);
   };
 
-  if (notFound) {
+  if (notFound || invalidId) {
     return (
       <div className="flex-1 overflow-auto">
         <PageHeader title="Project-specific skill not found" />

--- a/plugin/dashboard/lib/reflexio-client.ts
+++ b/plugin/dashboard/lib/reflexio-client.ts
@@ -46,6 +46,7 @@ export const reflexio = {
   /** POST /api/get_user_playbooks — all filters are optional. */
   async getUserPlaybooks(
     opts: {
+      userPlaybookId?: number;
       userId?: string;
       agentVersion?: string;
       playbookName?: string;
@@ -54,6 +55,8 @@ export const reflexio = {
     },
   ): Promise<{ user_playbooks: UserPlaybook[] }> {
     const body: Json = { limit: opts.limit ?? 100 };
+    if (opts.userPlaybookId !== undefined)
+      body.user_playbook_id = opts.userPlaybookId;
     if (opts.userId) body.user_id = opts.userId;
     if (opts.agentVersion) body.agent_version = opts.agentVersion;
     if (opts.playbookName) body.playbook_name = opts.playbookName;


### PR DESCRIPTION
## Summary
- Make project skill detail routes resolve the requested user playbook instead of searching only the first paginated result set.
- Send the numeric route ID to Reflexio as `user_playbook_id` with a one-record limit.
- Reject invalid route IDs before issuing an API request.

## Changes
- Add exact user playbook ID filtering to the dashboard Reflexio client.
- Update `/skills/project/[id]` to request and render the exact API result.

## Test Plan
- `npx biome check 'app/skills/project/[id]/page.tsx' lib/reflexio-client.ts`
- `npx tsc --noEmit`
- `npm run build`
- `uv run --project plugin pytest --rootdir . -o addopts= tests/test_dashboard_install.py tests/test_dashboard_managed_reflexio.py -q`
- Verified `http://localhost:3001/skills/project/87` renders playbook 87 through the dashboard API proxy.

## Follow-ups
- Paired enterprise PR: https://github.com/ReflexioAI/reflexio-enterprise/pull/836
- Merge this PR first, then update the enterprise submodule pointer to the merged `main` commit before merging the enterprise PR.