### PR TITLE
docs: align Codex plugin discovery metadata

### DIFF
--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.50",
-  "description": "Self-improving coding assistant plugin — learns from corrections across sessions via reflexio",
+  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
   "author": {
     "name": "Yi Lu"
   },
@@ -10,19 +10,27 @@
   "license": "Apache-2.0",
   "keywords": [
     "claude",
+    "claude-code",
+    "claude-code-plugin",
     "codex",
+    "codex-plugin",
+    "opencode",
+    "opencode-plugin",
+    "memory",
+    "agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
-    "playbook",
+    "self-improving-agents",
+    "skills",
     "learning"
   ],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "interface": {
     "displayName": "claude-smart",
-    "shortDescription": "Persistent learning across coding sessions",
-    "longDescription": "claude-smart captures user preferences and project-specific skills into a local reflexio backend, then injects relevant learnings back into future Claude Code and Codex sessions.",
+    "shortDescription": "Local learning across coding sessions",
+    "longDescription": "claude-smart turns corrections and successful workflows into local Preferences, Project-specific skills, and Shared skills, then injects relevant learnings back into future Claude Code, Codex, and OpenCode sessions.",
     "developerName": "ReflexioAI",
     "category": "Productivity",
     "capabilities": [


### PR DESCRIPTION
## Summary
- Align Codex plugin metadata with the current claude-smart positioning for Claude Code, Codex, and OpenCode.
- Use the public Preferences / Project-specific skills / Shared skills terminology in user-facing metadata.
- Refresh Codex plugin discovery keywords to match the broader package/plugin keyword set and replace the older `playbook` keyword with `skills`.

## Test Plan / Validation
- `git diff --check`
- `python3 -m json.tool plugin/.codex-plugin/plugin.json`

## Marketing rationale
This keeps Codex plugin metadata consistent with the README, npm package metadata, and Claude plugin metadata so developers searching for Codex memory, agent-memory, and self-improving agent tooling see accurate, current positioning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugin’s description to highlight local learning across coding sessions.
  * Clarified support for Claude Code, Codex, and OpenCode.
  * Expanded metadata to better describe Preferences and shared or project-specific skills.
  * Refined search keywords to improve discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->