### PR TITLE
fix(state): never emit created_at on the wire

### DIFF
--- a/plugin/src/claude_smart/state.py
+++ b/plugin/src/claude_smart/state.py
@@ -62,6 +62,16 @@ _INTERACTION_DATA_FIELDS = frozenset(
     }
 )
 
+# Fields actually put on the wire. `created_at` is a real InteractionData field
+# — so it must stay in the set above, which is pinned against the model — but it
+# must NOT be emitted. Sending a buffered event time backdates the interaction,
+# and the extractor's bookmark is keyed on `created_at` (`created_at >= ?`), so a
+# batch recovered after the bookmark moved is stored and then never extracted:
+# permanent, silent loss of learning data on exactly the offline-recovery path
+# this buffer exists for. Letting the server stamp its own time is the lesser
+# evil until ingest ordering stops depending on caller-supplied event time.
+_WIRE_FIELDS = _INTERACTION_DATA_FIELDS - {"created_at"}
+
 _VALID_CITATION_KINDS = frozenset(
     {"playbook", "profile", "user_playbook", "agent_playbook"}
 )
@@ -436,9 +446,7 @@ def unpublished_slice(
         # turn that rot into a publish failure this plugin's adapter swallows
         # without advancing its watermark.
         turn = {
-            key: value
-            for key, value in record.items()
-            if key in _INTERACTION_DATA_FIELDS
+            key: value for key, value in record.items() if key in _WIRE_FIELDS
         }
         turn["role"] = role
         # NOTE: deliberately does NOT send `created_at`. Carrying the buffer's

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -544,6 +544,24 @@ class TestWirePayloadContract:
             " the slicer would silently drop them"
         )
 
+    def test_created_at_is_never_emitted_even_when_present(self):
+        """A literal `created_at` in the buffer must not reach the wire.
+
+        The field is in the model-contract set (it is a real InteractionData
+        field), so filtering on that set alone let it through. Only `ts` was
+        tested, which could not catch this. Backdating an interaction hides it
+        from the extractor permanently — see `_WIRE_FIELDS`.
+        """
+        _, turns = state.unpublished_slice(
+            [{"ts": 1, "role": "User", "content": "x", "created_at": 999}]
+        )
+        assert "created_at" not in turns[0], turns[0]
+
+    def test_wire_fields_excludes_created_at_but_contract_set_keeps_it(self):
+        assert "created_at" in state._INTERACTION_DATA_FIELDS
+        assert "created_at" not in state._WIRE_FIELDS
+        assert state._WIRE_FIELDS < state._INTERACTION_DATA_FIELDS
+
     def test_buffer_timestamp_is_not_sent(self):
         """`created_at` must stay off the wire.
 


### PR DESCRIPTION
Follow-up to #144, from a CodeRabbit Major on that PR after it merged.

#144 removed the `ts -> created_at` carry but left `created_at` **in the allowlist the serializer filters against**, so a buffer record containing that key literally would still pass straight through. Verified on merged `main`:

```
wire turn: {'role':'User','content':'x','created_at':999}  -> leaks? True
```

Nothing writes that key today, so it was latent rather than live — but closing exactly this kind of door is what the allowlist is *for*, and the existing test only supplied `ts`, so it could not catch it.

## The fix

Splits two concepts that were conflated:

- `_INTERACTION_DATA_FIELDS` stays the **model-contract** set. `created_at` genuinely *is* an `InteractionData` field, and the drift test pins this set against the real model, so it must remain here.
- `_WIRE_FIELDS` is what the serializer filters on, and excludes it.

## Why `created_at` must never be emitted

The extractor's bookmark is keyed on interaction `created_at` (`last_processed_timestamp`, compared with `created_at >= ?`). A backdated batch — one recovered after the bookmark has moved — is stored and then **never seen by the extractor**. That was reproduced end to end as permanent, silent loss of learning data, on precisely the offline-recovery path this buffer exists to protect. Letting the server stamp its own time is the lesser evil until ingest ordering stops depending on caller-supplied event time.

Tests: one asserting a literal `created_at` in the buffer is not emitted, one pinning `_WIRE_FIELDS < _INTERACTION_DATA_FIELDS` so the two sets cannot silently converge again. 457 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented internal creation timestamps from being included in published interaction events.
  * Ensured outbound event data follows the intended payload contract, even when timestamps are present in source records.

* **Tests**
  * Added coverage verifying that creation timestamps are consistently excluded from transmitted event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->