### PR TITLE
fix: prevent setup --help side effects (#152)

### DIFF
--- a/bin/claude-smart.js
+++ b/bin/claude-smart.js
@@ -2570,7 +2570,16 @@ async function main() {
   }
 
   if (cmd === "setup") {
-    await runSetup(args.slice(1));
+    const setupArgs = args.slice(1);
+    if (
+      setupArgs.includes("--help") ||
+      setupArgs.includes("-h") ||
+      setupArgs[0] === "help"
+    ) {
+      printHelp();
+      return;
+    }
+    await runSetup(setupArgs);
     return;
   }
 

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -254,6 +254,26 @@ def _fake_claude_install_script() -> str:
     return '#!/bin/sh\nprintf \'claude %s\\n\' "$*" >> "$HOME/claude.log"\nexit 0\n'
 
 
+def test_node_setup_help_prints_usage_without_side_effects(tmp_path: Path) -> None:
+    env = _isolated_env(tmp_path)
+    env["PATH"] = _minimal_path(tmp_path, "node", "bash", "dirname", "mkdir")
+
+    result = subprocess.run(
+        ["node", str(CLAUDE_SMART_BIN), "setup", "--help"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert "Host (1=Claude Code" not in result.stderr
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "npx claude-smart setup" in result.stdout
+    assert not (tmp_path / ".reflexio").exists()
+    assert not (tmp_path / ".claude-smart").exists()
+
+
 def _node_platform() -> str:
     uname_s = subprocess.check_output(["uname", "-s"], text=True).strip()
     uname_m = subprocess.check_output(["uname", "-m"], text=True).strip()


### PR DESCRIPTION
## Summary
- Handles `claude-smart setup --help`/`-h`/`help` in the Node entrypoint before invoking the destructive setup shell script.
- Adds a regression test that verifies setup help prints usage, avoids prompts, and does not create setup state directories.

## Test Plan
- `uv run --project plugin pytest tests/test_install_scripts.py::test_node_setup_help_prints_usage_without_side_effects -q`
- `uv run --project plugin pytest tests/test_install_scripts.py -q`
- `npm run build:opencode`
- `git diff --check`

Fixes #152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `setup --help`, `setup -h`, and `setup help` to display usage information without running setup.

* **Bug Fixes**
  * Help requests now exit successfully without producing host-related errors or creating setup files.

* **Tests**
  * Added regression coverage to verify help output and ensure no unintended side effects occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->