### PR TITLE
docs: refresh plugin discovery metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.50",
-  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
+  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections and successful workflows into Preferences, Project-specific skills, and Shared skills",
   "keywords": [
     "claude",
     "claude-code",
@@ -12,10 +12,14 @@
     "opencode-plugin",
     "memory",
     "agent-memory",
+    "persistent-memory",
+    "local-memory",
+    "ai-agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
     "self-improving-agents",
+    "agent-learning",
     "skills",
     "learning"
   ],

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.50",
-  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
+  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections and successful workflows into Preferences, Project-specific skills, and Shared skills",
   "author": {
     "name": "Yi Lu"
   },
@@ -15,10 +15,14 @@
     "opencode-plugin",
     "memory",
     "agent-memory",
+    "persistent-memory",
+    "local-memory",
+    "ai-agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
     "self-improving-agents",
+    "agent-learning",
     "skills",
     "learning"
   ]

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-smart",
   "version": "0.2.50",
-  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills",
+  "description": "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections and successful workflows into Preferences, Project-specific skills, and Shared skills",
   "author": {
     "name": "Yi Lu"
   },
@@ -18,10 +18,14 @@
     "opencode-plugin",
     "memory",
     "agent-memory",
+    "persistent-memory",
+    "local-memory",
+    "ai-agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
     "self-improving-agents",
+    "agent-learning",
     "skills",
     "learning"
   ],

--- a/plugin/pyproject.toml
+++ b/plugin/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "claude-smart"
 version = "0.2.50"
-description = "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections into Preferences, Project-specific skills, and Shared skills"
+description = "Self-improving Claude Code, Codex, and OpenCode plugin that turns corrections and successful workflows into Preferences, Project-specific skills, and Shared skills"
 keywords = [
     "claude",
     "claude-code",
@@ -12,10 +12,14 @@ keywords = [
     "opencode-plugin",
     "memory",
     "agent-memory",
+    "persistent-memory",
+    "local-memory",
+    "ai-agent-memory",
     "plugin",
     "reflexio",
     "self-improvement",
     "self-improving-agents",
+    "agent-learning",
     "skills",
     "learning",
 ]


### PR DESCRIPTION
## Summary
- Refresh npm, Python, Claude Code plugin, and Codex plugin metadata to mention both corrections and successful workflows.
- Add high-intent discovery keywords for persistent/local AI agent memory and agent learning.
- Preserve public claude-smart terminology: Preferences, Project-specific skills, and Shared skills.

## Test Plan / Validation
- `git diff --check`
- `npm pack --dry-run --json >/tmp/claude-smart-npm-pack.json && wc -c /tmp/claude-smart-npm-pack.json`

## Marketing rationale
Developers searching for Claude Code/Codex persistent memory, local AI memory, or agents learning from corrections should be able to discover claude-smart from package/plugin metadata. This is a low-risk metadata-only change aligned with the existing README hero copy and avoids new benchmark, security, pricing, or adoption claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project and plugin descriptions to highlight learning from successful workflows.
  * Added keywords related to persistent memory, local memory, AI-agent memory, and agent learning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->