### PR TITLE
docs: refresh Codex plugin discovery metadata

### DIFF
--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.50",
-  "description": "Self-improving coding assistant plugin — learns from corrections across sessions via reflexio",
+  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
   "author": {
     "name": "Yi Lu"
   },
@@ -10,19 +10,27 @@
   "license": "Apache-2.0",
   "keywords": [
     "claude",
+    "claude-code",
+    "claude-code-plugin",
     "codex",
+    "codex-plugin",
+    "opencode",
+    "opencode-plugin",
+    "memory",
+    "agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
-    "playbook",
+    "self-improving-agents",
+    "skills",
     "learning"
   ],
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "interface": {
     "displayName": "claude-smart",
-    "shortDescription": "Persistent learning across coding sessions",
-    "longDescription": "claude-smart captures user preferences and project-specific skills into a local reflexio backend, then injects relevant learnings back into future Claude Code and Codex sessions.",
+    "shortDescription": "Local learning across coding sessions",
+    "longDescription": "claude-smart captures Preferences and Project-specific skills into a local Reflexio-powered backend, rolls durable patterns into Shared skills, and injects relevant learnings into future Claude Code, Codex, and OpenCode sessions.",
     "developerName": "ReflexioAI",
     "category": "Productivity",
     "capabilities": [


### PR DESCRIPTION
## Summary
- Refreshes Codex plugin manifest copy to match the current claude-smart positioning across Claude Code, Codex, and OpenCode.
- Uses the public terminology from DEVELOPER.md: Preferences, Project-specific skills, and Shared skills.
- Expands plugin discovery keywords around Claude Code plugin, Codex plugin, OpenCode plugin, agent memory, self-improving agents, and skills.

## Test Plan / Validation
- `git diff --check`
- `python3 -m json.tool plugin/.codex-plugin/plugin.json >/tmp/claude-smart-codex-plugin-json.ok`

## Marketing rationale
Developers scanning Codex plugin/package metadata are high-intent users. Aligning this manifest with the README/package metadata improves discoverability for searches around Codex memory, agent memory, Claude Code skills, and self-improving agent tooling without adding new product claims or broad docs churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugin description to clarify support for Claude Code, Codex, and OpenCode learning workflows.
  * Expanded discoverability keywords for supported platforms and self-improving agents.
  * Clarified interfaces for local learning, Preferences, project-specific skills, Shared skills, and Reflexio-backed injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->